### PR TITLE
Add missing return statements in error blocks

### DIFF
--- a/linode/data_source_linode_firewall.go
+++ b/linode/data_source_linode_firewall.go
@@ -132,17 +132,17 @@ func datasourceLinodeFirewallRead(ctx context.Context, d *schema.ResourceData, m
 
 	firewall, err := client.GetFirewall(context.Background(), id)
 	if err != nil {
-		diag.Errorf("failed to get firewall %d: %s", id, err)
+		return diag.Errorf("failed to get firewall %d: %s", id, err)
 	}
 
 	rules, err := client.GetFirewallRules(context.Background(), id)
 	if err != nil {
-		diag.Errorf("failed to get firewall rules %d: %s", id, err)
+		return diag.Errorf("failed to get firewall rules %d: %s", id, err)
 	}
 
 	devices, err := client.ListFirewallDevices(context.Background(), id, nil)
 	if err != nil {
-		diag.Errorf("failed to get firewall devices %d: %s", id, err)
+		return diag.Errorf("failed to get firewall devices %d: %s", id, err)
 	}
 
 	d.SetId(strconv.Itoa(id))

--- a/linode/resource_linode_instance_ip.go
+++ b/linode/resource_linode_instance_ip.go
@@ -77,7 +77,7 @@ func resourceLinodeInstanceIPRead(ctx context.Context, d *schema.ResourceData, m
 	linodeID := d.Get("linode_id").(int)
 	ip, err := client.GetInstanceIPAddress(ctx, linodeID, address)
 	if err != nil {
-		diag.Errorf("failed to get instance (%d) ip: %s", linodeID, err)
+		return diag.Errorf("failed to get instance (%d) ip: %s", linodeID, err)
 	}
 
 	d.Set("address", ip.Address)
@@ -97,7 +97,7 @@ func resourceLinodeInstanceIPCreate(ctx context.Context, d *schema.ResourceData,
 	private := d.Get("public").(bool)
 	ip, err := client.AddInstanceIPAddress(ctx, linodeID, private)
 	if err != nil {
-		diag.Errorf("failed to create instance (%d) ip: %s", linodeID, err)
+		return diag.Errorf("failed to create instance (%d) ip: %s", linodeID, err)
 	}
 
 	rdns := d.Get("rdns").(string)


### PR DESCRIPTION
This PR is a fix for #356

In order to address the panic output when creating a `linode_instance_ip` resource, I added a return statement in front of the call to `diag.Errorf()` seen [here](https://github.com/linode/terraform-provider-linode/blob/ef894fad95e32e157dc56cc5f6a1280163ae3197/linode/resource_linode_instance_ip.go#L100).

In addition to this, I noticed other areas in the codebase where there was not a return statement in front of a call to `diag.Errorf()`. I have added return statements in front of these as well for the following lines:
1. [Line1](https://github.com/linode/terraform-provider-linode/blob/ef894fad95e32e157dc56cc5f6a1280163ae3197/linode/resource_linode_instance_ip.go#L80)
2. [Line2](https://github.com/linode/terraform-provider-linode/blob/ef894fad95e32e157dc56cc5f6a1280163ae3197/linode/data_source_linode_firewall.go#L135)
3. [Line3](https://github.com/linode/terraform-provider-linode/blob/ef894fad95e32e157dc56cc5f6a1280163ae3197/linode/data_source_linode_firewall.go#L140)
4. [Line4](https://github.com/linode/terraform-provider-linode/blob/ef894fad95e32e157dc56cc5f6a1280163ae3197/linode/data_source_linode_firewall.go#L145)


As a result of adding the return statement [here](https://github.com/linode/terraform-provider-linode/blob/ef894fad95e32e157dc56cc5f6a1280163ae3197/linode/resource_linode_instance_ip.go#L100), there is no longer a panic output, but rather the error message that we expect.
![linode_instance_ip_error_message](https://user-images.githubusercontent.com/67260328/122880446-db67e280-d2ee-11eb-8e52-c5c5662e1323.png).

I hope that this change is helpful. Please let me know if there is anything I need to change, I would certainly appreciate any feedback :D

