### PR TITLE
Make firewall protocol case-insensitive

### DIFF
--- a/linode/resource_linode_firewall_test.go
+++ b/linode/resource_linode_firewall_test.go
@@ -306,7 +306,7 @@ resource "linode_firewall" "test" {
 	inbound {
 		label    = "tf-test-in"
 		action = "ACCEPT"
-		protocol = "TCP"
+		protocol = "tcp"
 		ipv4 = ["0.0.0.0/0"]
 	}
 	inbound_policy = "DROP"


### PR DESCRIPTION
This pull requests makes the `protocol` field for firewall rules accept any case.