### PR TITLE
Use test templating for NodeBalancer test configurations

### DIFF
--- a/linode/acceptance/test_util.go
+++ b/linode/acceptance/test_util.go
@@ -1,13 +1,17 @@
 package acceptance
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -29,6 +33,7 @@ var (
 	PublicKeyMaterial  string
 	TestAccProviders   map[string]*schema.Provider
 	TestAccProvider    *schema.Provider
+	ConfigTemplates    *template.Template
 )
 
 func init() {
@@ -49,6 +54,29 @@ func init() {
 	TestAccProvider = linode.Provider()
 	TestAccProviders = map[string]*schema.Provider{
 		"linode": TestAccProvider,
+	}
+
+	var templateFiles []string
+
+	err = filepath.Walk("../", func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) == ".gotf" {
+			templateFiles = append(templateFiles, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Fatalf("failed to load template files: %v", err)
+	}
+
+	ConfigTemplates = template.New("tf-test")
+	if _, err := ConfigTemplates.ParseFiles(templateFiles...); err != nil {
+		log.Fatalf("failed to parse templates: %v", err)
 	}
 }
 
@@ -180,4 +208,15 @@ func CheckLKEClusterDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func ExecuteTemplate(t *testing.T, templateName string, data interface{}) string {
+	var b bytes.Buffer
+
+	err := ConfigTemplates.ExecuteTemplate(&b, templateName, data)
+	if err != nil {
+		t.Fatalf("failed to execute template %s: %v", templateName, err)
+	}
+
+	return b.String()
 }

--- a/linode/balancer/datasource_test.go
+++ b/linode/balancer/datasource_test.go
@@ -1,6 +1,7 @@
 package balancer_test
 
 import (
+	"github.com/linode/terraform-provider-linode/linode/balancer/tmpl"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -20,7 +21,7 @@ func TestAccDataSourceNodeBalancer_basic(t *testing.T) {
 		CheckDestroy: checkNodeBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: dataSourceConfigBasic(nodebalancerName),
+				Config: tmpl.DataBasic(t, nodebalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					checkNodeBalancerExists,
 					resource.TestCheckResourceAttr(resName, "label", nodebalancerName),
@@ -41,12 +42,4 @@ func TestAccDataSourceNodeBalancer_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func dataSourceConfigBasic(nodeBalancerName string) string {
-	return resourceConfigBasic(nodeBalancerName) + `
-data "linode_nodebalancer" "foobar" {
-	id = "${linode_nodebalancer.foobar.id}"
-}
-`
 }

--- a/linode/balancer/resource_test.go
+++ b/linode/balancer/resource_test.go
@@ -3,6 +3,7 @@ package balancer_test
 import (
 	"context"
 	"fmt"
+	"github.com/linode/terraform-provider-linode/linode/balancer/tmpl"
 	"strconv"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestAccResourceNodeBalancer_basic(t *testing.T) {
 		CheckDestroy: checkNodeBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceConfigBasic(nodebalancerName),
+				Config: tmpl.Basic(t, nodebalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					checkNodeBalancerExists,
 					resource.TestCheckResourceAttr(resName, "label", nodebalancerName),
@@ -96,7 +97,7 @@ func TestAccResourceNodeBalancer_update(t *testing.T) {
 		CheckDestroy: checkNodeBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceConfigBasic(nodebalancerName),
+				Config: tmpl.Basic(t, nodebalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					checkNodeBalancerExists,
 					resource.TestCheckResourceAttr(resName, "label", nodebalancerName),
@@ -104,7 +105,7 @@ func TestAccResourceNodeBalancer_update(t *testing.T) {
 				),
 			},
 			{
-				Config: resourceConfigUpdates(nodebalancerName),
+				Config: tmpl.Updates(t, nodebalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					checkNodeBalancerExists,
 					resource.TestCheckResourceAttr(resName, "label", fmt.Sprintf("%s_r", nodebalancerName)),
@@ -168,25 +169,4 @@ func checkNodeBalancerDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-func resourceConfigBasic(nodebalancer string) string {
-	return fmt.Sprintf(`
-resource "linode_nodebalancer" "foobar" {
-	label = "%s"
-	region = "us-east"
-	client_conn_throttle = 20
-	tags = ["tf_test"]
-}
-`, nodebalancer)
-}
-
-func resourceConfigUpdates(nodebalancer string) string {
-	return fmt.Sprintf(`
-resource "linode_nodebalancer" "foobar" {
-	label = "%s_r"
-	region = "us-east"
-	client_conn_throttle = 0
-	tags = ["tf_test", "tf_test_2"]
-}
-`, nodebalancer)
 }

--- a/linode/balancer/tmpl/basic.gotf
+++ b/linode/balancer/tmpl/basic.gotf
@@ -1,0 +1,10 @@
+{{ define "nodebalancer_basic" }}
+
+resource "linode_nodebalancer" "foobar" {
+    label = "{{.Label}}"
+    region = "us-east"
+    client_conn_throttle = 20
+    tags = ["tf_test"]
+}
+
+{{ end }}

--- a/linode/balancer/tmpl/data_basic.gotf
+++ b/linode/balancer/tmpl/data_basic.gotf
@@ -1,0 +1,9 @@
+{{ define "nodebalancer_data_basic" }}
+
+{{ template "nodebalancer_basic" . }}
+
+data "linode_nodebalancer" "foobar" {
+    id = "${linode_nodebalancer.foobar.id}"
+}
+
+{{ end }}

--- a/linode/balancer/tmpl/template.go
+++ b/linode/balancer/tmpl/template.go
@@ -1,0 +1,27 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+type TemplateData struct {
+	Label string
+}
+
+func Basic(t *testing.T, nodebalancer string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_basic", TemplateData{Label: nodebalancer})
+}
+
+func Updates(t *testing.T, nodebalancer string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_updates", TemplateData{Label: nodebalancer})
+}
+
+func DataBasic(t *testing.T, nodebalancer string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_data_basic",
+		TemplateData{Label: nodebalancer})
+}

--- a/linode/balancer/tmpl/updates.gotf
+++ b/linode/balancer/tmpl/updates.gotf
@@ -1,0 +1,10 @@
+{{ define "nodebalancer_updates" }}
+
+resource "linode_nodebalancer" "foobar" {
+    label = "{{.Label}}_r"
+    region = "us-east"
+    client_conn_throttle = 0
+    tags = ["tf_test", "tf_test_2"]
+}
+
+{{ end }}

--- a/linode/balancerconfig/datasource_test.go
+++ b/linode/balancerconfig/datasource_test.go
@@ -1,6 +1,7 @@
 package balancerconfig_test
 
 import (
+	"github.com/linode/terraform-provider-linode/linode/balancerconfig/tmpl"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -21,7 +22,7 @@ func TestAccDataSourceNodeBalancerConfig_basic(t *testing.T) {
 		CheckDestroy: checkNodeBalancerConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: dataSourceConfigBasic(nodebalancerName),
+				Config: tmpl.DataBasic(t, nodebalancerName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkNodeBalancerConfigExists,
 					resource.TestCheckResourceAttr(resName, "port", "8080"),
@@ -46,13 +47,4 @@ func TestAccDataSourceNodeBalancerConfig_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func dataSourceConfigBasic(nodeBalancerName string) string {
-	return resourceConfigBasic(nodeBalancerName) + `
-data "linode_nodebalancer_config" "foofig" {
-	id = "${linode_nodebalancer_config.foofig.id}"
-	nodebalancer_id = "${linode_nodebalancer.foobar.id}"
-}
-`
 }

--- a/linode/balancerconfig/tmpl/basic.gotf
+++ b/linode/balancerconfig/tmpl/basic.gotf
@@ -1,0 +1,14 @@
+{{ define "nodebalancer_config_basic" }}
+
+{{ template "nodebalancer_basic" .NodeBalancer }}
+
+resource "linode_nodebalancer_config" "foofig" {
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+    port = 8080
+    protocol = "HttP"
+    check = "http"
+    check_passive = true
+    check_path = "/"
+}
+
+{{ end }}

--- a/linode/balancerconfig/tmpl/data_basic.gotf
+++ b/linode/balancerconfig/tmpl/data_basic.gotf
@@ -1,0 +1,10 @@
+{{ define "nodebalancer_config_data_basic" }}
+
+{{ template "nodebalancer_config_basic" . }}
+
+data "linode_nodebalancer_config" "foofig" {
+    id = "${linode_nodebalancer_config.foofig.id}"
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+}
+
+{{ end }}

--- a/linode/balancerconfig/tmpl/proxy_protocol.gotf
+++ b/linode/balancerconfig/tmpl/proxy_protocol.gotf
@@ -1,0 +1,12 @@
+{{ define "nodebalancer_config_proxy_protocol" }}
+
+{{ template "nodebalancer_basic" .NodeBalancer }}
+
+resource "linode_nodebalancer_config" "foofig" {
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+    port = 80
+    protocol = "tcp"
+    proxy_protocol = "v2"
+}
+
+{{ end }}

--- a/linode/balancerconfig/tmpl/ssl.gotf
+++ b/linode/balancerconfig/tmpl/ssl.gotf
@@ -1,0 +1,20 @@
+{{ define "nodebalancer_config_ssl" }}
+
+{{ template "nodebalancer_basic" .NodeBalancer }}
+
+resource "linode_nodebalancer_config" "foofig" {
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+    port = 8080
+    protocol = "https"
+    check = "http"
+    check_passive = true
+    check_path = "/"
+    ssl_cert = <<EOT
+{{.SSLCert}}
+EOT
+    ssl_key = <<EOT
+{{.SSLKey}}
+EOT
+}
+
+{{ end }}

--- a/linode/balancerconfig/tmpl/template.go
+++ b/linode/balancerconfig/tmpl/template.go
@@ -1,0 +1,56 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	nodebalancer "github.com/linode/terraform-provider-linode/linode/balancer/tmpl"
+)
+
+type TemplateData struct {
+	NodeBalancer nodebalancer.TemplateData
+	SSLCert      string
+	SSLKey       string
+}
+
+func Basic(t *testing.T, nodebalancerName string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_config_basic", TemplateData{
+			NodeBalancer: nodebalancer.TemplateData{
+				Label: nodebalancerName,
+			}})
+}
+
+func Updates(t *testing.T, nodebalancerName string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_config_updates", TemplateData{
+			NodeBalancer: nodebalancer.TemplateData{
+				Label: nodebalancerName,
+			}})
+}
+
+func SSL(t *testing.T, nodebalancerName, cert, privKey string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_config_ssl", TemplateData{
+			SSLCert: cert,
+			SSLKey:  privKey,
+			NodeBalancer: nodebalancer.TemplateData{
+				Label: nodebalancerName,
+			}})
+}
+
+func ProxyProtocol(t *testing.T, nodebalancerName string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_config_proxy_protocol", TemplateData{
+			NodeBalancer: nodebalancer.TemplateData{
+				Label: nodebalancerName,
+			}})
+}
+
+func DataBasic(t *testing.T, nodebalancerName string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_config_data_basic", TemplateData{
+			NodeBalancer: nodebalancer.TemplateData{
+				Label: nodebalancerName,
+			}})
+}

--- a/linode/balancerconfig/tmpl/updates.gotf
+++ b/linode/balancerconfig/tmpl/updates.gotf
@@ -1,0 +1,18 @@
+{{ define "nodebalancer_config_updates" }}
+
+{{ template "nodebalancer_basic" .NodeBalancer }}
+
+resource "linode_nodebalancer_config" "foofig" {
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+    port = 8088
+    protocol = "http"
+    check = "http"
+    check_path = "/foo"
+    check_attempts = 3
+    check_timeout = 30
+    check_passive = false
+    stickiness = "http_cookie"
+    algorithm = "source"
+}
+
+{{ end }}

--- a/linode/balancernode/datasource_test.go
+++ b/linode/balancernode/datasource_test.go
@@ -1,6 +1,7 @@
 package balancernode_test
 
 import (
+	"github.com/linode/terraform-provider-linode/linode/balancernode/tmpl"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -20,7 +21,7 @@ func TestAccDataSourceNodeBalancerNode_basic(t *testing.T) {
 		CheckDestroy: checkNodeBalancerNodeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acceptance.AccTestWithProvider(dataSourceConfigBasic(nodebalancerName), map[string]interface{}{
+				Config: acceptance.AccTestWithProvider(tmpl.DataBasic(t, nodebalancerName), map[string]interface{}{
 					acceptance.SkipInstanceReadyPollKey: true,
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -33,14 +34,4 @@ func TestAccDataSourceNodeBalancerNode_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func dataSourceConfigBasic(nodeBalancerName string) string {
-	return resourceConfigBasic(nodeBalancerName) + `
-data "linode_nodebalancer_node" "foonode" {
-	id = "${linode_nodebalancer_node.foonode.id}"
-	config_id = "${linode_nodebalancer_config.foofig.id}"
-	nodebalancer_id = "${linode_nodebalancer.foobar.id}"
-}
-`
 }

--- a/linode/balancernode/tmpl/basic.gotf
+++ b/linode/balancernode/tmpl/basic.gotf
@@ -1,0 +1,15 @@
+{{ define "nodebalancer_node_basic" }}
+
+{{ template "nodebalancer_node_networking" .Instance }}
+
+{{ template "nodebalancer_config_basic" .Config }}
+
+resource "linode_nodebalancer_node" "foonode" {
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+    config_id = "${linode_nodebalancer_config.foofig.id}"
+    address = "${linode_instance.foobar.private_ip_address}:80"
+    label = "{{.Label}}"
+    weight = 50
+}
+
+{{ end }}

--- a/linode/balancernode/tmpl/data_basic.gotf
+++ b/linode/balancernode/tmpl/data_basic.gotf
@@ -1,0 +1,11 @@
+{{ define "nodebalancer_node_data_basic" }}
+
+{{ template "nodebalancer_node_basic" . }}
+
+data "linode_nodebalancer_node" "foonode" {
+    id = "${linode_nodebalancer_node.foonode.id}"
+    config_id = "${linode_nodebalancer_config.foofig.id}"
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+}
+
+{{ end }}

--- a/linode/balancernode/tmpl/networking.gotf
+++ b/linode/balancernode/tmpl/networking.gotf
@@ -1,0 +1,15 @@
+{{ define "nodebalancer_node_networking" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    type = "g6-nanode-1"
+    image = "linode/ubuntu18.04"
+    region = "us-east"
+    root_pass = "terraform-test"
+    swap_size = 256
+    private_ip = true
+    authorized_keys = ["{{.PubKey}}"]
+    group = "tf_test"
+}
+
+{{ end }}

--- a/linode/balancernode/tmpl/template.go
+++ b/linode/balancernode/tmpl/template.go
@@ -1,0 +1,71 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/balancer/tmpl"
+	config "github.com/linode/terraform-provider-linode/linode/balancerconfig/tmpl"
+)
+
+type TemplateData struct {
+	Label    string
+	Instance InstanceTemplateData
+	Config   config.TemplateData
+}
+
+type InstanceTemplateData struct {
+	Label  string
+	PubKey string
+}
+
+func Basic(t *testing.T, nodebalancer string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_node_basic",
+		TemplateData{
+			Label: nodebalancer,
+			Instance: InstanceTemplateData{
+				Label:  nodebalancer,
+				PubKey: acceptance.PublicKeyMaterial,
+			},
+			Config: config.TemplateData{
+				NodeBalancer: tmpl.TemplateData{
+					Label: nodebalancer,
+				},
+			},
+		})
+}
+
+func Updates(t *testing.T, nodebalancer string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_node_updates",
+		TemplateData{
+			Label: nodebalancer,
+			Instance: InstanceTemplateData{
+				Label:  nodebalancer,
+				PubKey: acceptance.PublicKeyMaterial,
+			},
+			Config: config.TemplateData{
+				NodeBalancer: tmpl.TemplateData{
+					Label: nodebalancer,
+				},
+			},
+		})
+}
+
+func DataBasic(t *testing.T, nodebalancer string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nodebalancer_node_data_basic",
+		TemplateData{
+			Label: nodebalancer,
+			Instance: InstanceTemplateData{
+				Label:  nodebalancer,
+				PubKey: acceptance.PublicKeyMaterial,
+			},
+			Config: config.TemplateData{
+				NodeBalancer: tmpl.TemplateData{
+					Label: nodebalancer,
+				},
+			},
+		})
+}

--- a/linode/balancernode/tmpl/updates.gotf
+++ b/linode/balancernode/tmpl/updates.gotf
@@ -1,0 +1,15 @@
+{{ define "nodebalancer_node_updates" }}
+
+{{ template "nodebalancer_node_networking" .Instance }}
+
+{{ template "nodebalancer_config_basic" .Config }}
+
+resource "linode_nodebalancer_node" "foonode" {
+    nodebalancer_id = "${linode_nodebalancer.foobar.id}"
+    config_id = "${linode_nodebalancer_config.foofig.id}"
+    address = "${linode_instance.foobar.private_ip_address}:8080"
+    label = "{{.Label}}_r"
+    weight = 200
+}
+
+{{ end }}


### PR DESCRIPTION
This change replaces hardcoded test configurations with templates for all nodebalancer related resources and data sources.