### PR TITLE
disable release.draft in goreleaser workflow

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,8 +43,5 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-release:
-  # Visit your project's GitHub Releases page to publish this release.
-  draft: true
 changelog:
   skip: true


### PR DESCRIPTION
This configuration prevents releases from being published after the
workflow completes. See https://goreleaser.com/customization/release.