### PR TITLE
Add NodeBalancer state upgraders

### DIFF
--- a/linode/resource_linode_nodebalancer.go
+++ b/linode/resource_linode_nodebalancer.go
@@ -44,6 +44,14 @@ func resourceLinodeNodeBalancer() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceLinodeNodeBalancerV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceLinodeNodeBalancerV0Upgrade,
+				Version: 0,
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			"label": {
 				Type:        schema.TypeString,
@@ -103,6 +111,53 @@ func resourceLinodeNodeBalancer() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceLinodeNodeBalancerV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"transfer": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLinodeNodeBalancerV0Upgrade(ctx context.Context,
+	rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	oldTransfer, ok := rawState["transfer"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to upgrade state: transfer key does not exist")
+	}
+
+	newTransfer := []map[string]interface{}{
+		{
+			"in":    0.0,
+			"out":   0.0,
+			"total": 0.0,
+		},
+	}
+
+	for key, val := range oldTransfer {
+		val := val.(string)
+
+		// This is necessary because it is possible old versions of the state have empty transfer fields
+		// that must default to zero.
+		if val == "" {
+			continue
+		}
+
+		result, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upgrade state: %v", err)
+		}
+
+		newTransfer[0][key] = result
+	}
+
+	rawState["transfer"] = newTransfer
+	return rawState, nil
 }
 
 func resourceLinodeNodeBalancerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/linode/resource_linode_nodebalancer_config_test.go
+++ b/linode/resource_linode_nodebalancer_config_test.go
@@ -3,6 +3,7 @@ package linode
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -251,6 +252,64 @@ func TestAccLinodeNodeBalancerConfig_proxyProtocol(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestLinodeNodeBalancerConfig_UpgradeV0(t *testing.T) {
+	t.Parallel()
+
+	oldState := map[string]interface{}{
+		"node_status": map[string]interface{}{
+			"down": "13",
+			"up":   "37",
+		},
+	}
+
+	desiredState := map[string]interface{}{
+		"node_status": []map[string]interface{}{
+			{
+				"down": 13,
+				"up":   37,
+			},
+		},
+	}
+
+	newState, err := resourceLinodeNodeBalancerConfigV0Upgrade(context.Background(), oldState, nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %v", err)
+	}
+
+	if !reflect.DeepEqual(desiredState, newState) {
+		t.Fatalf("expected %v, got %v", desiredState, newState)
+	}
+}
+
+func TestLinodeNodeBalancerConfig_UpgradeV0Empty(t *testing.T) {
+	t.Parallel()
+
+	oldState := map[string]interface{}{
+		"node_status": map[string]interface{}{
+			"down": "",
+			"up":   "",
+		},
+	}
+
+	desiredState := map[string]interface{}{
+		"node_status": []map[string]interface{}{
+			{
+				"down": 0,
+				"up":   0,
+			},
+		},
+	}
+
+	newState, err := resourceLinodeNodeBalancerConfigV0Upgrade(context.Background(), oldState, nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %v", err)
+	}
+
+	if !reflect.DeepEqual(desiredState, newState) {
+		t.Fatalf("expected %v, got %v", desiredState, newState)
+	}
 }
 
 func testAccCheckLinodeNodeBalancerConfigExists(s *terraform.State) error {

--- a/linode/resource_linode_nodebalancer_test.go
+++ b/linode/resource_linode_nodebalancer_test.go
@@ -3,6 +3,7 @@ package linode
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -114,6 +115,68 @@ func TestAccLinodeNodeBalancer_update(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestLinodeNodeBalancer_UpgradeV0(t *testing.T) {
+	t.Parallel()
+
+	oldState := map[string]interface{}{
+		"transfer": map[string]interface{}{
+			"in":    "1337",
+			"out":   "1338",
+			"total": "1339",
+		},
+	}
+
+	desiredState := map[string]interface{}{
+		"transfer": []map[string]interface{}{
+			{
+				"in":    1337.0,
+				"out":   1338.0,
+				"total": 1339.0,
+			},
+		},
+	}
+
+	newState, err := resourceLinodeNodeBalancerV0Upgrade(context.Background(), oldState, nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %v", err)
+	}
+
+	if !reflect.DeepEqual(desiredState, newState) {
+		t.Fatalf("expected %v, got %v", desiredState, newState)
+	}
+}
+
+func TestLinodeNodeBalancer_UpgradeV0Empty(t *testing.T) {
+	t.Parallel()
+
+	oldState := map[string]interface{}{
+		"transfer": map[string]interface{}{
+			"in":    "",
+			"out":   "",
+			"total": "",
+		},
+	}
+
+	desiredState := map[string]interface{}{
+		"transfer": []map[string]interface{}{
+			{
+				"in":    0.0,
+				"out":   0.0,
+				"total": 0.0,
+			},
+		},
+	}
+
+	newState, err := resourceLinodeNodeBalancerV0Upgrade(context.Background(), oldState, nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %v", err)
+	}
+
+	if !reflect.DeepEqual(desiredState, newState) {
+		t.Fatalf("expected %v, got %v", desiredState, newState)
+	}
 }
 
 func testAccCheckLinodeNodeBalancerExists(s *terraform.State) error {


### PR DESCRIPTION
This change allows for Terraform state upgrades from provider versions v1.13.4 to v1.14.0+

Resolves #437
Resolves #338  
