### PR TITLE
Add ACL and CorsEnabled fields to Object Storage bucket resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/bflad/tfproviderlint v0.21.0
 	github.com/golangci/golangci-lint v1.24.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.0
-	github.com/linode/linodego v0.26.0
+	github.com/linode/linodego v0.26.1
 	github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/linode/linodego v0.20.1/go.mod h1:XOWXRHjqeU2uPS84tKLgfWIfTlv3TYzCS0io4GOQzEI=
-github.com/linode/linodego v0.26.0 h1:UgJSN2ylT+cUyaSblxaMB1hEdoSSMsil7ogCiGOD+3w=
-github.com/linode/linodego v0.26.0/go.mod h1:GSBKPpjoQfxEfryoCRcgkuUOCuVtGHWhzI8OMdycNTE=
+github.com/linode/linodego v0.26.1 h1:g+6oJpheMbQmgZyizbz0GfU8YItcRxV7TYDjxpVUkhk=
+github.com/linode/linodego v0.26.1/go.mod h1:BR0gVkCJffEdIGJSl6bHR80Ty+Uvg/2jkjmrWaFectM=
 github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947 h1:e+tpC7AIiEgfYGEDq9Rjtdybq+V10S6OXzWjeGV/CEk=
 github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947/go.mod h1:MWI0tFyaJqRpirMv0VO7CGYT4V3IhHvml2rs/DlRQmY=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=

--- a/website/docs/r/object_storage_bucket.html.md
+++ b/website/docs/r/object_storage_bucket.html.md
@@ -34,6 +34,10 @@ The following arguments are supported:
 
 * `label` - (Required) The label of the Linode Object Storage Bucket.
 
+* `acl` - (Optional) The Access Control Level of the bucket using a canned ACL string. See all ACL strings [in the Linode API v4 documentation](linode.com/docs/api/object-storage/#object-storage-bucket-access-update__request-body-schema).
+
+* `cors_enabled` - (Optional) If true, the bucket will have CORS enabled for all origins.
+
 * [`cert`](#cert) - (Optional) The bucket's TLS/SSL certificate.
 
 ### cert


### PR DESCRIPTION
- Add `acl` and `cors_enabled` field to Object Storage bucket resource
- Add `TestAccLinodeObjectStorageBucket_access`
- Update documentation to reflect changes