### PR TITLE
Clean up tfproviderlint settings

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,12 +17,7 @@ tooldeps:
 lint: fmtcheck
 	golangci-lint run
 	tfproviderlint \
-		-R003=false \
-		-R005=false \
-		-R007=false \
-		-R008=false \
 		-S006=false \
-		-S022=false \
 		-R018=false \
 		-R019=false \
 		./...

--- a/linode/resource_linode_image.go
+++ b/linode/resource_linode_image.go
@@ -121,7 +121,6 @@ func resourceLinodeImageRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLinodeImageCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderMeta).Client
-	d.Partial(true)
 
 	linodeID := d.Get("linode_id").(int)
 	diskID := d.Get("disk_id").(int)
@@ -145,7 +144,6 @@ func resourceLinodeImageCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(image.ID)
-	d.Partial(false)
 
 	if _, err := client.WaitForInstanceDiskStatus(
 		context.Background(), linodeID, diskID, linodego.DiskReady, int(d.Timeout(schema.TimeoutCreate).Seconds()),

--- a/linode/resource_linode_nodebalancer.go
+++ b/linode/resource_linode_nodebalancer.go
@@ -176,7 +176,7 @@ func resourceLinodeNodeBalancerUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error fetching data about the current NodeBalancer: %s", err)
 	}
 
-	if d.HasChange("label") || d.HasChange("client_conn_throttle") || d.HasChange("tags") {
+	if d.HasChanges("label", "client_conn_throttle", "tags") {
 		label := d.Get("label").(string)
 		clientConnThrottle := d.Get("client_conn_throttle").(int)
 

--- a/linode/resource_linode_volume.go
+++ b/linode/resource_linode_volume.go
@@ -107,7 +107,6 @@ func resourceLinodeVolumeRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceLinodeVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderMeta).Client
-	d.Partial(true)
 
 	var linodeID *int
 
@@ -150,14 +149,11 @@ func resourceLinodeVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	d.Partial(false)
-
 	return resourceLinodeVolumeRead(d, meta)
 }
 
 func resourceLinodeVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ProviderMeta).Client
-	d.Partial(true)
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -256,7 +252,6 @@ func resourceLinodeVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		d.Set("linode_id", linodeID)
 	}
-	d.Partial(false)
 
 	return resourceLinodeVolumeRead(d, meta)
 }


### PR DESCRIPTION
This pull request removes the following tfproviderlint settings:
- `R003` - `Resource` types should not have `Exists` functions.
- `R005` - `ResourceData.HasChange` calls should be combined into one. (`HasChanges`)
- `R007` - `(schema.ResourceData).Partial` calls should be removed.
- `R008` - `(schema.ResourceData).SetPartial` calls should be removed.
- `S022` - `TypeMap` schemas should not declare `Elem` of type `Resource`.