### PR TITLE
Add apply_immediately to linode_instance_ip

### DIFF
--- a/linode/resource_linode_instance_ip.go
+++ b/linode/resource_linode_instance_ip.go
@@ -66,6 +66,11 @@ func resourceLinodeInstanceIP() *schema.Resource {
 				Description: "The type of IP address.",
 				Computed:    true,
 			},
+			"apply_immediately": {
+				Type:        schema.TypeBool,
+				Description: "If true, the instance will be rebooted to update network interfaces.",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -95,6 +100,8 @@ func resourceLinodeInstanceIPCreate(ctx context.Context, d *schema.ResourceData,
 
 	linodeID := d.Get("linode_id").(int)
 	private := d.Get("public").(bool)
+	applyImmediately := d.Get("apply_immediately").(bool)
+
 	ip, err := client.AddInstanceIPAddress(ctx, linodeID, private)
 	if err != nil {
 		return diag.Errorf("failed to create instance (%d) ip: %s", linodeID, err)
@@ -111,12 +118,16 @@ func resourceLinodeInstanceIPCreate(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId(ip.Address)
 
-	// TODO(jxriddle): check instance status and react to state
+	// Only reboot the associated instance with apply_immediately == true
+	if applyImmediately {
+		// TODO(jxriddle): check instance status and react to state
 
-	// setting bootConfig to 0 to use current bootConfig
-	if diagErr := resourceLinodeInstanceReboot(ctx, d, linodeID, meta, 0); diagErr != nil {
-		return diagErr
+		// setting bootConfig to 0 to use current bootConfig
+		if diagErr := resourceLinodeInstanceReboot(ctx, d, linodeID, meta, 0); diagErr != nil {
+			return diagErr
+		}
 	}
+
 	return resourceLinodeInstanceIPRead(ctx, d, meta)
 }
 

--- a/linode/resource_linode_instance_test.go
+++ b/linode/resource_linode_instance_test.go
@@ -343,18 +343,21 @@ func TestAccLinodeInstance_configInterfaces(t *testing.T) {
 func testAccAssertReboot(t *testing.T, shouldRestart bool, instance *linodego.Instance) func() {
 	return func() {
 		client := testAccProvider.Meta().(*ProviderMeta).Client
+
 		eventFilter := fmt.Sprintf(`{"entity.type": "linode", "entity.id": %d, "action": "linode_reboot", "created": { "+gte": "%s" }}`,
 			instance.ID, instance.Created.Format("2006-01-02T15:04:05"))
+
 		events, err := client.ListEvents(context.Background(), &linodego.ListOptions{Filter: eventFilter})
+
 		if err != nil {
 			t.Fail()
 		}
 
-		if len(events) == 0 {
-			if shouldRestart {
-				t.Fatal("expected instance to have been rebooted")
-			}
-		} else if !shouldRestart {
+		if len(events) == 0 && shouldRestart {
+			t.Fatal("expected instance to have been rebooted")
+		}
+
+		if len(events) > 0 && !shouldRestart {
 			t.Fatal("expected instance to not have been rebooted")
 		}
 	}

--- a/website/docs/r/instance_ip.html.md
+++ b/website/docs/r/instance_ip.html.md
@@ -39,6 +39,8 @@ The following arguments are supported:
 
 * `rdns` - (Optional) The reverse DNS assigned to this address.
 
+* `apply_immediately` - (Optional) If true, the instance will be rebooted to update network interfaces.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
This change adds the `apply_immediately` field to the `linode_instance_ip` resource. This field must be set to `true` in order for instances to be automatically rebooted on IP creation.