### PR TITLE
Bump Kubernetes version in LKE acceptance tests

### DIFF
--- a/linode/resource_linode_lke_cluster_test.go
+++ b/linode/resource_linode_lke_cluster_test.go
@@ -241,19 +241,19 @@ func TestAccLinodeLKECluster_k8sUpgrade(t *testing.T) {
 		CheckDestroy: testAccCheckLinodeLKEClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckLinodeLKEClusterManyPools(clusterName, "1.19"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testLKEClusterResName, "label", clusterName),
-					resource.TestCheckResourceAttr(testLKEClusterResName, "region", "us-central"),
-					resource.TestCheckResourceAttr(testLKEClusterResName, "k8s_version", "1.19"),
-				),
-			},
-			{
 				Config: testAccCheckLinodeLKEClusterManyPools(clusterName, "1.20"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testLKEClusterResName, "label", clusterName),
 					resource.TestCheckResourceAttr(testLKEClusterResName, "region", "us-central"),
 					resource.TestCheckResourceAttr(testLKEClusterResName, "k8s_version", "1.20"),
+				),
+			},
+			{
+				Config: testAccCheckLinodeLKEClusterManyPools(clusterName, "1.21"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testLKEClusterResName, "label", clusterName),
+					resource.TestCheckResourceAttr(testLKEClusterResName, "region", "us-central"),
+					resource.TestCheckResourceAttr(testLKEClusterResName, "k8s_version", "1.21"),
 				),
 			},
 		},


### PR DESCRIPTION
This change is in response to the Kubernetes 1.19 EOL.