### PR TITLE
Fix issue with NodeBalancers and Linode instance recreation

### DIFF
--- a/linode/resource_linode_nodebalancer_node.go
+++ b/linode/resource_linode_nodebalancer_node.go
@@ -57,6 +57,7 @@ func resourceLinodeNodeBalancerNode() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The private IP Address and port (IP:PORT) where this backend can be reached. This must be a private IP address.",
 				Required:    true,
+				ForceNew:    true,
 			},
 			"status": {
 				Type:        schema.TypeString,
@@ -179,18 +180,6 @@ func resourceLinodeNodeBalancerNodeUpdate(d *schema.ResourceData, meta interface
 	configID, ok := d.Get("config_id").(int)
 	if !ok {
 		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
-	}
-
-	// If node doesn't exist, create a new one.
-	// This is necessary because the deletion of an instance
-	// will automatically delete its associated node.
-	_, err = client.GetNodeBalancerNode(context.Background(), nodebalancerID, configID, int(id))
-	if err != nil {
-		if err.(*linodego.Error).Code == 404 {
-			return resourceLinodeNodeBalancerNodeCreate(d, meta)
-		}
-
-		return fmt.Errorf("failed to get nodebalancer node %v: %s", id, err)
 	}
 
 	updateOpts := linodego.NodeBalancerNodeUpdateOptions{

--- a/linode/resource_linode_nodebalancer_node_test.go
+++ b/linode/resource_linode_nodebalancer_node_test.go
@@ -74,6 +74,35 @@ func TestAccLinodeNodeBalancerNode_update(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccStateIDNodeBalancerNode,
+			},
+		},
+	})
+}
+
+func TestAccLinodeNodeBalancerNode_instanceRecreated(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_nodebalancer_node.foonode"
+	nodeName := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeNodeBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLinodeNodeBalancerNodeBasic(nodeName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeNodeBalancerNode,
+					resource.TestCheckResourceAttr(resName, "label", nodeName),
+					resource.TestCheckResourceAttr(resName, "weight", "50"),
+				),
+			},
+			{
 				Config: testAccCheckLinodeNodeBalancerNodeInstanceUpdates(nodeName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeNodeBalancerNode,

--- a/linode/resource_linode_nodebalancer_node_test.go
+++ b/linode/resource_linode_nodebalancer_node_test.go
@@ -74,6 +74,17 @@ func TestAccLinodeNodeBalancerNode_update(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccCheckLinodeNodeBalancerNodeInstanceUpdates(nodeName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeNodeBalancerNode,
+					resource.TestCheckResourceAttr(resName, "label", nodeName),
+					resource.TestCheckResourceAttrSet(resName, "status"),
+					resource.TestCheckResourceAttrSet(resName, "address"),
+					resource.TestCheckResourceAttr(resName, "mode", "accept"),
+					resource.TestCheckResourceAttr(resName, "weight", "50"),
+				),
+			},
+			{
 				ResourceName:      resName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -217,6 +228,18 @@ func testAccStateIDNodeBalancerNode(s *terraform.State) (string, error) {
 
 func testAccCheckLinodeNodeBalancerNodeBasic(label string) string {
 	return testAccCheckLinodeInstanceConfigPrivateNetworking(label, publicKeyMaterial) + testAccCheckLinodeNodeBalancerConfigBasic(label) + fmt.Sprintf(`
+resource "linode_nodebalancer_node" "foonode" {
+	nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+	config_id = "${linode_nodebalancer_config.foofig.id}"
+	address = "${linode_instance.foobar.private_ip_address}:80"
+	label = "%s"
+	weight = 50
+}
+`, label)
+}
+
+func testAccCheckLinodeNodeBalancerNodeInstanceUpdates(label string) string {
+	return testAccCheckLinodeInstanceConfigPrivateNetworking(label, publicKeyMaterial+"_new") + testAccCheckLinodeNodeBalancerConfigBasic(label) + fmt.Sprintf(`
 resource "linode_nodebalancer_node" "foonode" {
 	nodebalancer_id = "${linode_nodebalancer.foobar.id}"
 	config_id = "${linode_nodebalancer_config.foofig.id}"


### PR DESCRIPTION
This pull request fixes an error that occurs when a Linode instance currently associated with a NodeBalancer is force-recreated (for example: when there are changes to authorized_keys).