### PR TITLE
remove unused hashibot config

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,9 +1,0 @@
-behavior "regexp_issue_labeler" "bug_label" {
-    regexp = " \\[issue-type:bug-report\\] "
-    labels = ["bug"]
-}
-
-behavior "regexp_issue_labeler" "enhancement_label" {
-    regexp = " \\[issue-type:enhancement\\] "
-    labels = ["enhancement"]
-}


### PR DESCRIPTION
This was used when terraform-provider-linode resided in the terraform-providers Github org. It no longer serves a purpose.