### PR TITLE
fix watchdog_enabled state drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.14.3 (January 28, 2021)
+
+BUG FIXES:
+
+* Fixed an issue with the `watchdog_enabled` field on `linode_instance` where on creation, Watchdog is assumed disabled by default and causes resources with the field set to `false` to need to update on the next apply.
+
 ## 1.14.2 (January 27, 2021)
 
 FEATURES:

--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -783,9 +783,9 @@ func resourceLinodeInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 	updateOpts := linodego.InstanceUpdateOptions{}
 	doUpdate := false
 
-	if _, watchdogEnabledOk := d.GetOk("watchdog_enabled"); watchdogEnabledOk {
+	watchdogEnabled := d.Get("watchdog_enabled").(bool)
+	if !watchdogEnabled {
 		doUpdate = true
-		watchdogEnabled := d.Get("watchdog_enabled").(bool)
 		updateOpts.WatchdogEnabled = &watchdogEnabled
 	}
 

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -104,6 +104,31 @@ func TestAccLinodeInstance_dontPoll(t *testing.T) {
 	})
 }
 
+func TestAccLinodeInstance_watchdogDisabled(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_instance.foobar"
+	instanceName := acctest.RandomWithPrefix("tf_test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLinodeInstanceWithWatchdogDisabled(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "watchdog_enabled", "false"),
+				),
+			},
+			{
+				Config:   testAccCheckLinodeInstanceWithWatchdogDisabled(instanceName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccLinodeInstance_authorizedUsers(t *testing.T) {
 	t.Parallel()
 
@@ -1707,6 +1732,20 @@ resource "linode_instance" "%s" {
 	root_pass = "terraform-test"
 }
 `, identifier, instance)
+}
+
+func testAccCheckLinodeInstanceWithWatchdogDisabled(instance string) string {
+	return fmt.Sprintf(`
+resource "linode_instance" "foobar" {
+	label     = "%s"
+	region    = "ca-central"
+	image     = "linode/alpine3.12"
+	type      = "g6-nanode-1"
+	root_pass = "terraform-test"
+
+	watchdog_enabled = false
+}
+`, instance)
 }
 
 func testAccCheckLinodeInstanceWithType(instance string, pubkey string, typ string) string {


### PR DESCRIPTION
Watchdog is now enabled by default by the API. This change fixes the drift in state on the second apply of a Watchdog-disabled instance.