### PR TITLE
Enable tfproviderlint s022

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,6 @@ lint:
 		-R007=false \
 		-R008=false \
 		-S006=false \
-		-S022=false \
 		-V004=false \
 		./...
 	

--- a/linode/resource_linode_nodebalancer.go
+++ b/linode/resource_linode_nodebalancer.go
@@ -68,25 +68,7 @@ func resourceLinodeNodeBalancer() *schema.Resource {
 			"transfer": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"in": {
-							Type:        schema.TypeFloat,
-							Description: "The total transfer, in MB, used by this NodeBalancer this month",
-							Computed:    true,
-						},
-						"out": {
-							Type:        schema.TypeFloat,
-							Description: "The total inbound transfer, in MB, used for this NodeBalancer this month",
-							Computed:    true,
-						},
-						"total": {
-							Type:        schema.TypeFloat,
-							Description: "The total outbound transfer, in MB, used for this NodeBalancer this month",
-							Computed:    true,
-						},
-					},
-				},
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"tags": {
 				Type:        schema.TypeSet,

--- a/linode/resource_linode_nodebalancer_config.go
+++ b/linode/resource_linode_nodebalancer_config.go
@@ -133,20 +133,7 @@ func resourceLinodeNodeBalancerConfig() *schema.Resource {
 			"node_status": {
 				Type:     schema.TypeMap,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"status_up": {
-							Type:        schema.TypeInt,
-							Description: "The number of backends considered to be 'UP' and healthy, and that are serving requests.",
-							Computed:    true,
-						},
-						"status_down": {
-							Type:        schema.TypeInt,
-							Description: "The number of backends considered to be 'DOWN' and unhealthy. These are not in rotation, and not serving requests.",
-							Computed:    true,
-						},
-					},
-				},
+				Elem:     schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}


### PR DESCRIPTION
So basically, declaring the `Elem` of a `schema.TypeMap` as `schema.Resource` is undefined behavior, and Terraform does not benefit from this. We have basically been defining this piece of the schema as an arbitrary string map all along.

As this is a `computed` attribute, I'm not sure that we benefit from the typing anyways, although it is nice from a readability standpoint.

Another option would be making this a `schema.TypeList` with just one element. This is a breaking change for anyone consuming the attribute of course.