### PR TITLE
Making Linode IDs Optional

### DIFF
--- a/linode/resource_linode_firewall.go
+++ b/linode/resource_linode_firewall.go
@@ -88,7 +88,7 @@ func resourceLinodeFirewall() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeInt},
 				Description: "The IDs of Linodes to apply this firewall to.",
 				MinItems:    1,
-				Required:    true,
+				Optional:    true,
 				Set:         schema.HashInt,
 			},
 			"devices": {

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * [`outbound`](#outbound) - (Optional) A firewall rule that specifies what outbound network traffic is allowed.
 
-* `linodes` - (Required) A list of IDs of Linodes this Firewall should govern it's network traffic for.
+* `linodes` - (Optional) A list of IDs of Linodes this Firewall should govern it's network traffic for.
 
 * `tags` - (Optional) A list of tags applied to the Kubernetes cluster. Tags are for organizational purposes only.
 


### PR DESCRIPTION
You are able to create firewalls without assigned a linode to it. This should not be required so firewalls can be made even if not currently in use.