### PR TITLE
Add missing attributes to instance_type docs

### DIFF
--- a/website/docs/d/instance_type.html.md
+++ b/website/docs/d/instance_type.html.md
@@ -45,3 +45,11 @@ The Linode Instance Type resource exports the following attributes:
 * `addons.0.backups.0.price.0.hourly` - The cost (in US dollars) per hour to add Backups service.
 
 * `addons.0.backups.0.price.0.monthly` - The cost (in US dollars) per month to add Backups service.
+
+* `network_out` - The Mbits outbound bandwidth allocation.
+
+* `memory` - The amount of RAM included in this Linode Type.
+
+* `transfer` - The monthly outbound transfer amount, in MB.
+
+* `vcpus` - The number of VCPU cores this Linode Type offers.


### PR DESCRIPTION
- Add `instance_type`  data source attributes that were missing from docs.