### PR TITLE
Fix typo on comments on website/docs/r

### DIFF
--- a/website/docs/r/nodebalancer.html.md
+++ b/website/docs/r/nodebalancer.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `client_conn_throttle` - (Optional) Throttle connections per second (0-20). Set to 0 (default) to disable throttling.
 
-* `linode_id` - (Optional) The ID of a Linode Instance where the the NodeBalancer should be attached.
+* `linode_id` - (Optional) The ID of a Linode Instance where the NodeBalancer should be attached.
 
 * `tags` - (Optional) A list of tags applied to this object. Tags are for organizational purposes only.
 

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `size` - (Optional) Size of the Volume in GB.
 
-* `linode_id` - (Optional) The ID of a Linode Instance where the the Volume should be attached.
+* `linode_id` - (Optional) The ID of a Linode Instance where the Volume should be attached.
 
 * `tags` - (Optional) A list of tags applied to this object. Tags are for organizational purposes only.
 


### PR DESCRIPTION
Remove consecutive "the" occurrences
`s/the /the the /g`