### PR TITLE
Add linode_images datasource

### DIFF
--- a/linode/data_source_linode_images.go
+++ b/linode/data_source_linode_images.go
@@ -1,0 +1,63 @@
+package linode
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
+
+	"context"
+	"fmt"
+	"strconv"
+)
+
+func dataSourceLinodeImages() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceLinodeImagesRead,
+		Schema: map[string]*schema.Schema{
+			"filter": filterSchema(),
+			"images": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceLinodeImage(),
+			},
+		},
+	}
+}
+
+func dataSourceLinodeImagesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ProviderMeta).Client
+
+	filter, err := constructFilterString(d, imageValueToFilterType)
+	if err != nil {
+		return fmt.Errorf("failed to construct filter: %s", err)
+	}
+
+	images, err := client.ListImages(context.Background(), &linodego.ListOptions{
+		Filter: filter,
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to list linode images: %s", err)
+	}
+
+	imagesFlattened := make([]interface{}, len(images))
+	for i, image := range images {
+		imagesFlattened[i] = flattenLinodeImage(&image)
+	}
+
+	d.SetId(filter)
+	d.Set("images", imagesFlattened)
+
+	return nil
+}
+
+func imageValueToFilterType(filterName, value string) (interface{}, error) {
+	switch filterName {
+	case "deprecated", "is_public":
+		return strconv.ParseBool(value)
+
+	case "size":
+		return strconv.Atoi(value)
+	}
+
+	return value, nil
+}

--- a/linode/data_source_linode_images_test.go
+++ b/linode/data_source_linode_images_test.go
@@ -1,0 +1,73 @@
+package linode
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccDataSourceLinodeImages_basic(t *testing.T) {
+	t.Parallel()
+
+	imageName := acctest.RandomWithPrefix("tf_test")
+	resourceName := "data.linode_images.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceLinodeImagesBasic(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "images.0.label", imageName),
+					resource.TestCheckResourceAttr(resourceName, "images.0.description", "descriptive text"),
+					resource.TestCheckResourceAttr(resourceName, "images.0.is_public", "false"),
+					resource.TestCheckResourceAttr(resourceName, "images.0.type", "manual"),
+					resource.TestCheckResourceAttrSet(resourceName, "images.0.created"),
+					resource.TestCheckResourceAttrSet(resourceName, "images.0.created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "images.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "images.0.deprecated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceLinodeImages_noFilters(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_images.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceLinodeImagesNoFilters(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceNonEmptyList(resourceName, "images"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceLinodeImagesBasic(image string) string {
+	return testAccCheckLinodeImageConfigBasic(image) + `
+data "linode_images" "foobar" {
+	filter {
+		name = "label"
+		values = [linode_image.foobar.label]
+	}
+
+	filter {
+		name = "is_public"
+		values = ["false"]
+	}
+}`
+}
+
+func testDataSourceLinodeImagesNoFilters() string {
+	return `
+data "linode_images" "foobar" {}`
+}

--- a/linode/helpers_test.go
+++ b/linode/helpers_test.go
@@ -3,6 +3,7 @@ package linode
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +82,26 @@ func testAccCheckResourceAttrNotEqual(resName string, path, notValue string) res
 			return fmt.Errorf("attribute %s does not exist", path)
 		} else if value == notValue {
 			return fmt.Errorf("attribute was equal")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckResourceNonEmptyList(resourceName, attrName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		instCount, err := strconv.Atoi(rs.Primary.Attributes[fmt.Sprintf("%s.#", attrName)])
+		if err != nil {
+			return fmt.Errorf("failed to parse: %s", err)
+		}
+
+		if instCount < 1 {
+			return fmt.Errorf("expected at least 1 element in %s", attrName)
 		}
 
 		return nil

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -85,6 +85,7 @@ func Provider() *schema.Provider {
 			"linode_domain_record":          dataSourceLinodeDomainRecord(),
 			"linode_firewall":               dataSourceLinodeFirewall(),
 			"linode_image":                  dataSourceLinodeImage(),
+			"linode_images":                 dataSourceLinodeImages(),
 			"linode_instances":              dataSourceLinodeInstances(),
 			"linode_instance_type":          dataSourceLinodeInstanceType(),
 			"linode_lke_cluster":            dataSourceLinodeLKECluster(),

--- a/linode/resource_linode_image.go
+++ b/linode/resource_linode_image.go
@@ -190,3 +190,27 @@ func resourceLinodeImageDelete(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("")
 	return nil
 }
+
+func flattenLinodeImage(image *linodego.Image) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	result["id"] = image.ID
+	result["label"] = image.Label
+	result["description"] = image.Description
+	result["created_by"] = image.CreatedBy
+	result["deprecated"] = image.Deprecated
+	result["is_public"] = image.IsPublic
+	result["size"] = image.Size
+	result["type"] = image.Type
+	result["vendor"] = image.Vendor
+
+	if image.Created != nil {
+		result["created"] = image.Created.Format(time.RFC3339)
+	}
+
+	if image.Expiry != nil {
+		result["expiry"] = image.Expiry.Format(time.RFC3339)
+	}
+
+	return result
+}

--- a/website/docs/d/images.html.md
+++ b/website/docs/d/images.html.md
@@ -1,0 +1,83 @@
+---
+layout: "linode"
+page_title: "Linode: linode_images"
+sidebar_current: "docs-linode-datasource-images"
+description: |-
+Provides information about Linode images that match a set of filters.
+---
+
+# Data Source: linode\_images
+
+Provides information about Linode images that match a set of filters.
+
+## Example Usage
+
+Get information about all Linode images with a certain label and visibility:
+
+```hcl
+data "linode_images" "specific-images" {
+  filter {
+    name = "label"
+    values = ["Debian 8"]
+  }
+
+  filter {
+    name = "is_public"
+    values = ["true"]
+  }
+}
+```
+
+Get information about all Linode images associated with the current token:
+
+```hcl
+data "linode_images" "all-images" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* [`filter`](#filter) - (Optional) A set of filters used to select Linode images that meet certain requirements.
+
+### Filter
+
+* `name` - (Required) The name of the field to filter by. See the [Filterable Fields section](#filterable-fields) for a complete list of filterable fields.
+
+* `values` - (Required) A list of values for the filter to allow. These values should all be in string form.
+
+## Attributes
+
+Each Linode image will be stored in the `images` attribute and will export the following attributes:
+
+* `id` - The unique ID of this Image.  The ID of private images begin with `private/` followed by the numeric identifier of the private image, for example `private/12345`.
+
+* `label` - A short description of the Image.
+
+* `created` - When this Image was created.
+
+* `created_by` - The name of the User who created this Image, or "linode" for official Images.
+
+* `deprecated` - Whether or not this Image is deprecated. Will only be true for deprecated public Images.
+
+* `description` - A detailed description of this Image.
+
+* `is_public` - True if the Image is public.
+
+* `size` - The minimum size this Image needs to deploy. Size is in MB. example: 2500
+
+* `type` - How the Image was created. Manual Images can be created at any time. "Automatic" Images are created automatically from a deleted Linode.
+
+* `vendor` - The upstream distribution vendor. `None` for private Images.
+
+## Filterable Fields
+
+* `deprecated`
+
+* `is_public`
+
+* `label`
+
+* `size`
+
+* `vendor`

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -28,6 +28,9 @@
             <li<%= sidebar_current("docs-linode-datasource-image") %>>
               <a href="/docs/providers/linode/d/image.html">linode_image</a>
             </li>
+            <li<%= sidebar_current("docs-linode-datasource-images") %>>
+              <a href="/docs/providers/linode/d/images.html">linode_images</a>
+            </li>
             <li<%= sidebar_current("docs-linode-datasource-instances") %>>
               <a href="/docs/providers/linode/d/instances.html">linode_instances</a>
             </li>


### PR DESCRIPTION
- Add `linode_images` datasource

Usage:

```hcl
data "linode_images" "specific-images" {
  filter {
    name = "label"
    values = ["Debian 8"]
  }

  filter {
    name = "is_public"
    values = ["true"]
  }
}
```

```hcl
data "linode_images" "all-images" {}
```