### PR TITLE
Fix issue with StackScript test cleanup

### DIFF
--- a/linode/resource_linode_stackscript_test.go
+++ b/linode/resource_linode_stackscript_test.go
@@ -206,7 +206,7 @@ func testAccCheckLinodeStackscriptDestroy(s *terraform.State) error {
 			return fmt.Errorf("Linode Stackscript with id %d still exists", id)
 		}
 
-		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code != 404 {
+		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code != 401 {
 			return fmt.Errorf("Error requesting Linode Stackscript with id %d", id)
 		}
 	}


### PR DESCRIPTION
After a StackScript is deleted, GET requests to that StackScript can return status code `401` rather than `404`. This causes the cleanup stage of the StackScript tests to fail due to an unexpected `401` response.