### PR TITLE
remove containerlinux references from test cases

### DIFF
--- a/linode/data_source_linode_networking_ip_test.go
+++ b/linode/data_source_linode_networking_ip_test.go
@@ -50,7 +50,7 @@ func testDataSourceLinodeNetworkingIPBasic(label string) string {
 resource "linode_instance" "foobar" {
 	label = "%s"
 	group = "tf_test"
-	image = "linode/containerlinux"
+	image = "linode/alpine3.12"
 	type = "g6-standard-1"
 	region = "us-east"
 }

--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -636,9 +636,6 @@ func resourceLinodeInstanceRead(d *schema.ResourceData, meta interface{}) error 
 			"type": "ssh",
 			"host": public[0].Address,
 		})
-		// TODO(displague) to determine 'user', need to check disk.image
-		// "linode/containerlinux" is "core", else "root"
-		// might be better to make this a resource field and avoid lookups
 	}
 
 	if len(private) > 0 {

--- a/linode/resource_linode_rdns_test.go
+++ b/linode/resource_linode_rdns_test.go
@@ -159,7 +159,7 @@ func testAccCheckLinodeRDNSBasic(label string) string {
 resource "linode_instance" "foobar" {
 	label = "%s"
 	group = "tf_test"
-	image = "linode/containerlinux"
+	image = "linode/alpine3.12"
 	type = "g6-standard-1"
 	region = "us-east"
 }
@@ -175,7 +175,7 @@ func testAccCheckLinodeRDNSChanged(label string) string {
 resource "linode_instance" "foobar" {
 	label = "%s"
 	group = "tf_test"
-	image = "linode/containerlinux"
+	image = "linode/alpine3.12"
 	type = "g6-standard-1"
 	region = "us-east"
 }
@@ -192,7 +192,7 @@ func testAccCheckLinodeRDNSDeleted(label string) string {
 resource "linode_instance" "foobar" {
 	label = "%s"
 	group = "tf_test"
-	image = "linode/containerlinux"
+	image = "linode/alpine3.12"
 	type = "g6-standard-1"
 	region = "us-east"
 }


### PR DESCRIPTION
`linode/containerlinux` is no longer available in the Linode machine image registry. This removes all references to it.