### PR TITLE
Use createOpts for detecting the presence of an Image on Instance creation

### DIFF
--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -1001,7 +1001,7 @@ func resourceLinodeInstanceCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	// If the instance has implicit disks and config with no specified image it will not boot.
-	if !(disksOk && configsOk) && len(instance.Image) < 1 {
+	if !(disksOk && configsOk) && len(createOpts.Image) < 1 {
 		targetStatus = linodego.InstanceOffline
 	}
 


### PR DESCRIPTION
This change is necessary because private images are not returned in the `image` field of Linode instances.

resolves #346 