### PR TITLE
empty Object Storage Buckets before deletion in sweeper

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,7 @@ docscheck:
 
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
+	go test ./$(PKG_NAME) -v -sweep=$(SWEEP) $(SWEEPARGS)
 
 default: build
 

--- a/linode/object_storage.go
+++ b/linode/object_storage.go
@@ -10,6 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const (
+	linodeObjectsEndpoint = "https://us-east-1.linodeobjects.com"
+)
+
 // s3ConnFromResourceData builds an S3 client from the linode_object_storage_object
 // resource's access_key and secret_key fields.
 func s3ConnFromResourceData(d *schema.ResourceData) *s3.S3 {
@@ -20,7 +24,7 @@ func s3ConnFromResourceData(d *schema.ResourceData) *s3.S3 {
 		// This region is hardcoded strictly for preflight validation purposes.
 		Region:      aws.String("us-east-1"),
 		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
-		Endpoint:    aws.String("https://us-east-1.linodeobjects.com"),
+		Endpoint:    aws.String(linodeObjectsEndpoint),
 	})
 	return s3.New(sess)
 }


### PR DESCRIPTION
`make sweep` will fail if it encounters a leaked Object Storage Bucket that is not empty because a non-empty bucket cannot be deleted.

If the sweeper is ran with `LINODE_OBJ_ACCESS_KEY` and `LINODE_OBJ_SECRET_KEY`, non-empty buckets can be emptied and then deleted. If not, the new behavior is just warning that the bucket will not be deleted, swallowing the error, and then continuing on to other leaked resources.