### PR TITLE
reboot if Interface or boot config interface's ip changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/linode/terraform-provider-linode
 require (
 	github.com/aws/aws-sdk-go v1.34.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/linode/linodego v0.30.0
+	github.com/linode/linodego v0.31.0
 	github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/linode/linodego v0.20.1/go.mod h1:XOWXRHjqeU2uPS84tKLgfWIfTlv3TYzCS0io4GOQzEI=
-github.com/linode/linodego v0.30.0 h1:r9Sujfeo4FfEn/KdOjYegMP5sNCXL5rZUc4zNcDa+2E=
-github.com/linode/linodego v0.30.0/go.mod h1:BR0gVkCJffEdIGJSl6bHR80Ty+Uvg/2jkjmrWaFectM=
+github.com/linode/linodego v0.31.0 h1:99+t6GtTaIsL+ncz5BpCbkh8Y90rC7qW1Not8MFe0Gw=
+github.com/linode/linodego v0.31.0/go.mod h1:BR0gVkCJffEdIGJSl6bHR80Ty+Uvg/2jkjmrWaFectM=
 github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947 h1:e+tpC7AIiEgfYGEDq9Rjtdybq+V10S6OXzWjeGV/CEk=
 github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947/go.mod h1:MWI0tFyaJqRpirMv0VO7CGYT4V3IhHvml2rs/DlRQmY=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/linode/linode_instance_helpers.go
+++ b/linode/linode_instance_helpers.go
@@ -250,8 +250,8 @@ func updateInstanceConfigs(ctx context.Context, client linodego.Client, d *schem
 			oldLabel := oldConfig["label"].(string)
 			oldConfigLabels = append(oldConfigLabels, oldLabel)
 			if oldLabel == bootConfigLabel {
-				if iface, ok := oldConfig["interface"].(map[string]interface{}); ok {
-					oldBootInterfaces = append(oldBootInterfaces, iface["ipam_address"].(string))
+				for _, iface := range oldConfig["interface"].([]interface{}) {
+					oldBootInterfaces = append(oldBootInterfaces, iface.(map[string]interface{})["ipam_address"].(string))
 				}
 			}
 		}

--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -1199,6 +1199,15 @@ func resourceLinodeInstanceUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	bootConfig := 0
 	bootConfigLabel := d.Get("boot_config_label").(string)
+
+	tfConfigsOld, tfConfigsNew := d.GetChange("config")
+	didChangeConfig, updatedConfigMap, updatedConfigs, err := updateInstanceConfigs(
+		ctx, client, d, *instance, tfConfigsOld, tfConfigsNew, diskIDLabelMap, bootConfigLabel)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	rebootInstance = rebootInstance || didChangeConfig
+
 	if bootConfigLabel != "" {
 		if foundConfig, found := updatedConfigMap[bootConfigLabel]; found {
 			bootConfig = foundConfig
@@ -1208,14 +1217,6 @@ func resourceLinodeInstanceUpdate(ctx context.Context, d *schema.ResourceData, m
 	} else if len(updatedConfigs) > 0 {
 		bootConfig = updatedConfigs[0].ID
 	}
-
-	tfConfigsOld, tfConfigsNew := d.GetChange("config")
-	didChangeConfig, updatedConfigMap, updatedConfigs, err := updateInstanceConfigs(
-		ctx, client, d, *instance, tfConfigsOld, tfConfigsNew, diskIDLabelMap, bootConfigLabel)
-	if err != nil {
-            return diag.FromErr(err)
-	}
-	rebootInstance = rebootInstance || didChangeConfig
 
 	if d.HasChange("interface") {
 		interfaces := d.Get("interface").([]interface{})
@@ -1231,13 +1232,13 @@ func resourceLinodeInstanceUpdate(ctx context.Context, d *schema.ResourceData, m
 		}); err != nil {
 			return diag.Errorf("failed to set boot config interfaces: %s", err)
 		}
-                rebootInstance = true
+		rebootInstance = true
 	}
 
 	if rebootInstance && len(diskIDLabelMap) > 0 && len(updatedConfigMap) > 0 && bootConfig > 0 {
 		err = client.RebootInstance(ctx, instance.ID, bootConfig)
 
-                log.Printf("[INFO] Instance must be reboot for change in terraform")
+		log.Printf("[INFO] Instance [%d] will be rebooted\n", instance.ID)
 
 		if err != nil {
 			return diag.Errorf("Error rebooting Instance %d: %s", instance.ID, err)

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -295,24 +294,34 @@ func TestAccLinodeInstance_configInterfaces(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "region", "us-southeast"),
 					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
 
+					resource.TestCheckResourceAttr(resName, "config.#", "1"),
+					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "1"),
 					resource.TestCheckResourceAttr(resName, "config.0.interface.0.purpose", "vlan"),
 					resource.TestCheckResourceAttr(resName, "config.0.interface.0.label", "tf-really-cool-vlan"),
+					resource.TestCheckResourceAttr(resName, "config.0.label", "config"),
+					resource.TestCheckResourceAttr(resName, "boot_config_label", "config"),
 				),
 			},
 			{
 				Config: testAccCheckLinodeInstanceWithConfigInterfacesMultiple(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "config.#", "2"),
+					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "1"),
+					resource.TestCheckResourceAttr(resName, "config.0.interface.0.purpose", "vlan"),
+					resource.TestCheckResourceAttr(resName, "config.0.interface.0.label", "tf-really-cool-vlan"),
+					resource.TestCheckResourceAttr(resName, "config.0.label", "config"),
+					resource.TestCheckResourceAttr(resName, "config.1.interface.#", "2"),
+					resource.TestCheckResourceAttr(resName, "boot_config_label", "config"),
 				),
 			},
 			{
 				PreConfig: testAccAssertReboot(t, false, &instance),
 				Config:    testAccCheckLinodeInstanceWithConfigInterfacesUpdate(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resName, "config.0.interface.0.purpose", "public"),
-
-					resource.TestCheckResourceAttr(resName, "config.0.interface.1.purpose", "vlan"),
-					resource.TestCheckResourceAttr(resName, "config.0.interface.1.label", "tf-really-cool-vlan"),
+					resource.TestCheckResourceAttr(resName, "config.#", "2"),
+					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "2"),
+					resource.TestCheckResourceAttr(resName, "config.0.label", "config"),
+					resource.TestCheckResourceAttr(resName, "boot_config_label", "config"),
 				),
 			},
 			{
@@ -340,8 +349,6 @@ func testAccAssertReboot(t *testing.T, shouldRestart bool, instance *linodego.In
 		if err != nil {
 			t.Fail()
 		}
-
-		fmt.Fprintf(os.Stderr, "instance: %d, shouldRestart: %v, reboot events: %#v\n", instance.ID, shouldRestart, events)
 
 		if len(events) == 0 {
 			if shouldRestart {


### PR DESCRIPTION
If the user edits the boot config interface and the IP changes we need to reboot the linode to use the new IP