### PR TITLE
refactor linode_lke_cluster update to reuse node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ FEATURES:
 * **New Data Source** `linode_lke_cluster`
 * **New Resource** `linode_user`
 
+ENHANCEMENTS:
+
+* Existing `linode_lke_cluster` node pools are now reused when performing node pool updates.
+
 ## 1.14.3 (January 28, 2021)
 
 BUG FIXES:

--- a/linode/resource_linode_lke_cluster_test.go
+++ b/linode/resource_linode_lke_cluster_test.go
@@ -3,6 +3,7 @@ package linode
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -19,6 +20,106 @@ func init() {
 		Name: "linode_lke_cluster",
 		F:    testSweepLinodeLKECluster,
 	})
+}
+
+func TestReconcileLKEClusterPoolSpecs(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		specs            []linodeLKEClusterPoolSpec
+		provisionedPools []linodego.LKEClusterPool
+
+		expectedToDelete []int
+		expectedToCreate []linodego.LKEClusterPoolCreateOptions
+		expectedToUpdate map[int]linodego.LKEClusterPoolUpdateOptions
+	}{
+		{
+			name: "no change",
+			provisionedPools: []linodego.LKEClusterPool{
+				{ID: 123, Type: "g6-standard-1", Count: 2},
+			},
+			specs: []linodeLKEClusterPoolSpec{
+				{Type: "g6-standard-1", Count: 2},
+			},
+			expectedToUpdate: map[int]linodego.LKEClusterPoolUpdateOptions{},
+		},
+		{
+			name: "upsize a single pool",
+			provisionedPools: []linodego.LKEClusterPool{
+				{ID: 123, Type: "g6-standard-1", Count: 2},
+			},
+			specs: []linodeLKEClusterPoolSpec{
+				{Type: "g6-standard-1", Count: 3},
+			},
+			expectedToUpdate: map[int]linodego.LKEClusterPoolUpdateOptions{
+				123: {Count: 3},
+			},
+		},
+		{
+			name: "change single pool type",
+			provisionedPools: []linodego.LKEClusterPool{
+				{ID: 123, Type: "g6-standard-1", Count: 2},
+			},
+			specs: []linodeLKEClusterPoolSpec{
+				{Type: "g6-standard-2", Count: 2},
+			},
+			expectedToCreate: []linodego.LKEClusterPoolCreateOptions{
+				{Type: "g6-standard-2", Count: 2},
+			},
+			expectedToDelete: []int{123},
+			expectedToUpdate: map[int]linodego.LKEClusterPoolUpdateOptions{},
+		},
+		{
+			name: "reuse cluster for resize",
+			provisionedPools: []linodego.LKEClusterPool{
+				{ID: 123, Type: "g6-standard-1", Count: 1},
+				{ID: 124, Type: "g6-standard-1", Count: 10},
+			},
+			specs: []linodeLKEClusterPoolSpec{
+				{Type: "g6-standard-1", Count: 9},  // bumped from 1 to 9
+				{Type: "g6-standard-2", Count: 10}, // type changed
+			},
+			expectedToDelete: []int{123},
+			expectedToUpdate: map[int]linodego.LKEClusterPoolUpdateOptions{
+				124: {Count: 9},
+			},
+			expectedToCreate: []linodego.LKEClusterPoolCreateOptions{
+				{Type: "g6-standard-2", Count: 10},
+			},
+		},
+		{
+			name: "competing resizes",
+			provisionedPools: []linodego.LKEClusterPool{
+				{ID: 123, Type: "g6-standard-3", Count: 3},
+				{ID: 124, Type: "g6-standard-3", Count: 7},
+				{ID: 126, Type: "g6-standard-3", Count: 4},
+				{ID: 127, Type: "g6-standard-3", Count: 2},
+			},
+			specs: []linodeLKEClusterPoolSpec{
+				{Type: "g6-standard-3", Count: 2},
+				{Type: "g6-standard-3", Count: 9},
+				{Type: "g6-standard-3", Count: 8},
+				{Type: "g6-standard-3", Count: 2},
+			},
+			expectedToUpdate: map[int]linodego.LKEClusterPoolUpdateOptions{
+				123: {Count: 2}, // -1
+				124: {Count: 8}, // +1
+				126: {Count: 9}, // +5
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			updates := reconcileLKEClusterPoolSpecs(tc.specs, tc.provisionedPools)
+			if !reflect.DeepEqual(tc.expectedToCreate, updates.ToCreate) {
+				t.Errorf("expected to create:\n%#v\ngot:\n%#v", tc.expectedToCreate, updates.ToCreate)
+			}
+			if !reflect.DeepEqual(tc.expectedToUpdate, updates.ToUpdate) {
+				t.Errorf("expected to update:\n%#v\ngot:\n%#v", tc.expectedToUpdate, updates.ToUpdate)
+			}
+			if !reflect.DeepEqual(tc.expectedToDelete, updates.ToDelete) {
+				t.Errorf("expected to delete:\n%#v\ngot:\n%#v", tc.expectedToDelete, updates.ToDelete)
+			}
+		})
+	}
 }
 
 func testSweepLinodeLKECluster(prefix string) error {
@@ -289,7 +390,7 @@ resource "linode_lke_cluster" "test" {
 		type  = "g6-standard-2"
 		count = 2
 	}
-	
+
 	pool {
 		type = "g6-standard-1"
 		count = 1


### PR DESCRIPTION
With this change, when updating the node pool specs, specs will be matched with the closest deployed pool and updated to meet the new spec.

Fixes #198