### PR TITLE
Make all resources and datasources context-aware

### DIFF
--- a/linode/data_source_linode_account.go
+++ b/linode/data_source_linode_account.go
@@ -2,14 +2,14 @@ package linode
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeAccount() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeAccountRead,
+		ReadContext: dataSourceLinodeAccountRead,
 		Schema: map[string]*schema.Schema{
 			"email": {
 				Type: schema.TypeString,
@@ -78,12 +78,12 @@ func dataSourceLinodeAccount() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeAccountRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
-	account, err := client.GetAccount(context.Background())
+	account, err := client.GetAccount(ctx)
 	if err != nil {
-		return fmt.Errorf("Error getting account: %s", err)
+		return diag.Errorf("Error getting account: %s", err)
 	}
 
 	d.SetId(account.Email)

--- a/linode/data_source_linode_domain.go
+++ b/linode/data_source_linode_domain.go
@@ -3,9 +3,9 @@ package linode
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
@@ -15,7 +15,7 @@ const domainSecondsDescription = "Valid values are 300, 3600, 7200, 14400, 28800
 
 func dataSourceLinodeDomain() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeDomainRead,
+		ReadContext: dataSourceLinodeDomainRead,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -106,14 +106,14 @@ func dataSourceLinodeDomain() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeDomainRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqIDString := d.Get("id").(string)
 	reqDomain := d.Get("domain").(string)
 
 	if reqDomain == "" && reqIDString == "" {
-		return fmt.Errorf("Domain or Domain ID is required")
+		return diag.Errorf("Domain or Domain ID is required")
 	}
 
 	var domain *linodego.Domain
@@ -123,24 +123,24 @@ func dataSourceLinodeDomainRead(d *schema.ResourceData, meta interface{}) error 
 	if reqIDString != "" {
 		reqID, err := strconv.Atoi(reqIDString)
 		if err != nil {
-			return fmt.Errorf("Domain ID %q must be numeric", reqIDString)
+			return diag.Errorf("Domain ID %q must be numeric", reqIDString)
 		}
 
-		domain, err = client.GetDomain(context.Background(), reqID)
+		domain, err = client.GetDomain(ctx, reqID)
 		if err != nil {
-			return fmt.Errorf("Error listing domain: %s", err)
+			return diag.Errorf("Error listing domain: %s", err)
 		}
 		if reqDomain != "" && domain.Domain != reqDomain {
-			return fmt.Errorf("Domain ID was found but did not match the requested Domain name")
+			return diag.Errorf("Domain ID was found but did not match the requested Domain name")
 		}
 	} else if reqDomain != "" {
 		filter, _ := json.Marshal(map[string]interface{}{"domain": reqDomain})
-		domains, err := client.ListDomains(context.Background(), linodego.NewListOptions(0, string(filter)))
+		domains, err := client.ListDomains(ctx, linodego.NewListOptions(0, string(filter)))
 		if err != nil {
-			return fmt.Errorf("Error listing Domains: %s", err)
+			return diag.Errorf("Error listing Domains: %s", err)
 		}
 		if len(domains) != 1 || domains[0].Domain != reqDomain {
-			return fmt.Errorf("Domain %s was not found", reqDomain)
+			return diag.Errorf("Domain %s was not found", reqDomain)
 		}
 		domain = &domains[0]
 	}
@@ -163,5 +163,5 @@ func dataSourceLinodeDomainRead(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	return fmt.Errorf("Domain %s%s was not found", reqIDString, reqDomain)
+	return diag.Errorf("Domain %s%s was not found", reqIDString, reqDomain)
 }

--- a/linode/data_source_linode_firewall.go
+++ b/linode/data_source_linode_firewall.go
@@ -130,17 +130,17 @@ func datasourceLinodeFirewallRead(ctx context.Context, d *schema.ResourceData, m
 	client := meta.(*ProviderMeta).Client
 	id := d.Get("id").(int)
 
-	firewall, err := client.GetFirewall(context.Background(), id)
+	firewall, err := client.GetFirewall(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get firewall %d: %s", id, err)
 	}
 
-	rules, err := client.GetFirewallRules(context.Background(), id)
+	rules, err := client.GetFirewallRules(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get firewall rules %d: %s", id, err)
 	}
 
-	devices, err := client.ListFirewallDevices(context.Background(), id, nil)
+	devices, err := client.ListFirewallDevices(ctx, id, nil)
 	if err != nil {
 		return diag.Errorf("failed to get firewall devices %d: %s", id, err)
 	}

--- a/linode/data_source_linode_image.go
+++ b/linode/data_source_linode_image.go
@@ -2,15 +2,15 @@ package linode
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeImage() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeImageRead,
+		ReadContext: dataSourceLinodeImageRead,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -78,18 +78,18 @@ func dataSourceLinodeImage() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeImageRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqImage := d.Get("id").(string)
 
 	if reqImage == "" {
-		return fmt.Errorf("Image id is required")
+		return diag.Errorf("Image id is required")
 	}
 
-	image, err := client.GetImage(context.Background(), reqImage)
+	image, err := client.GetImage(ctx, reqImage)
 	if err != nil {
-		return fmt.Errorf("Error listing images: %s", err)
+		return diag.Errorf("Error listing images: %s", err)
 	}
 
 	if image != nil {
@@ -114,5 +114,5 @@ func dataSourceLinodeImageRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId("")
 
-	return fmt.Errorf("Image %s was not found", reqImage)
+	return diag.Errorf("Image %s was not found", reqImage)
 }

--- a/linode/data_source_linode_images.go
+++ b/linode/data_source_linode_images.go
@@ -1,17 +1,17 @@
 package linode
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 
 	"context"
-	"fmt"
 	"strconv"
 )
 
 func dataSourceLinodeImages() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeImagesRead,
+		ReadContext: dataSourceLinodeImagesRead,
 		Schema: map[string]*schema.Schema{
 			"filter": filterSchema([]string{"deprecated", "is_public", "label", "size", "vendor"}),
 			"images": {
@@ -24,20 +24,20 @@ func dataSourceLinodeImages() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeImagesRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeImagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	filter, err := constructFilterString(d, imageValueToFilterType)
 	if err != nil {
-		return fmt.Errorf("failed to construct filter: %s", err)
+		return diag.Errorf("failed to construct filter: %s", err)
 	}
 
-	images, err := client.ListImages(context.Background(), &linodego.ListOptions{
+	images, err := client.ListImages(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to list linode images: %s", err)
+		return diag.Errorf("failed to list linode images: %s", err)
 	}
 
 	imagesFlattened := make([]interface{}, len(images))

--- a/linode/data_source_linode_instance_type.go
+++ b/linode/data_source_linode_instance_type.go
@@ -2,14 +2,14 @@ package linode
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeInstanceType() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeInstanceTypeRead,
+		ReadContext: dataSourceLinodeInstanceTypeRead,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -114,12 +114,12 @@ func dataSourceLinodeInstanceType() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeInstanceTypeRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeInstanceTypeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
-	types, err := client.ListTypes(context.Background(), nil)
+	types, err := client.ListTypes(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("Error listing ranges: %s", err)
+		return diag.Errorf("Error listing ranges: %s", err)
 	}
 
 	reqType := d.Get("id").(string)
@@ -154,5 +154,5 @@ func dataSourceLinodeInstanceTypeRead(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 
-	return fmt.Errorf("Instance Type %s was not found", reqType)
+	return diag.Errorf("Instance Type %s was not found", reqType)
 }

--- a/linode/data_source_linode_instances.go
+++ b/linode/data_source_linode_instances.go
@@ -441,7 +441,8 @@ func dataSourceLinodeInstancesRead(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func flattenLinodeInstance(ctx context.Context, client *linodego.Client, instance *linodego.Instance) (map[string]interface{}, error) {
+func flattenLinodeInstance(
+	ctx context.Context, client *linodego.Client, instance *linodego.Instance) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 
 	id := instance.ID

--- a/linode/data_source_linode_lke_cluster.go
+++ b/linode/data_source_linode_lke_cluster.go
@@ -114,22 +114,22 @@ func datasourceLinodeLKEClusterRead(ctx context.Context, d *schema.ResourceData,
 	client := meta.(*ProviderMeta).Client
 	id := d.Get("id").(int)
 
-	cluster, err := client.GetLKECluster(context.Background(), id)
+	cluster, err := client.GetLKECluster(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get LKE cluster %d: %s", id, err)
 	}
 
-	pools, err := client.ListLKEClusterPools(context.Background(), id, nil)
+	pools, err := client.ListLKEClusterPools(ctx, id, nil)
 	if err != nil {
 		return diag.Errorf("failed to get pools for LKE cluster %d: %s", id, err)
 	}
 
-	kubeconfig, err := client.GetLKEClusterKubeconfig(context.Background(), id)
+	kubeconfig, err := client.GetLKEClusterKubeconfig(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get kubeconfig for LKE cluster %d: %s", id, err)
 	}
 
-	endpoints, err := client.ListLKEClusterAPIEndpoints(context.Background(), id, nil)
+	endpoints, err := client.ListLKEClusterAPIEndpoints(ctx, id, nil)
 	if err != nil {
 		return diag.Errorf("failed to get API endpoints for LKE cluster %d: %s", id, err)
 	}

--- a/linode/data_source_linode_networking_ip.go
+++ b/linode/data_source_linode_networking_ip.go
@@ -2,14 +2,14 @@ package linode
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeNetworkingIP() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeNetworkingIPRead,
+		ReadContext: dataSourceLinodeNetworkingIPRead,
 
 		Schema: map[string]*schema.Schema{
 			"address": {
@@ -62,18 +62,18 @@ func dataSourceLinodeNetworkingIP() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeNetworkingIPRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeNetworkingIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqImage := d.Get("address").(string)
 
 	if reqImage == "" {
-		return fmt.Errorf("NetworkingIP address is required")
+		return diag.Errorf("NetworkingIP address is required")
 	}
 
-	address, err := client.GetIPAddress(context.Background(), reqImage)
+	address, err := client.GetIPAddress(ctx, reqImage)
 	if err != nil {
-		return fmt.Errorf("Error listing addresses: %s", err)
+		return diag.Errorf("Error listing addresses: %s", err)
 	}
 
 	if address != nil {
@@ -92,5 +92,5 @@ func dataSourceLinodeNetworkingIPRead(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 
-	return fmt.Errorf("NetworkingIP address %s was not found", reqImage)
+	return diag.Errorf("NetworkingIP address %s was not found", reqImage)
 }

--- a/linode/data_source_linode_nodebalancer.go
+++ b/linode/data_source_linode_nodebalancer.go
@@ -78,7 +78,7 @@ func datasourceLinodeNodeBalancerRead(ctx context.Context, d *schema.ResourceDat
 	client := meta.(*ProviderMeta).Client
 	id := d.Get("id").(int)
 
-	nodebalancer, err := client.GetNodeBalancer(context.Background(), id)
+	nodebalancer, err := client.GetNodeBalancer(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get nodebalancer %d: %s", id, err)
 	}

--- a/linode/data_source_linode_nodebalancer_config.go
+++ b/linode/data_source_linode_nodebalancer_config.go
@@ -133,7 +133,7 @@ func datasourceLinodeNodeBalancerConfigRead(
 	id := d.Get("id").(int)
 	nodebalancerID := d.Get("nodebalancer_id").(int)
 
-	config, err := client.GetNodeBalancerConfig(context.Background(), nodebalancerID, id)
+	config, err := client.GetNodeBalancerConfig(ctx, nodebalancerID, id)
 	if err != nil {
 		return diag.Errorf("failed to get nodebalancer config %d: %s", id, err)
 	}

--- a/linode/data_source_linode_nodebalancer_node.go
+++ b/linode/data_source_linode_nodebalancer_node.go
@@ -71,7 +71,7 @@ func datasourceLinodeNodeBalancerNodeRead(
 	nodebalancerID := d.Get("nodebalancer_id").(int)
 	configID := d.Get("config_id").(int)
 
-	node, err := client.GetNodeBalancerNode(context.Background(), nodebalancerID, configID, id)
+	node, err := client.GetNodeBalancerNode(ctx, nodebalancerID, configID, id)
 	if err != nil {
 		return diag.Errorf("failed to get nodebalancer node %d: %s", id, err)
 	}

--- a/linode/data_source_linode_object_storage_cluster.go
+++ b/linode/data_source_linode_object_storage_cluster.go
@@ -2,14 +2,14 @@ package linode
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeObjectStorageCluster() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeObjectStorageClusterRead,
+		ReadContext: dataSourceLinodeObjectStorageClusterRead,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -45,18 +45,18 @@ func dataSourceLinodeObjectStorageCluster() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeObjectStorageClusterRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeObjectStorageClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqObjectStorageCluster := d.Get("id").(string)
 
 	if reqObjectStorageCluster == "" {
-		return fmt.Errorf("Error object storage cluster id is required")
+		return diag.Errorf("Error object storage cluster id is required")
 	}
 
-	objectStorageCluster, err := client.GetObjectStorageCluster(context.Background(), reqObjectStorageCluster)
+	objectStorageCluster, err := client.GetObjectStorageCluster(ctx, reqObjectStorageCluster)
 	if err != nil {
-		return fmt.Errorf("Error listing object storage clusters: %s", err)
+		return diag.Errorf("Error listing object storage clusters: %s", err)
 	}
 
 	if objectStorageCluster != nil {
@@ -69,5 +69,5 @@ func dataSourceLinodeObjectStorageClusterRead(d *schema.ResourceData, meta inter
 		return nil
 	}
 
-	return fmt.Errorf("Linode object storage cluster %s was not found", reqObjectStorageCluster)
+	return diag.Errorf("Linode object storage cluster %s was not found", reqObjectStorageCluster)
 }

--- a/linode/data_source_linode_object_storage_cluster.go
+++ b/linode/data_source_linode_object_storage_cluster.go
@@ -45,7 +45,8 @@ func dataSourceLinodeObjectStorageCluster() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeObjectStorageClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLinodeObjectStorageClusterRead(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqObjectStorageCluster := d.Get("id").(string)

--- a/linode/data_source_linode_profile.go
+++ b/linode/data_source_linode_profile.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeProfile() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeProfileRead,
+		ReadContext: dataSourceLinodeProfileRead,
 		Schema: map[string]*schema.Schema{
 			"email": {
 				Type:        schema.TypeString,
@@ -107,12 +108,12 @@ func dataSourceLinodeProfile() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeProfileRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
-	profile, err := client.GetProfile(context.Background())
+	profile, err := client.GetProfile(ctx)
 	if err != nil {
-		return fmt.Errorf("Error getting profile: %s", err)
+		return diag.Errorf("Error getting profile: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%d", profile.UID))

--- a/linode/data_source_linode_region.go
+++ b/linode/data_source_linode_region.go
@@ -2,14 +2,14 @@ package linode
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeRegion() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeRegionRead,
+		ReadContext: dataSourceLinodeRegionRead,
 
 		Schema: map[string]*schema.Schema{
 			"country": {
@@ -27,18 +27,18 @@ func dataSourceLinodeRegion() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeRegionRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeRegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqRegion := d.Get("id").(string)
 
 	if reqRegion == "" {
-		return fmt.Errorf("Error region id is required")
+		return diag.Errorf("Error region id is required")
 	}
 
-	region, err := client.GetRegion(context.Background(), reqRegion)
+	region, err := client.GetRegion(ctx, reqRegion)
 	if err != nil {
-		return fmt.Errorf("Error listing regions: %s", err)
+		return diag.Errorf("Error listing regions: %s", err)
 	}
 
 	if region != nil {
@@ -47,5 +47,5 @@ func dataSourceLinodeRegionRead(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	return fmt.Errorf("Linode Region %s was not found", reqRegion)
+	return diag.Errorf("Linode Region %s was not found", reqRegion)
 }

--- a/linode/data_source_linode_sshkey.go
+++ b/linode/data_source_linode_sshkey.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
 
 func dataSourceLinodeSSHKey() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeSSHKeyRead,
+		ReadContext: dataSourceLinodeSSHKeyRead,
 
 		Schema: map[string]*schema.Schema{
 			"label": {
@@ -33,19 +34,19 @@ func dataSourceLinodeSSHKey() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqLabel := d.Get("label").(string)
 
 	if reqLabel == "" {
-		return fmt.Errorf("Error SSH Key label is required")
+		return diag.Errorf("Error SSH Key label is required")
 	}
 
-	sshkeys, err := client.ListSSHKeys(context.Background(), nil)
+	sshkeys, err := client.ListSSHKeys(ctx, nil)
 	var sshkey linodego.SSHKey
 	if err != nil {
-		return fmt.Errorf("Error listing sshkey: %s", err)
+		return diag.Errorf("Error listing sshkey: %s", err)
 	}
 
 	for _, testkey := range sshkeys {
@@ -66,5 +67,5 @@ func dataSourceLinodeSSHKeyRead(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	return fmt.Errorf("Linode SSH Key with label %s was not found", reqLabel)
+	return diag.Errorf("Linode SSH Key with label %s was not found", reqLabel)
 }

--- a/linode/data_source_linode_stackscript.go
+++ b/linode/data_source_linode_stackscript.go
@@ -2,16 +2,16 @@ package linode
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceLinodeStackscript() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeStackscriptRead,
+		ReadContext: dataSourceLinodeStackscriptRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeInt,
@@ -129,13 +129,13 @@ func dataSourceLinodeStackscript() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeStackscriptRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeStackscriptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id := d.Get("id").(int)
 
-	ss, err := client.GetStackscript(context.Background(), id)
+	ss, err := client.GetStackscript(ctx, id)
 	if err != nil {
-		return fmt.Errorf("Error getting Staakscript: %s", err)
+		return diag.Errorf("Error getting Staakscript: %s", err)
 	}
 
 	if ss != nil {
@@ -156,5 +156,5 @@ func dataSourceLinodeStackscriptRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	return fmt.Errorf("StackScript %d not found", id)
+	return diag.Errorf("StackScript %d not found", id)
 }

--- a/linode/data_source_linode_user.go
+++ b/linode/data_source_linode_user.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
 
 func dataSourceLinodeUser() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeUserRead,
+		ReadContext: dataSourceLinodeUserRead,
 		Schema: map[string]*schema.Schema{
 			"username": {
 				Type: schema.TypeString,
@@ -41,19 +42,19 @@ func dataSourceLinodeUser() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeUserRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	reqUsername := d.Get("username").(string)
 
 	if reqUsername == "" {
-		return fmt.Errorf("Error User username is required")
+		return diag.Errorf("Error User username is required")
 	}
 
-	users, err := client.ListUsers(context.Background(), nil)
+	users, err := client.ListUsers(ctx, nil)
 	var user linodego.User
 	if err != nil {
-		return fmt.Errorf("Error listing user: %s", err)
+		return diag.Errorf("Error listing user: %s", err)
 	}
 
 	for _, testuser := range users {
@@ -73,5 +74,5 @@ func dataSourceLinodeUserRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	return fmt.Errorf("Linode User with username %s was not found", reqUsername)
+	return diag.Errorf("Linode User with username %s was not found", reqUsername)
 }

--- a/linode/data_source_linode_vlans.go
+++ b/linode/data_source_linode_vlans.go
@@ -1,11 +1,11 @@
 package linode
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -39,7 +39,7 @@ func dataSourceLinodeVLAN() *schema.Resource {
 
 func dataSourceLinodeVLANs() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeVLANsRead,
+		ReadContext: dataSourceLinodeVLANsRead,
 		Schema: map[string]*schema.Schema{
 			"filter": filterSchema([]string{"label", "region"}),
 			"vlans": {
@@ -52,20 +52,20 @@ func dataSourceLinodeVLANs() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeVLANsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeVLANsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	filter, err := constructFilterString(d, vlanValueToFilterType)
 	if err != nil {
-		return fmt.Errorf("failed to construct filter: %s", err)
+		return diag.Errorf("failed to construct filter: %s", err)
 	}
 
-	vlans, err := client.ListVLANs(context.Background(), &linodego.ListOptions{
+	vlans, err := client.ListVLANs(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to list linode vlans: %s", err)
+		return diag.Errorf("failed to list linode vlans: %s", err)
 	}
 
 	vlansFlattened := make([]interface{}, len(vlans))

--- a/linode/data_source_linode_volume.go
+++ b/linode/data_source_linode_volume.go
@@ -6,13 +6,14 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
 
 func dataSourceLinodeVolume() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceLinodeVolumeRead,
+		ReadContext: dataSourceLinodeVolumeRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeInt,
@@ -70,19 +71,19 @@ func dataSourceLinodeVolume() *schema.Resource {
 	}
 }
 
-func dataSourceLinodeVolumeRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceLinodeVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	requestedVolumeID := d.Get("id").(int)
 
 	if requestedVolumeID == 0 {
-		return fmt.Errorf("Volume ID is required")
+		return diag.Errorf("Volume ID is required")
 	}
 
 	var volume *linodego.Volume
 
-	volume, err := client.GetVolume(context.Background(), requestedVolumeID)
+	volume, err := client.GetVolume(ctx, requestedVolumeID)
 	if err != nil {
-		return fmt.Errorf("Error requesting Volume: %s", err)
+		return diag.Errorf("Error requesting Volume: %s", err)
 	}
 
 	if volume != nil {
@@ -99,5 +100,5 @@ func dataSourceLinodeVolumeRead(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	return fmt.Errorf("Linode Volume %s was not found", fmt.Sprint(requestedVolumeID))
+	return diag.Errorf("Linode Volume %s was not found", fmt.Sprint(requestedVolumeID))
 }

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -152,7 +152,8 @@ type ProviderMeta struct {
 	Config *Config
 }
 
-func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVersion string) (interface{}, diag.Diagnostics) {
+func providerConfigure(
+	ctx context.Context, d *schema.ResourceData, terraformVersion string) (interface{}, diag.Diagnostics) {
 	config := &Config{
 		AccessToken: d.Get("token").(string),
 		APIURL:      d.Get("url").(string),

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -2,8 +2,8 @@ package linode
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/linode/linodego"
@@ -135,14 +135,14 @@ func Provider() *schema.Provider {
 		},
 	}
 
-	provider.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		terraformVersion := provider.TerraformVersion
 		if terraformVersion == "" {
 			// Terraform 0.12 introduced this field to the protocol
 			// We can therefore assume that if it's missing it's 0.10 or 0.11
 			terraformVersion = "0.11+compatible"
 		}
-		return providerConfigure(d, terraformVersion)
+		return providerConfigure(ctx, d, terraformVersion)
 	}
 	return provider
 }
@@ -152,7 +152,7 @@ type ProviderMeta struct {
 	Config *Config
 }
 
-func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
+func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVersion string) (interface{}, diag.Diagnostics) {
 	config := &Config{
 		AccessToken: d.Get("token").(string),
 		APIURL:      d.Get("url").(string),
@@ -174,8 +174,8 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	client := config.Client()
 
 	// Ping the API for an empty response to verify the configuration works
-	if _, err := client.ListTypes(context.Background(), linodego.NewListOptions(100, "")); err != nil {
-		return nil, fmt.Errorf("Error connecting to the Linode API: %s", err)
+	if _, err := client.ListTypes(ctx, linodego.NewListOptions(100, "")); err != nil {
+		return nil, diag.Errorf("Error connecting to the Linode API: %s", err)
 	}
 	return &ProviderMeta{
 		Client: client,

--- a/linode/resource_linode_domain_record.go
+++ b/linode/resource_linode_domain_record.go
@@ -100,7 +100,8 @@ func resourceLinodeDomainRecord() *schema.Resource {
 	}
 }
 
-func resourceLinodeDomainRecordImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceLinodeDomainRecordImport(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	if strings.Contains(d.Id(), ",") {
 		s := strings.Split(d.Id(), ",")
 		// Validate that this is an ID by making sure it can be converted into an int

--- a/linode/resource_linode_domain_record.go
+++ b/linode/resource_linode_domain_record.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/linode/linodego"
@@ -16,12 +17,12 @@ func resourceLinodeDomainRecord() *schema.Resource {
 	secondsDiffSuppressor := domainSecondsDiffSuppressor()
 
 	return &schema.Resource{
-		Create: resourceLinodeDomainRecordCreate,
-		Read:   resourceLinodeDomainRecordRead,
-		Update: resourceLinodeDomainRecordUpdate,
-		Delete: resourceLinodeDomainRecordDelete,
+		CreateContext: resourceLinodeDomainRecordCreate,
+		ReadContext:   resourceLinodeDomainRecordRead,
+		UpdateContext: resourceLinodeDomainRecordUpdate,
+		DeleteContext: resourceLinodeDomainRecordDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceLinodeDomainRecordImport,
+			StateContext: resourceLinodeDomainRecordImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"domain_id": {
@@ -99,7 +100,7 @@ func resourceLinodeDomainRecord() *schema.Resource {
 	}
 }
 
-func resourceLinodeDomainRecordImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceLinodeDomainRecordImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	if strings.Contains(d.Id(), ",") {
 		s := strings.Split(d.Id(), ",")
 		// Validate that this is an ID by making sure it can be converted into an int
@@ -117,7 +118,7 @@ func resourceLinodeDomainRecordImport(d *schema.ResourceData, meta interface{}) 
 		d.Set("domain_id", domainID)
 	}
 
-	err := resourceLinodeDomainRecordRead(d, meta)
+	err := resourceLinodeDomainRecordRead(ctx, d, meta)
 	if err != nil {
 		return nil, fmt.Errorf("unable to import %v as domain_record: %v", d.Id(), err)
 	}
@@ -128,21 +129,21 @@ func resourceLinodeDomainRecordImport(d *schema.ResourceData, meta interface{}) 
 	return results, nil
 }
 
-func resourceLinodeDomainRecordRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeDomainRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode DomainRecord ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode DomainRecord ID %s as int: %s", d.Id(), err)
 	}
 	domainID := d.Get("domain_id").(int)
-	record, err := client.GetDomainRecord(context.Background(), int(domainID), int(id))
+	record, err := client.GetDomainRecord(ctx, int(domainID), int(id))
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			log.Printf("[WARN] removing Linode Domain Record ID %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error finding the specified Linode DomainRecord: %s", err)
+		return diag.Errorf("Error finding the specified Linode DomainRecord: %s", err)
 	}
 
 	d.Set("name", record.Name)
@@ -193,7 +194,7 @@ func domainRecordFromResourceData(d *schema.ResourceData) *linodego.DomainRecord
 	}
 }
 
-func resourceLinodeDomainRecordCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeDomainRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	domainID := d.Get("domain_id").(int)
 	rec := domainRecordFromResourceData(d)
@@ -211,24 +212,24 @@ func resourceLinodeDomainRecordCreate(d *schema.ResourceData, meta interface{}) 
 		Tag:      resourceDataStringOrNil(d, "tag"),
 	}
 
-	domainRecord, err := client.CreateDomainRecord(context.Background(), domainID, createOpts)
+	domainRecord, err := client.CreateDomainRecord(ctx, domainID, createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating a Linode DomainRecord: %s", err)
+		return diag.Errorf("Error creating a Linode DomainRecord: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%d", domainRecord.ID))
 
-	return resourceLinodeDomainRecordRead(d, meta)
+	return resourceLinodeDomainRecordRead(ctx, d, meta)
 }
 
-func resourceLinodeDomainRecordUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeDomainRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	domainID := d.Get("domain_id").(int)
 	rec := domainRecordFromResourceData(d)
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode DomainRecord id %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode DomainRecord id %s as int: %s", d.Id(), err)
 	}
 	updateOpts := linodego.DomainRecordUpdateOptions{
 		Type:     rec.Type,
@@ -243,24 +244,24 @@ func resourceLinodeDomainRecordUpdate(d *schema.ResourceData, meta interface{}) 
 		Tag:      resourceDataStringOrNil(d, "tag"),
 	}
 
-	_, err = client.UpdateDomainRecord(context.Background(), domainID, int(id), updateOpts)
+	_, err = client.UpdateDomainRecord(ctx, domainID, int(id), updateOpts)
 	if err != nil {
-		return fmt.Errorf("Error updating Domain Record: %s", err)
+		return diag.Errorf("Error updating Domain Record: %s", err)
 	}
 
-	return resourceLinodeDomainRecordRead(d, meta)
+	return resourceLinodeDomainRecordRead(ctx, d, meta)
 }
 
-func resourceLinodeDomainRecordDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeDomainRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	domainID := d.Get("domain_id").(int)
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode DomainRecord id %s as int", d.Id())
+		return diag.Errorf("Error parsing Linode DomainRecord id %s as int", d.Id())
 	}
-	err = client.DeleteDomainRecord(context.Background(), domainID, int(id))
+	err = client.DeleteDomainRecord(ctx, domainID, int(id))
 	if err != nil {
-		return fmt.Errorf("Error deleting Linode DomainRecord %d: %s", id, err)
+		return diag.Errorf("Error deleting Linode DomainRecord %d: %s", id, err)
 	}
 	d.SetId("")
 

--- a/linode/resource_linode_image.go
+++ b/linode/resource_linode_image.go
@@ -27,7 +27,7 @@ func resourceLinodeImage() *schema.Resource {
 		UpdateContext: resourceLinodeImageUpdate,
 		DeleteContext: resourceLinodeImageDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(LinodeImageCreateTimeout),

--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -83,7 +83,7 @@ func resourceLinodeInstance() *schema.Resource {
 		DeleteContext: resourceLinodeInstanceDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(LinodeInstanceCreateTimeout),

--- a/linode/resource_linode_nodebalancer_config.go
+++ b/linode/resource_linode_nodebalancer_config.go
@@ -190,7 +190,8 @@ func resourceLinodeNodeBalancerConfig() *schema.Resource {
 	}
 }
 
-func resourceLinodeNodeBalancerConfigImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceLinodeNodeBalancerConfigImport(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	if strings.Contains(d.Id(), ",") {
 		s := strings.Split(d.Id(), ",")
 		// Validate that this is an ID by making sure it can be converted into an int
@@ -219,7 +220,8 @@ func resourceLinodeNodeBalancerConfigImport(ctx context.Context, d *schema.Resou
 	return results, nil
 }
 
-func resourceLinodeNodeBalancerConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerConfigRead(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -263,7 +265,8 @@ func resourceLinodeNodeBalancerConfigRead(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceLinodeNodeBalancerConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerConfigCreate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	nodebalancerID := d.Get("nodebalancer_id").(int)
@@ -299,7 +302,8 @@ func resourceLinodeNodeBalancerConfigCreate(ctx context.Context, d *schema.Resou
 	return resourceLinodeNodeBalancerConfigRead(ctx, d, meta)
 }
 
-func resourceLinodeNodeBalancerConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerConfigUpdate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -338,7 +342,8 @@ func resourceLinodeNodeBalancerConfigUpdate(ctx context.Context, d *schema.Resou
 	return resourceLinodeNodeBalancerConfigRead(ctx, d, meta)
 }
 
-func resourceLinodeNodeBalancerConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerConfigDelete(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/linode/resource_linode_nodebalancer_node.go
+++ b/linode/resource_linode_nodebalancer_node.go
@@ -75,7 +75,8 @@ func resourceLinodeNodeBalancerNode() *schema.Resource {
 	}
 }
 
-func resourceLinodeNodeBalancerNodeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerNodeRead(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -109,7 +110,8 @@ func resourceLinodeNodeBalancerNodeRead(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceLinodeNodeBalancerNodeImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceLinodeNodeBalancerNodeImport(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	if strings.Contains(d.Id(), ",") {
 		s := strings.Split(d.Id(), ",")
 		// Validate that this is an ID by making sure it can be converted into an int
@@ -144,7 +146,8 @@ func resourceLinodeNodeBalancerNodeImport(ctx context.Context, d *schema.Resourc
 	return results, nil
 }
 
-func resourceLinodeNodeBalancerNodeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerNodeCreate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	nodebalancerID, ok := d.Get("nodebalancer_id").(int)
@@ -173,7 +176,8 @@ func resourceLinodeNodeBalancerNodeCreate(ctx context.Context, d *schema.Resourc
 	return resourceLinodeNodeBalancerNodeRead(ctx, d, meta)
 }
 
-func resourceLinodeNodeBalancerNodeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerNodeUpdate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
@@ -204,7 +208,8 @@ func resourceLinodeNodeBalancerNodeUpdate(ctx context.Context, d *schema.Resourc
 	return resourceLinodeNodeBalancerNodeRead(ctx, d, meta)
 }
 
-func resourceLinodeNodeBalancerNodeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeNodeBalancerNodeDelete(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/linode/resource_linode_nodebalancer_node.go
+++ b/linode/resource_linode_nodebalancer_node.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/linode/linodego"
@@ -14,12 +15,12 @@ import (
 
 func resourceLinodeNodeBalancerNode() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeNodeBalancerNodeCreate,
-		Read:   resourceLinodeNodeBalancerNodeRead,
-		Update: resourceLinodeNodeBalancerNodeUpdate,
-		Delete: resourceLinodeNodeBalancerNodeDelete,
+		CreateContext: resourceLinodeNodeBalancerNodeCreate,
+		ReadContext:   resourceLinodeNodeBalancerNodeRead,
+		UpdateContext: resourceLinodeNodeBalancerNodeUpdate,
+		DeleteContext: resourceLinodeNodeBalancerNodeDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceLinodeNodeBalancerNodeImport,
+			StateContext: resourceLinodeNodeBalancerNodeImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"nodebalancer_id": {
@@ -74,22 +75,22 @@ func resourceLinodeNodeBalancerNode() *schema.Resource {
 	}
 }
 
-func resourceLinodeNodeBalancerNodeRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeNodeBalancerNodeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode NodeBalancerNode ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode NodeBalancerNode ID %s as int: %s", d.Id(), err)
 	}
 	nodebalancerID, ok := d.Get("nodebalancer_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
 	}
 	configID, ok := d.Get("config_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
 	}
 
-	node, err := client.GetNodeBalancerNode(context.Background(), nodebalancerID, configID, int(id))
+	node, err := client.GetNodeBalancerNode(ctx, nodebalancerID, configID, int(id))
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			log.Printf("[WARN] removing NodeBalancer Node ID %q from state because it no longer exists", d.Id())
@@ -97,7 +98,7 @@ func resourceLinodeNodeBalancerNodeRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return fmt.Errorf("Error finding the specified Linode NodeBalancerNode: %s", err)
+		return diag.Errorf("Error finding the specified Linode NodeBalancerNode: %s", err)
 	}
 
 	d.Set("label", node.Label)
@@ -108,7 +109,7 @@ func resourceLinodeNodeBalancerNodeRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceLinodeNodeBalancerNodeImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceLinodeNodeBalancerNodeImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	if strings.Contains(d.Id(), ",") {
 		s := strings.Split(d.Id(), ",")
 		// Validate that this is an ID by making sure it can be converted into an int
@@ -132,7 +133,7 @@ func resourceLinodeNodeBalancerNodeImport(d *schema.ResourceData, meta interface
 		d.Set("config_id", configID)
 	}
 
-	err := resourceLinodeNodeBalancerNodeRead(d, meta)
+	err := resourceLinodeNodeBalancerNodeRead(ctx, d, meta)
 	if err != nil {
 		return nil, fmt.Errorf("unable to import %v as nodebalancer_node: %v", d.Id(), err)
 	}
@@ -143,16 +144,16 @@ func resourceLinodeNodeBalancerNodeImport(d *schema.ResourceData, meta interface
 	return results, nil
 }
 
-func resourceLinodeNodeBalancerNodeCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeNodeBalancerNodeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	nodebalancerID, ok := d.Get("nodebalancer_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
 	}
 	configID, ok := d.Get("config_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
 	}
 
 	createOpts := linodego.NodeBalancerNodeCreateOptions{
@@ -161,31 +162,31 @@ func resourceLinodeNodeBalancerNodeCreate(d *schema.ResourceData, meta interface
 		Mode:    linodego.NodeMode(d.Get("mode").(string)),
 		Weight:  d.Get("weight").(int),
 	}
-	node, err := client.CreateNodeBalancerNode(context.Background(), int(nodebalancerID), int(configID), createOpts)
+	node, err := client.CreateNodeBalancerNode(ctx, int(nodebalancerID), int(configID), createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating a Linode NodeBalancerNode: %s", err)
+		return diag.Errorf("Error creating a Linode NodeBalancerNode: %s", err)
 	}
 	d.SetId(fmt.Sprintf("%d", node.ID))
 	d.Set("config_id", configID)
 	d.Set("nodebalancer_id", nodebalancerID)
 
-	return resourceLinodeNodeBalancerNodeRead(d, meta)
+	return resourceLinodeNodeBalancerNodeRead(ctx, d, meta)
 }
 
-func resourceLinodeNodeBalancerNodeUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeNodeBalancerNodeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode NodeBalancerConfig ID %v as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode NodeBalancerConfig ID %v as int: %s", d.Id(), err)
 	}
 	nodebalancerID, ok := d.Get("nodebalancer_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
 	}
 	configID, ok := d.Get("config_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
 	}
 
 	updateOpts := linodego.NodeBalancerNodeUpdateOptions{
@@ -195,33 +196,31 @@ func resourceLinodeNodeBalancerNodeUpdate(d *schema.ResourceData, meta interface
 		Weight:  d.Get("weight").(int),
 	}
 
-	if _, err = client.UpdateNodeBalancerNode(
-		context.Background(), nodebalancerID, configID, int(id), updateOpts,
-	); err != nil {
-		return fmt.Errorf("Error updating Linode Nodebalancer %d Config %d Node %d: %s",
+	if _, err = client.UpdateNodeBalancerNode(ctx, nodebalancerID, configID, int(id), updateOpts); err != nil {
+		return diag.Errorf("Error updating Linode Nodebalancer %d Config %d Node %d: %s",
 			nodebalancerID, configID, int(id), err)
 	}
 
-	return resourceLinodeNodeBalancerNodeRead(d, meta)
+	return resourceLinodeNodeBalancerNodeRead(ctx, d, meta)
 }
 
-func resourceLinodeNodeBalancerNodeDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeNodeBalancerNodeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode NodeBalancerConfig ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode NodeBalancerConfig ID %s as int: %s", d.Id(), err)
 	}
 	nodebalancerID, ok := d.Get("nodebalancer_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("nodebalancer_id"))
 	}
 	configID, ok := d.Get("config_id").(int)
 	if !ok {
-		return fmt.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
+		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
 	}
-	err = client.DeleteNodeBalancerNode(context.Background(), nodebalancerID, configID, int(id))
+	err = client.DeleteNodeBalancerNode(ctx, nodebalancerID, configID, int(id))
 	if err != nil {
-		return fmt.Errorf("Error deleting Linode NodeBalancerNode %d: %s", id, err)
+		return diag.Errorf("Error deleting Linode NodeBalancerNode %d: %s", id, err)
 	}
 	return nil
 }

--- a/linode/resource_linode_object_storage_bucket.go
+++ b/linode/resource_linode_object_storage_bucket.go
@@ -173,7 +173,8 @@ func resourceLinodeObjectStorageBucket() *schema.Resource {
 	}
 }
 
-func resourceLinodeObjectStorageBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageBucketRead(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	cluster, label, err := decodeLinodeObjectStorageBucketID(d.Id())
@@ -228,7 +229,8 @@ func resourceLinodeObjectStorageBucketRead(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func resourceLinodeObjectStorageBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageBucketCreate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	cluster := d.Get("cluster").(string)
@@ -253,7 +255,8 @@ func resourceLinodeObjectStorageBucketCreate(ctx context.Context, d *schema.Reso
 	return resourceLinodeObjectStorageBucketUpdate(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageBucketUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageBucketUpdate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	accessKey := d.Get("access_key")
@@ -298,7 +301,8 @@ func resourceLinodeObjectStorageBucketUpdate(ctx context.Context, d *schema.Reso
 	return resourceLinodeObjectStorageBucketRead(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageBucketDelete(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	cluster, label, err := decodeLinodeObjectStorageBucketID(d.Id())
 	if err != nil {
@@ -387,7 +391,8 @@ func updateLinodeObjectStorageBucketLifecycle(d *schema.ResourceData, conn *s3.S
 	return err
 }
 
-func updateLinodeObjectStorageBucketAccess(ctx context.Context, d *schema.ResourceData, client linodego.Client) error {
+func updateLinodeObjectStorageBucketAccess(
+	ctx context.Context, d *schema.ResourceData, client linodego.Client) error {
 	cluster := d.Get("cluster").(string)
 	label := d.Get("label").(string)
 
@@ -408,7 +413,8 @@ func updateLinodeObjectStorageBucketAccess(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func updateLinodeObjectStorageBucketCert(ctx context.Context, d *schema.ResourceData, client linodego.Client) error {
+func updateLinodeObjectStorageBucketCert(
+	ctx context.Context, d *schema.ResourceData, client linodego.Client) error {
 	cluster := d.Get("cluster").(string)
 	label := d.Get("label").(string)
 	oldCert, newCert := d.GetChange("cert")

--- a/linode/resource_linode_object_storage_bucket.go
+++ b/linode/resource_linode_object_storage_bucket.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
@@ -92,12 +93,12 @@ func resourceLinodeObjectStorageBucketLifecycleRule() *schema.Resource {
 
 func resourceLinodeObjectStorageBucket() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeObjectStorageBucketCreate,
-		Read:   resourceLinodeObjectStorageBucketRead,
-		Update: resourceLinodeObjectStorageBucketUpdate,
-		Delete: resourceLinodeObjectStorageBucketDelete,
+		CreateContext: resourceLinodeObjectStorageBucketCreate,
+		ReadContext:   resourceLinodeObjectStorageBucketRead,
+		UpdateContext: resourceLinodeObjectStorageBucketUpdate,
+		DeleteContext: resourceLinodeObjectStorageBucketDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"secret_key": {
@@ -172,27 +173,27 @@ func resourceLinodeObjectStorageBucket() *schema.Resource {
 	}
 }
 
-func resourceLinodeObjectStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeObjectStorageBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	cluster, label, err := decodeLinodeObjectStorageBucketID(d.Id())
 	if err != nil {
-		return fmt.Errorf("failed to parse Linode ObjectStorageBucket id %s", d.Id())
+		return diag.Errorf("failed to parse Linode ObjectStorageBucket id %s", d.Id())
 	}
 
-	bucket, err := client.GetObjectStorageBucket(context.Background(), cluster, label)
+	bucket, err := client.GetObjectStorageBucket(ctx, cluster, label)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			log.Printf("[WARN] removing Object Storage Bucket %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("failed to find the specified Linode ObjectStorageBucket: %s", err)
+		return diag.Errorf("failed to find the specified Linode ObjectStorageBucket: %s", err)
 	}
 
-	access, err := client.GetObjectStorageBucketAccess(context.Background(), cluster, label)
+	access, err := client.GetObjectStorageBucketAccess(ctx, cluster, label)
 	if err != nil {
-		return fmt.Errorf("failed to find the access config for the specified Linode ObjectStorageBucket: %s", err)
+		return diag.Errorf("failed to find the access config for the specified Linode ObjectStorageBucket: %s", err)
 	}
 
 	// Functionality requiring direct S3 API access
@@ -204,17 +205,17 @@ func resourceLinodeObjectStorageBucketRead(d *schema.ResourceData, meta interfac
 
 	if versioningPresent || lifecyclePresent {
 		if accessKey == "" || secretKey == "" {
-			return fmt.Errorf("access_key and secret_key are required to get versioning and lifecycle info")
+			return diag.Errorf("access_key and secret_key are required to get versioning and lifecycle info")
 		}
 
 		conn := s3ConnFromResourceData(d)
 
 		if err := readLinodeObjectStorageBucketLifecycle(d, conn); err != nil {
-			return fmt.Errorf("failed to find get object storage bucket lifecycle: %s", err)
+			return diag.Errorf("failed to find get object storage bucket lifecycle: %s", err)
 		}
 
 		if err := readLinodeObjectStorageBucketVersioning(d, conn); err != nil {
-			return fmt.Errorf("failed to find get object storage bucket versioning: %s", err)
+			return diag.Errorf("failed to find get object storage bucket versioning: %s", err)
 		}
 	}
 
@@ -227,7 +228,7 @@ func resourceLinodeObjectStorageBucketRead(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func resourceLinodeObjectStorageBucketCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeObjectStorageBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	cluster := d.Get("cluster").(string)
@@ -242,17 +243,17 @@ func resourceLinodeObjectStorageBucketCreate(d *schema.ResourceData, meta interf
 		CorsEnabled: &corsEnabled,
 	}
 
-	bucket, err := client.CreateObjectStorageBucket(context.Background(), createOpts)
+	bucket, err := client.CreateObjectStorageBucket(ctx, createOpts)
 	if err != nil {
-		return fmt.Errorf("failed to create a Linode ObjectStorageBucket: %s", err)
+		return diag.Errorf("failed to create a Linode ObjectStorageBucket: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", bucket.Cluster, bucket.Label))
 
-	return resourceLinodeObjectStorageBucketUpdate(d, meta)
+	return resourceLinodeObjectStorageBucketUpdate(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeObjectStorageBucketUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	accessKey := d.Get("access_key")
@@ -261,14 +262,14 @@ func resourceLinodeObjectStorageBucketUpdate(d *schema.ResourceData, meta interf
 	conn := s3ConnFromResourceData(d)
 
 	if d.HasChanges("acl", "cors_enabled") {
-		if err := updateLinodeObjectStorageBucketAccess(d, client); err != nil {
-			return err
+		if err := updateLinodeObjectStorageBucketAccess(ctx, d, client); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
 	if d.HasChange("cert") {
-		if err := updateLinodeObjectStorageBucketCert(d, client); err != nil {
-			return err
+		if err := updateLinodeObjectStorageBucketCert(ctx, d, client); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -277,35 +278,35 @@ func resourceLinodeObjectStorageBucketUpdate(d *schema.ResourceData, meta interf
 
 	if versioningChanged || lifecycleChanged {
 		if accessKey == "" || secretKey == "" {
-			return fmt.Errorf("access_key and secret_key are required to set versioning and lifecycle info")
+			return diag.Errorf("access_key and secret_key are required to set versioning and lifecycle info")
 		}
 
 		// Ensure we only update what is changed
 		if versioningChanged {
 			if err := updateLinodeObjectStorageBucketVersioning(d, conn); err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 		}
 
 		if lifecycleChanged {
 			if err := updateLinodeObjectStorageBucketLifecycle(d, conn); err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 		}
 	}
 
-	return resourceLinodeObjectStorageBucketRead(d, meta)
+	return resourceLinodeObjectStorageBucketRead(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageBucketDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeObjectStorageBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	cluster, label, err := decodeLinodeObjectStorageBucketID(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode ObjectStorageBucket id %s", d.Id())
+		return diag.Errorf("Error parsing Linode ObjectStorageBucket id %s", d.Id())
 	}
-	err = client.DeleteObjectStorageBucket(context.Background(), cluster, label)
+	err = client.DeleteObjectStorageBucket(ctx, cluster, label)
 	if err != nil {
-		return fmt.Errorf("Error deleting Linode ObjectStorageBucket %s: %s", d.Id(), err)
+		return diag.Errorf("Error deleting Linode ObjectStorageBucket %s: %s", d.Id(), err)
 	}
 	return nil
 }
@@ -386,7 +387,7 @@ func updateLinodeObjectStorageBucketLifecycle(d *schema.ResourceData, conn *s3.S
 	return err
 }
 
-func updateLinodeObjectStorageBucketAccess(d *schema.ResourceData, client linodego.Client) error {
+func updateLinodeObjectStorageBucketAccess(ctx context.Context, d *schema.ResourceData, client linodego.Client) error {
 	cluster := d.Get("cluster").(string)
 	label := d.Get("label").(string)
 
@@ -400,21 +401,21 @@ func updateLinodeObjectStorageBucketAccess(d *schema.ResourceData, client linode
 		updateOpts.CorsEnabled = &newCorsBool
 	}
 
-	if err := client.UpdateObjectStorageBucketAccess(context.Background(), cluster, label, updateOpts); err != nil {
+	if err := client.UpdateObjectStorageBucketAccess(ctx, cluster, label, updateOpts); err != nil {
 		return fmt.Errorf("failed to update bucket access: %s", err)
 	}
 
 	return nil
 }
 
-func updateLinodeObjectStorageBucketCert(d *schema.ResourceData, client linodego.Client) error {
+func updateLinodeObjectStorageBucketCert(ctx context.Context, d *schema.ResourceData, client linodego.Client) error {
 	cluster := d.Get("cluster").(string)
 	label := d.Get("label").(string)
 	oldCert, newCert := d.GetChange("cert")
 	hasOldCert := len(oldCert.([]interface{})) != 0
 
 	if hasOldCert {
-		if err := client.DeleteObjectStorageBucketCert(context.Background(), cluster, label); err != nil {
+		if err := client.DeleteObjectStorageBucketCert(ctx, cluster, label); err != nil {
 			return fmt.Errorf("failed to delete old bucket cert: %s", err)
 		}
 	}
@@ -425,7 +426,7 @@ func updateLinodeObjectStorageBucketCert(d *schema.ResourceData, client linodego
 	}
 
 	uploadOptions := expandLinodeObjectStorageBucketCert(certSpec[0])
-	if _, err := client.UploadObjectStorageBucketCert(context.Background(), cluster, label, uploadOptions); err != nil {
+	if _, err := client.UploadObjectStorageBucketCert(ctx, cluster, label, uploadOptions); err != nil {
 		return fmt.Errorf("failed to upload new bucket cert: %s", err)
 	}
 	return nil

--- a/linode/resource_linode_object_storage_key.go
+++ b/linode/resource_linode_object_storage_key.go
@@ -69,7 +69,8 @@ func resourceLinodeObjectStorageKey() *schema.Resource {
 	}
 }
 
-func resourceLinodeObjectStorageKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageKeyCreate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	createOpts := linodego.ObjectStorageKeyCreateOptions{
@@ -101,7 +102,8 @@ func resourceLinodeObjectStorageKeyCreate(ctx context.Context, d *schema.Resourc
 	return resourceLinodeObjectStorageKeyRead(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageKeyRead(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -129,7 +131,8 @@ func resourceLinodeObjectStorageKeyRead(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceLinodeObjectStorageKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageKeyUpdate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
@@ -157,7 +160,8 @@ func resourceLinodeObjectStorageKeyUpdate(ctx context.Context, d *schema.Resourc
 	return resourceLinodeObjectStorageKeyRead(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageKeyDelete(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {

--- a/linode/resource_linode_object_storage_object.go
+++ b/linode/resource_linode_object_storage_object.go
@@ -132,11 +132,13 @@ func resourceLinodeObjectStorageObject() *schema.Resource {
 	}
 }
 
-func resourceLinodeObjectStorageObjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageObjectCreate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return putLinodeObjectStorageObject(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageObjectRead(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := s3ConnFromResourceData(d)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
@@ -169,7 +171,8 @@ func resourceLinodeObjectStorageObjectRead(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func resourceLinodeObjectStorageObjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageObjectUpdate(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	if d.HasChanges("cache_control", "content_base64", "content_disposition",
 		"content_encoding", "content_language", "content_type", "content",
 		"etag", "metadata", "source", "website_redirect") {
@@ -194,7 +197,8 @@ func resourceLinodeObjectStorageObjectUpdate(ctx context.Context, d *schema.Reso
 	return resourceLinodeObjectStorageObjectRead(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageObjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLinodeObjectStorageObjectDelete(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := s3ConnFromResourceData(d)
 
 	if _, ok := d.GetOk("version_id"); ok {
@@ -218,7 +222,8 @@ func resourceLinodeObjectStorageObjectCustomizeDiff(
 // putLinodeObjectStorageObject builds the object from spec and puts it in the
 // specified bucket via the *schema.ResourceData, then it calls
 // resourceLinodeObjectStorageObjectRead.
-func putLinodeObjectStorageObject(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func putLinodeObjectStorageObject(
+	ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := s3ConnFromResourceData(d)
 	body, err := objectBodyFromResourceData(d)
 	if err != nil {
@@ -265,7 +270,8 @@ func putLinodeObjectStorageObject(ctx context.Context, d *schema.ResourceData, m
 
 // deleteAllLinodeObjectStorageObjectVersions deletes all versions of a given
 // object.
-func deleteAllLinodeObjectStorageObjectVersions(ctx context.Context, d *schema.ResourceData) diag.Diagnostics {
+func deleteAllLinodeObjectStorageObjectVersions(
+	ctx context.Context, d *schema.ResourceData) diag.Diagnostics {
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 	force := d.Get("force_destroy").(bool)

--- a/linode/resource_linode_object_storage_object.go
+++ b/linode/resource_linode_object_storage_object.go
@@ -13,15 +13,16 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceLinodeObjectStorageObject() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeObjectStorageObjectCreate,
-		Read:   resourceLinodeObjectStorageObjectRead,
-		Update: resourceLinodeObjectStorageObjectUpdate,
-		Delete: resourceLinodeObjectStorageObjectDelete,
+		CreateContext: resourceLinodeObjectStorageObjectCreate,
+		ReadContext:   resourceLinodeObjectStorageObjectRead,
+		UpdateContext: resourceLinodeObjectStorageObjectUpdate,
+		DeleteContext: resourceLinodeObjectStorageObjectDelete,
 
 		CustomizeDiff: resourceLinodeObjectStorageObjectCustomizeDiff,
 
@@ -131,11 +132,11 @@ func resourceLinodeObjectStorageObject() *schema.Resource {
 	}
 }
 
-func resourceLinodeObjectStorageObjectCreate(d *schema.ResourceData, meta interface{}) error {
-	return putLinodeObjectStorageObject(d, meta)
+func resourceLinodeObjectStorageObjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return putLinodeObjectStorageObject(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageObjectRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeObjectStorageObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := s3ConnFromResourceData(d)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
@@ -151,7 +152,7 @@ func resourceLinodeObjectStorageObjectRead(d *schema.ResourceData, meta interfac
 			fmt.Printf(`[WARN] could not find Bucket (%s) Object (%s)`, bucket, key)
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("cache_control", headOutput.CacheControl)
@@ -168,11 +169,11 @@ func resourceLinodeObjectStorageObjectRead(d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func resourceLinodeObjectStorageObjectUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeObjectStorageObjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	if d.HasChanges("cache_control", "content_base64", "content_disposition",
 		"content_encoding", "content_language", "content_type", "content",
 		"etag", "metadata", "source", "website_redirect") {
-		return putLinodeObjectStorageObject(d, meta)
+		return putLinodeObjectStorageObject(ctx, d, meta)
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -186,24 +187,24 @@ func resourceLinodeObjectStorageObjectUpdate(d *schema.ResourceData, meta interf
 			Key:    &key,
 			ACL:    &acl,
 		}); err != nil {
-			return fmt.Errorf("failed to put Bucket (%s) Object (%s) ACL: %s", bucket, key, err)
+			return diag.Errorf("failed to put Bucket (%s) Object (%s) ACL: %s", bucket, key, err)
 		}
 	}
 
-	return resourceLinodeObjectStorageBucketRead(d, meta)
+	return resourceLinodeObjectStorageObjectRead(ctx, d, meta)
 }
 
-func resourceLinodeObjectStorageObjectDelete(d *schema.ResourceData, meta interface{}) (err error) {
+func resourceLinodeObjectStorageObjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := s3ConnFromResourceData(d)
 
 	if _, ok := d.GetOk("version_id"); ok {
-		return deleteAllLinodeObjectStorageObjectVersions(d)
+		return deleteAllLinodeObjectStorageObjectVersions(ctx, d)
 	}
 
 	bucket := d.Get("bucket").(string)
 	key := strings.TrimPrefix(d.Get("key").(string), "/")
 	force := d.Get("force_destroy").(bool)
-	return deleteLinodeObjectStorageObject(conn, bucket, key, "", force)
+	return diag.FromErr(deleteLinodeObjectStorageObject(conn, bucket, key, "", force))
 }
 
 func resourceLinodeObjectStorageObjectCustomizeDiff(
@@ -217,11 +218,11 @@ func resourceLinodeObjectStorageObjectCustomizeDiff(
 // putLinodeObjectStorageObject builds the object from spec and puts it in the
 // specified bucket via the *schema.ResourceData, then it calls
 // resourceLinodeObjectStorageObjectRead.
-func putLinodeObjectStorageObject(d *schema.ResourceData, meta interface{}) error {
+func putLinodeObjectStorageObject(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := s3ConnFromResourceData(d)
 	body, err := objectBodyFromResourceData(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	defer body.Close()
 
@@ -254,17 +255,17 @@ func putLinodeObjectStorageObject(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if _, err := client.PutObject(putInput); err != nil {
-		return fmt.Errorf("failed to put Bucket (%s) Object (%s): %s", bucket, key, err)
+		return diag.Errorf("failed to put Bucket (%s) Object (%s): %s", bucket, key, err)
 	}
 
 	d.SetId(buildObjectStorageObjectID(d))
 
-	return resourceLinodeObjectStorageObjectRead(d, meta)
+	return resourceLinodeObjectStorageObjectRead(ctx, d, meta)
 }
 
 // deleteAllLinodeObjectStorageObjectVersions deletes all versions of a given
 // object.
-func deleteAllLinodeObjectStorageObjectVersions(d *schema.ResourceData) error {
+func deleteAllLinodeObjectStorageObjectVersions(ctx context.Context, d *schema.ResourceData) diag.Diagnostics {
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 	force := d.Get("force_destroy").(bool)
@@ -296,14 +297,14 @@ func deleteAllLinodeObjectStorageObjectVersions(d *schema.ResourceData) error {
 			return !lastPage
 		}); err != nil {
 		if err, ok := err.(awserr.Error); !(ok && err.Code() != s3.ErrCodeNoSuchBucket) {
-			return fmt.Errorf("failed to list Bucket (%s) Object (%s) versions: %s", bucket, key, err)
+			return diag.Errorf("failed to list Bucket (%s) Object (%s) versions: %s", bucket, key, err)
 		}
 	}
 
 	// delete all version of the current object
 	for _, version := range versions {
 		if err := deleteLinodeObjectStorageObject(conn, bucket, key, version, force); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	return nil

--- a/linode/resource_linode_sshkey.go
+++ b/linode/resource_linode_sshkey.go
@@ -7,18 +7,19 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
 
 func resourceLinodeSSHKey() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeSSHKeyCreate,
-		Read:   resourceLinodeSSHKeyRead,
-		Update: resourceLinodeSSHKeyUpdate,
-		Delete: resourceLinodeSSHKeyDelete,
+		CreateContext: resourceLinodeSSHKeyCreate,
+		ReadContext:   resourceLinodeSSHKeyRead,
+		UpdateContext: resourceLinodeSSHKeyUpdate,
+		DeleteContext: resourceLinodeSSHKeyDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"label": {
@@ -41,21 +42,21 @@ func resourceLinodeSSHKey() *schema.Resource {
 	}
 }
 
-func resourceLinodeSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode SSH Key ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode SSH Key ID %s as int: %s", d.Id(), err)
 	}
 
-	sshkey, err := client.GetSSHKey(context.Background(), int(id))
+	sshkey, err := client.GetSSHKey(ctx, int(id))
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			log.Printf("[WARN] removing Linode SSH Key ID %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error finding the specified Linode SSH Key: %s", err)
+		return diag.Errorf("Error finding the specified Linode SSH Key: %s", err)
 	}
 
 	d.Set("label", sshkey.Label)
@@ -67,16 +68,16 @@ func resourceLinodeSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceLinodeSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	createOpts := linodego.SSHKeyCreateOptions{
 		Label:  d.Get("label").(string),
 		SSHKey: d.Get("ssh_key").(string),
 	}
-	sshkey, err := client.CreateSSHKey(context.Background(), createOpts)
+	sshkey, err := client.CreateSSHKey(ctx, createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating a Linode SSH Key: %s", err)
+		return diag.Errorf("Error creating a Linode SSH Key: %s", err)
 	}
 	d.SetId(fmt.Sprintf("%d", sshkey.ID))
 	d.Set("label", sshkey.Label)
@@ -85,45 +86,45 @@ func resourceLinodeSSHKeyCreate(d *schema.ResourceData, meta interface{}) error 
 		d.Set("created", sshkey.Created.Format(time.RFC3339))
 	}
 
-	return resourceLinodeSSHKeyRead(d, meta)
+	return resourceLinodeSSHKeyRead(ctx, d, meta)
 }
 
-func resourceLinodeSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode SSH Key id %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode SSH Key id %s as int: %s", d.Id(), err)
 	}
 
 	if d.HasChange("label") {
-		sshkey, err := client.GetSSHKey(context.Background(), int(id))
+		sshkey, err := client.GetSSHKey(ctx, int(id))
 
 		updateOpts := sshkey.GetUpdateOptions()
 		updateOpts.Label = d.Get("label").(string)
 
 		if err != nil {
-			return fmt.Errorf("Error fetching data about the current Linode SSH Key: %s", err)
+			return diag.Errorf("Error fetching data about the current Linode SSH Key: %s", err)
 		}
 
-		if sshkey, err = client.UpdateSSHKey(context.Background(), int(id), updateOpts); err != nil {
-			return err
+		if sshkey, err = client.UpdateSSHKey(ctx, int(id), updateOpts); err != nil {
+			return diag.FromErr(err)
 		}
 		d.Set("label", sshkey.Label)
 	}
 
-	return resourceLinodeSSHKeyRead(d, meta)
+	return resourceLinodeSSHKeyRead(ctx, d, meta)
 }
 
-func resourceLinodeSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode SSH Key id %s as int", d.Id())
+		return diag.Errorf("Error parsing Linode SSH Key id %s as int", d.Id())
 	}
-	err = client.DeleteSSHKey(context.Background(), int(id))
+	err = client.DeleteSSHKey(ctx, int(id))
 	if err != nil {
-		return fmt.Errorf("Error deleting Linode SSH Key %d: %s", id, err)
+		return diag.Errorf("Error deleting Linode SSH Key %d: %s", id, err)
 	}
 	return nil
 }

--- a/linode/resource_linode_stackscript.go
+++ b/linode/resource_linode_stackscript.go
@@ -6,18 +6,19 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
 
 func resourceLinodeStackscript() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeStackscriptCreate,
-		Read:   resourceLinodeStackscriptRead,
-		Update: resourceLinodeStackscriptUpdate,
-		Delete: resourceLinodeStackscriptDelete,
+		CreateContext: resourceLinodeStackscriptCreate,
+		ReadContext:   resourceLinodeStackscriptRead,
+		UpdateContext: resourceLinodeStackscriptUpdate,
+		DeleteContext: resourceLinodeStackscriptDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"label": {
@@ -133,21 +134,21 @@ func resourceLinodeStackscript() *schema.Resource {
 	}
 }
 
-func resourceLinodeStackscriptRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeStackscriptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Stackscript ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Stackscript ID %s as int: %s", d.Id(), err)
 	}
 
-	stackscript, err := client.GetStackscript(context.Background(), int(id))
+	stackscript, err := client.GetStackscript(ctx, int(id))
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 401 {
 			log.Printf("[WARN] removing StackScript ID %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error finding the specified Linode Stackscript: %s", err)
+		return diag.Errorf("Error finding the specified Linode Stackscript: %s", err)
 	}
 
 	d.Set("label", stackscript.Label)
@@ -168,7 +169,7 @@ func resourceLinodeStackscriptRead(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceLinodeStackscriptCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeStackscriptCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	createOpts := linodego.StackscriptCreateOptions{
@@ -183,21 +184,21 @@ func resourceLinodeStackscriptCreate(d *schema.ResourceData, meta interface{}) e
 		createOpts.Images = append(createOpts.Images, image.(string))
 	}
 
-	stackscript, err := client.CreateStackscript(context.Background(), createOpts)
+	stackscript, err := client.CreateStackscript(ctx, createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating a Linode Stackscript: %s", err)
+		return diag.Errorf("Error creating a Linode Stackscript: %s", err)
 	}
 	d.SetId(fmt.Sprintf("%d", stackscript.ID))
 
-	return resourceLinodeStackscriptRead(d, meta)
+	return resourceLinodeStackscriptRead(ctx, d, meta)
 }
 
-func resourceLinodeStackscriptUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeStackscriptUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Stackscript id %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Stackscript id %s as int: %s", d.Id(), err)
 	}
 
 	updateOpts := linodego.StackscriptUpdateOptions{
@@ -212,25 +213,25 @@ func resourceLinodeStackscriptUpdate(d *schema.ResourceData, meta interface{}) e
 		updateOpts.Images = append(updateOpts.Images, image.(string))
 	}
 
-	if _, err = client.UpdateStackscript(context.Background(), int(id), updateOpts); err != nil {
-		return fmt.Errorf("Error updating Linode Stackscript %d: %s", int(id), err)
+	if _, err = client.UpdateStackscript(ctx, int(id), updateOpts); err != nil {
+		return diag.Errorf("Error updating Linode Stackscript %d: %s", int(id), err)
 	}
 
-	return resourceLinodeStackscriptRead(d, meta)
+	return resourceLinodeStackscriptRead(ctx, d, meta)
 }
 
-func resourceLinodeStackscriptDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeStackscriptDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Stackscript id %s as int", d.Id())
+		return diag.Errorf("Error parsing Linode Stackscript id %s as int", d.Id())
 	}
-	err = client.DeleteStackscript(context.Background(), int(id))
+	err = client.DeleteStackscript(ctx, int(id))
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			return nil
 		}
-		return fmt.Errorf("Error deleting Linode Stackscript %d: %s", id, err)
+		return diag.Errorf("Error deleting Linode Stackscript %d: %s", id, err)
 	}
 	return nil
 }

--- a/linode/resource_linode_template.go
+++ b/linode/resource_linode_template.go
@@ -15,18 +15,19 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
 
 func resourceLinodeTemplate() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeTemplateCreate,
-		Read:   resourceLinodeTemplateRead,
-		Update: resourceLinodeTemplateUpdate,
-		Delete: resourceLinodeTemplateDelete,
+		CreateContext: resourceLinodeTemplateCreate,
+		ReadContext:   resourceLinodeTemplateRead,
+		UpdateContext: resourceLinodeTemplateUpdate,
+		DeleteContext: resourceLinodeTemplateDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"label": {
@@ -43,17 +44,17 @@ func resourceLinodeTemplate() *schema.Resource {
 	}
 }
 
-func resourceLinodeTemplateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Template ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Template ID %s as int: %s", d.Id(), err)
 	}
 
-	template, err := client.GetTemplate(context.Background(), int(id))
+	template, err := client.GetTemplate(ctx, int(id))
 
 	if err != nil {
-		return fmt.Errorf("Error finding the specified Linode Template: %s", err)
+		return diag.Errorf("Error finding the specified Linode Template: %s", err)
 	}
 
 	d.Set("label", template.Label)
@@ -62,57 +63,57 @@ func resourceLinodeTemplateRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceLinodeTemplateCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, ok := meta.(*ProviderMeta).Client
 	if !ok {
-		return fmt.Errorf("Invalid Client when creating Linode Template")
+		return diag.Errorf("Invalid Client when creating Linode Template")
 	}
 
 	createOpts := linodego.TemplateCreateOptions{
 		Label: d.Get("label").(string),
 	}
-	template, err := client.CreateTemplate(context.Background(), createOpts)
+	template, err := client.CreateTemplate(ctx, createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating a Linode Template: %s", err)
+		return diag.Errorf("Error creating a Linode Template: %s", err)
 	}
 	d.SetId(fmt.Sprintf("%d", template.ID))
 	d.Set("label", template.Label)
 
-	return resourceLinodeTemplateRead(d, meta)
+	return resourceLinodeTemplateRead(ctx, d, meta)
 }
 
-func resourceLinodeTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Template id %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Template id %s as int: %s", d.Id(), err)
 	}
 
 	template, err := client.GetTemplate(int(id))
 	if err != nil {
-		return fmt.Errorf("Error fetching data about the current Linode Template: %s", err)
+		return diag.Errorf("Error fetching data about the current Linode Template: %s", err)
 	}
 
 	if d.HasChange("label") {
-		if template, err = client.RenameTemplate(context.Background(), template.ID, d.Get("label").(string)); err != nil {
-			return err
+		if template, err = client.RenameTemplate(ctx, template.ID, d.Get("label").(string)); err != nil {
+			return diag.FromErr(err)
 		}
 		d.Set("label", template.Label)
 	}
 
-	return resourceLinodeTemplateRead(d, meta)
+	return resourceLinodeTemplateRead(ctx, d, meta)
 }
 
-func resourceLinodeTemplateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTemplateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Template id %s as int", d.Id())
+		return diag.Errorf("Error parsing Linode Template id %s as int", d.Id())
 	}
-	err = client.DeleteTemplate(context.Background(), int(id))
+	err = client.DeleteTemplate(ctx, int(id))
 	if err != nil {
-		return fmt.Errorf("Error deleting Linode Template %d: %s", id, err)
+		return diag.Errorf("Error deleting Linode Template %d: %s", id, err)
 	}
 	return nil
 }

--- a/linode/resource_linode_token.go
+++ b/linode/resource_linode_token.go
@@ -7,18 +7,19 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
 
 func resourceLinodeToken() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeTokenCreate,
-		Read:   resourceLinodeTokenRead,
-		Update: resourceLinodeTokenUpdate,
-		Delete: resourceLinodeTokenDelete,
+		CreateContext: resourceLinodeTokenCreate,
+		ReadContext:   resourceLinodeTokenRead,
+		UpdateContext: resourceLinodeTokenUpdate,
+		DeleteContext: resourceLinodeTokenDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"label": {
@@ -84,21 +85,21 @@ func validDateTime(i interface{}, k string) (s []string, es []error) {
 	return
 }
 
-func resourceLinodeTokenRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Token ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Token ID %s as int: %s", d.Id(), err)
 	}
 
-	token, err := client.GetToken(context.Background(), int(id))
+	token, err := client.GetToken(ctx, int(id))
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			log.Printf("[WARN] removing Linode Token ID %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error finding the specified Linode Token: %s", err)
+		return diag.Errorf("Error finding the specified Linode Token: %s", err)
 	}
 
 	d.Set("label", token.Label)
@@ -109,7 +110,7 @@ func resourceLinodeTokenRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceLinodeTokenCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTokenCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	createOpts := linodego.TokenCreateOptions{
@@ -119,59 +120,59 @@ func resourceLinodeTokenCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if expiryRaw, ok := d.GetOk("expiry"); ok {
 		if expiry, ok := expiryRaw.(string); !ok {
-			return fmt.Errorf("expected expiry to be a string, got %s", expiryRaw)
+			return diag.Errorf("expected expiry to be a string, got %s", expiryRaw)
 		} else if dt, err := time.Parse("2006-01-02T15:04:05Z", expiry); err != nil {
-			return fmt.Errorf("expected expiry to be a datetime, got %s", expiry)
+			return diag.Errorf("expected expiry to be a datetime, got %s", expiry)
 		} else {
 			createOpts.Expiry = &dt
 		}
 	}
 
-	token, err := client.CreateToken(context.Background(), createOpts)
+	token, err := client.CreateToken(ctx, createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating a Linode Token: %s", err)
+		return diag.Errorf("Error creating a Linode Token: %s", err)
 	}
 	d.SetId(fmt.Sprintf("%d", token.ID))
 	d.Set("token", token.Token)
 
-	return resourceLinodeTokenRead(d, meta)
+	return resourceLinodeTokenRead(ctx, d, meta)
 }
 
-func resourceLinodeTokenUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTokenUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Token id %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Token id %s as int: %s", d.Id(), err)
 	}
 
-	token, err := client.GetToken(context.Background(), int(id))
+	token, err := client.GetToken(ctx, int(id))
 	if err != nil {
-		return fmt.Errorf("Error fetching data about the current linode: %s", err)
+		return diag.Errorf("Error fetching data about the current linode: %s", err)
 	}
 
 	updateOpts := token.GetUpdateOptions()
 	if d.HasChange("label") {
 		updateOpts.Label = d.Get("label").(string)
 
-		if token, err = client.UpdateToken(context.Background(), token.ID, updateOpts); err != nil {
-			return err
+		if token, err = client.UpdateToken(ctx, token.ID, updateOpts); err != nil {
+			return diag.FromErr(err)
 		}
 		d.Set("label", token.Label)
 	}
 
-	return resourceLinodeTokenRead(d, meta)
+	return resourceLinodeTokenRead(ctx, d, meta)
 }
 
-func resourceLinodeTokenDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Token id %s as int", d.Id())
+		return diag.Errorf("Error parsing Linode Token id %s as int", d.Id())
 	}
-	err = client.DeleteToken(context.Background(), int(id))
+	err = client.DeleteToken(ctx, int(id))
 	if err != nil {
-		return fmt.Errorf("Error deleting Linode Token %d: %s", id, err)
+		return diag.Errorf("Error deleting Linode Token %d: %s", id, err)
 	}
 	// a settling cooldown to avoid expired tokens from being returned in listings
 	time.Sleep(3 * time.Second)

--- a/linode/resource_linode_volume.go
+++ b/linode/resource_linode_volume.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 )
@@ -19,12 +20,12 @@ const (
 
 func resourceLinodeVolume() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLinodeVolumeCreate,
-		Read:   resourceLinodeVolumeRead,
-		Update: resourceLinodeVolumeUpdate,
-		Delete: resourceLinodeVolumeDelete,
+		CreateContext: resourceLinodeVolumeCreate,
+		ReadContext:   resourceLinodeVolumeRead,
+		UpdateContext: resourceLinodeVolumeUpdate,
+		DeleteContext: resourceLinodeVolumeDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(LinodeVolumeCreateTimeout),
@@ -77,21 +78,21 @@ func resourceLinodeVolume() *schema.Resource {
 	}
 }
 
-func resourceLinodeVolumeRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Volume ID %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Volume ID %s as int: %s", d.Id(), err)
 	}
 
-	volume, err := client.GetVolume(context.Background(), int(id))
+	volume, err := client.GetVolume(ctx, int(id))
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			log.Printf("[WARN] removing Volume ID %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error finding the specified Linode Volume: %s", err)
+		return diag.Errorf("Error finding the specified Linode Volume: %s", err)
 	}
 
 	d.Set("label", volume.Label)
@@ -105,7 +106,7 @@ func resourceLinodeVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceLinodeVolumeCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	var linodeID *int
@@ -128,53 +129,53 @@ func resourceLinodeVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	volume, err := client.CreateVolume(context.Background(), createOpts)
+	volume, err := client.CreateVolume(ctx, createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating a Linode Volume: %s", err)
+		return diag.Errorf("Error creating a Linode Volume: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%d", volume.ID))
 
 	if createOpts.LinodeID > 0 {
 		if _, err := client.WaitForVolumeLinodeID(
-			context.Background(), volume.ID, linodeID, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
+			ctx, volume.ID, linodeID, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
 		); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
 	if _, err = client.WaitForVolumeStatus(
-		context.Background(), volume.ID, linodego.VolumeActive, int(d.Timeout(schema.TimeoutCreate).Seconds()),
+		ctx, volume.ID, linodego.VolumeActive, int(d.Timeout(schema.TimeoutCreate).Seconds()),
 	); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return resourceLinodeVolumeRead(d, meta)
+	return resourceLinodeVolumeRead(ctx, d, meta)
 }
 
-func resourceLinodeVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Volume id %s as int: %s", d.Id(), err)
+		return diag.Errorf("Error parsing Linode Volume id %s as int: %s", d.Id(), err)
 	}
 
-	volume, errVolume := client.GetVolume(context.Background(), int(id))
+	volume, errVolume := client.GetVolume(ctx, int(id))
 	if errVolume != nil {
-		return fmt.Errorf("Error fetching data about the volume %d: %s", int(id), errVolume)
+		return diag.Errorf("Error fetching data about the volume %d: %s", int(id), errVolume)
 	}
 
 	if d.HasChange("size") {
 		size := d.Get("size").(int)
-		if err = client.ResizeVolume(context.Background(), volume.ID, size); err != nil {
-			return err
+		if err = client.ResizeVolume(ctx, volume.ID, size); err != nil {
+			return diag.FromErr(err)
 		}
 
 		if _, err = client.WaitForVolumeStatus(
-			context.Background(), volume.ID, linodego.VolumeActive, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
+			ctx, volume.ID, linodego.VolumeActive, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
 		); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		d.Set("size", size)
@@ -198,8 +199,8 @@ func resourceLinodeVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if doUpdate {
-		if volume, err = client.UpdateVolume(context.Background(), volume.ID, updateOpts); err != nil {
-			return err
+		if volume, err = client.UpdateVolume(ctx, volume.ID, updateOpts); err != nil {
+			return diag.FromErr(err)
 		}
 		d.Set("tags", volume.Tags)
 		d.Set("label", volume.Label)
@@ -218,15 +219,15 @@ func resourceLinodeVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 	if detectVolumeIDChange(linodeID, volume.LinodeID) {
 		if linodeID == nil || volume.LinodeID != nil {
 			log.Printf("[INFO] Detaching Linode Volume %d", volume.ID)
-			if err = client.DetachVolume(context.Background(), volume.ID); err != nil {
-				return err
+			if err = client.DetachVolume(ctx, volume.ID); err != nil {
+				return diag.FromErr(err)
 			}
 
 			log.Printf("[INFO] Waiting for Linode Volume %d to detach ...", volume.ID)
 			if _, err = client.WaitForVolumeLinodeID(
-				context.Background(), volume.ID, nil, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
+				ctx, volume.ID, nil, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
 			); err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 		}
 
@@ -238,47 +239,47 @@ func resourceLinodeVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 
 			log.Printf("[INFO] Attaching Linode Volume %d to Linode Instance %d", volume.ID, *linodeID)
 
-			if _, err = client.AttachVolume(context.Background(), volume.ID, &attachOptions); err != nil {
-				return fmt.Errorf("Error attaching Linode Volume %d to Linode Instance %d: %s", volume.ID, *linodeID, err)
+			if _, err = client.AttachVolume(ctx, volume.ID, &attachOptions); err != nil {
+				return diag.Errorf("Error attaching Linode Volume %d to Linode Instance %d: %s", volume.ID, *linodeID, err)
 			}
 
 			log.Printf("[INFO] Waiting for Linode Volume %d to attach ...", volume.ID)
 			if _, err = client.WaitForVolumeLinodeID(
-				context.Background(), volume.ID, linodeID, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
+				ctx, volume.ID, linodeID, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
 			); err != nil {
-				return err
+				return diag.FromErr(err)
 			}
 		}
 
 		d.Set("linode_id", linodeID)
 	}
 
-	return resourceLinodeVolumeRead(d, meta)
+	return resourceLinodeVolumeRead(ctx, d, meta)
 }
 
-func resourceLinodeVolumeDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceLinodeVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderMeta).Client
 	id64, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return fmt.Errorf("Error parsing Linode Volume id %s as int", d.Id())
+		return diag.Errorf("Error parsing Linode Volume id %s as int", d.Id())
 	}
 	id := int(id64)
 
 	log.Printf("[INFO] Detaching Linode Volume %d for deletion", id)
-	if err := client.DetachVolume(context.Background(), id); err != nil {
-		return fmt.Errorf("Error detaching Linode Volume %d: %s", id, err)
+	if err := client.DetachVolume(ctx, id); err != nil {
+		return diag.Errorf("Error detaching Linode Volume %d: %s", id, err)
 	}
 
 	log.Printf("[INFO] Waiting for Linode Volume %d to detach ...", id)
 	if _, err := client.WaitForVolumeLinodeID(
-		context.Background(), id, nil, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
+		ctx, id, nil, int(d.Timeout(schema.TimeoutUpdate).Seconds()),
 	); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	err = client.DeleteVolume(context.Background(), int(id))
+	err = client.DeleteVolume(ctx, int(id))
 	if err != nil {
-		return fmt.Errorf("Error deleting Linode Volume %d: %s", id, err)
+		return diag.Errorf("Error deleting Linode Volume %d: %s", id, err)
 	}
 	d.SetId("")
 	return nil


### PR DESCRIPTION
removing context.background() instances to make sure we use the same contexts throughout actions