### PR TITLE
Fix instance creation timeout on no image specified

### DIFF
--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -865,6 +865,11 @@ func resourceLinodeInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
+	// Instance will not successfully boot if image is not specified
+	if len(createOpts.Image) < 1 {
+		targetStatus = linodego.InstanceOffline
+	}
+
 	if !meta.(*ProviderMeta).Config.SkipInstanceReadyPoll {
 		if _, err = client.WaitForInstanceStatus(context.Background(), instance.ID, targetStatus, int(d.Timeout(schema.TimeoutCreate).Seconds())); err != nil {
 			return fmt.Errorf("timed-out waiting for Linode instance %d to reach status %s: %s", instance.ID, targetStatus, err)

--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -866,7 +866,7 @@ func resourceLinodeInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// Instance will not successfully boot if image is not specified
-	if len(createOpts.Image) < 1 {
+	if len(instance.Image) < 1 {
 		targetStatus = linodego.InstanceOffline
 	}
 

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -523,6 +523,38 @@ func TestAccLinodeInstance_privateImage(t *testing.T) {
 	})
 }
 
+func TestAccLinodeInstance_noImage(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_instance.foobar"
+	var instance linodego.Instance
+	instanceName := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLinodeInstanceWithNoImage(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
+					resource.TestCheckResourceAttr(resName, "region", "us-east"),
+					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
+				),
+			},
+
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLinodeInstance_updateSimple(t *testing.T) {
 	t.Parallel()
 	var instance linodego.Instance
@@ -2339,6 +2371,17 @@ func testAccCheckLinodeInstanceWithPrivateImage(instance string) string {
 		}
 	}
 `, instance, instance, instance)
+}
+
+func testAccCheckLinodeInstanceWithNoImage(instance string) string {
+	return fmt.Sprintf(`
+	resource "linode_instance" "foobar" {
+		label = "%s"
+		group = "tf_test"
+		type = "g6-nanode-1"
+		region = "us-east"
+	}
+`, instance)
 }
 
 func testAccCheckLinodeInstanceWithBootDiskImage(instance, image string) string {


### PR DESCRIPTION
This pull request fixes an issue where an Terraform waits for a timeout if an image is not specified during instance creation. It now waits for the `offline` state if an image is not specified, which is Linode's default functionality. 