### PR TITLE
fix broken links in docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ script:
 - make lint
 - make test
 - make vet
-- make website-test
 
 branches:
   only:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -73,18 +73,4 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS) -timeout 120m -parallel=2
 
-website:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
-
-website-test:
-ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
-	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
-	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
-endif
-	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
-
-.PHONY: build sweep test testacc vet fmt fmtcheck errcheck test-compile website website-test
+.PHONY: build sweep test testacc vet fmt fmtcheck errcheck test-compile

--- a/website/docs/d/account.html.md
+++ b/website/docs/d/account.html.md
@@ -10,7 +10,7 @@ description: |-
 
 Provides information about a Linode account.
 
-This data source should not be used in conjuction with the `LINODE_DEBUG` option.  See the [debugging notes](/docs/providers/linode/index.html#debugging) for more details.
+This data source should not be used in conjuction with the `LINODE_DEBUG` option.  See the [debugging notes](/providers/linode/linode/latest/docs#debugging) for more details.
 
 ## Example Usage
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -69,11 +69,11 @@ Error: Error getting Linode DomainRecord ID 123456: [002] unexpected end of JSON
 Error: Error finding the specified Linode DomainRecord: [002] unexpected end of JSON input
 ```
 
-If this affects you, run Terraform with [--parallelism=1](/docs/commands/apply.html#parallelism-n)
+If this affects you, run Terraform with [--parallelism=1](https://www.terraform.io/docs/commands/apply.html#parallelism-n)
 
 ## Debugging
 
 The [Linode APIv4 wrapper](https://github.com/linode/linodego) used by this provider accepts a `LINODE_DEBUG` environment variable.
-If this variable is assigned to `1`, the request and response of all Linode API traffic will be reported through [Terraform debugging and logging facilities](/docs/internals/debugging.html).
+If this variable is assigned to `1`, the request and response of all Linode API traffic will be reported through [Terraform debugging and logging facilities](https://www.terraform.io/docs/internals/debugging.html).
 
 Use of the `LINODE_DEBUG` variable in production settings is **strongly discouraged** with the `linode_account` datasource.  While Terraform does not directly store sensitive data from this datasource, the Linode Account API endpoint returns **sensitive data** such as the account `tax_id` (VAT) and the credit card `last_four` and `expiry`.  Be very cautious about storing this debug output.

--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -13,7 +13,7 @@ For more information, see [Getting Started with Linode](https://linode.com/docs/
 
 The Linode Guide, [Use Terraform to Provision Linode Environments](https://www.linode.com/docs/applications/configuration-management/how-to-build-your-infrastructure-using-terraform-and-linode/), provides step-by-step guidance and additional examples.
 
-Linode Instances can also use [provisioners](/docs/provisioners/index.html).
+Linode Instances can also use [provisioners](https://www.terraform.io/docs/provisioners/index.html).
 
 ## Example Usage
 


### PR DESCRIPTION
Because of the recent transition to the registry.terraform.io domain,
existing relative links relying on the old terraform.io domain's
structure were broken.