### PR TITLE
Add additional valid domain TTLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.3.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/jmespath/go-jmespath v0.3.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/klauspost/compress v1.11.2 // indirect
@@ -66,10 +66,10 @@ require (
 	go.opencensus.io v0.22.4 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/mod v0.3.0 // indirect
-	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
-	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect

--- a/linode/domain/resource_test.go
+++ b/linode/domain/resource_test.go
@@ -148,6 +148,36 @@ func TestAccResourceDomain_roundedDomainSecs(t *testing.T) {
 	})
 }
 
+func TestAccResourceDomain_zeroSecs(t *testing.T) {
+	t.Parallel()
+
+	var domainName = acctest.RandomWithPrefix("tf-test") + ".example"
+	var resName = "linode_domain.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.ZeroSec(t, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					checkDomainExists,
+					resource.TestCheckResourceAttr(resName, "domain", domainName),
+					resource.TestCheckResourceAttr(resName, "refresh_sec", "0"),
+					resource.TestCheckResourceAttr(resName, "retry_sec", "0"),
+					resource.TestCheckResourceAttr(resName, "ttl_sec", "0"),
+					resource.TestCheckResourceAttr(resName, "expire_sec", "0"),
+				),
+			},
+			{
+				Config:            tmpl.ZeroSec(t, domainName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceDomain_updateIPs(t *testing.T) {
 	t.Parallel()
 

--- a/linode/domain/schema_datasource.go
+++ b/linode/domain/schema_datasource.go
@@ -2,8 +2,8 @@ package domain
 
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-const domainSecondsDescription = "Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, " +
-	"604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value."
+const domainSecondsDataDescription = "Valid values are 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, " +
+	"172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value."
 
 var dataSourceSchema = map[string]*schema.Schema{
 	"id": {
@@ -58,25 +58,25 @@ var dataSourceSchema = map[string]*schema.Schema{
 	"ttl_sec": {
 		Type: schema.TypeInt,
 		Description: "'Time to Live' - the amount of time in seconds that this Domain's records may be " +
-			"cached by resolvers or other domain servers. " + domainSecondsDescription,
+			"cached by resolvers or other domain servers. " + domainSecondsDataDescription,
 		Computed: true,
 	},
 	"retry_sec": {
 		Type: schema.TypeInt,
 		Description: "The interval, in seconds, at which a failed refresh should be retried. " +
-			domainSecondsDescription,
+			domainSecondsDataDescription,
 		Computed: true,
 	},
 	"expire_sec": {
 		Type: schema.TypeInt,
 		Description: "The amount of time in seconds that may pass before this Domain is no longer " +
-			"authoritative. " + domainSecondsDescription,
+			"authoritative. " + domainSecondsDataDescription,
 		Computed: true,
 	},
 	"refresh_sec": {
 		Type: schema.TypeInt,
 		Description: "The amount of time in seconds before this Domain should be refreshed. " +
-			domainSecondsDescription,
+			domainSecondsDataDescription,
 		Computed: true,
 	},
 	"soa_email": {

--- a/linode/domain/schema_resource.go
+++ b/linode/domain/schema_resource.go
@@ -6,7 +6,10 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
-var secondsDiffSuppressor = helper.DomainSecondsDiffSuppressor()
+const domainSecondsDescription = "Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, " +
+	"57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to " +
+	"the nearest valid value."
+
 var resourceSchema = map[string]*schema.Schema{
 	"domain": {
 		Type: schema.TypeString,
@@ -62,35 +65,30 @@ var resourceSchema = map[string]*schema.Schema{
 	"ttl_sec": {
 		Type: schema.TypeInt,
 		Description: "'Time to Live' - the amount of time in seconds that this Domain's records may be " +
-			"cached by resolvers or other domain servers. Valid values are 0, 300, 3600, 7200, 14400, 28800, " +
-			"57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to " +
-			"the nearest valid value.",
+			"cached by resolvers or other domain servers. " + domainSecondsDescription,
 		Optional:         true,
-		DiffSuppressFunc: secondsDiffSuppressor,
+		DiffSuppressFunc: helper.DomainSecondsDiffSuppressor(),
 	},
 	"retry_sec": {
 		Type: schema.TypeInt,
-		Description: "The interval, in seconds, at which a failed refresh should be retried. Valid values " +
-			"are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - " +
-			"any other value will be rounded to the nearest valid value.",
+		Description: "The interval, in seconds, at which a failed refresh should be retried. " +
+			domainSecondsDescription,
 		Optional:         true,
-		DiffSuppressFunc: secondsDiffSuppressor,
+		DiffSuppressFunc: helper.DomainSecondsDiffSuppressor(),
 	},
 	"expire_sec": {
 		Type: schema.TypeInt,
 		Description: "The amount of time in seconds that may pass before this Domain is no longer " +
-			"authoritative. Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, " +
-			"604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.",
+			domainSecondsDescription,
 		Optional:         true,
-		DiffSuppressFunc: secondsDiffSuppressor,
+		DiffSuppressFunc: helper.DomainSecondsDiffSuppressor(),
 	},
 	"refresh_sec": {
 		Type: schema.TypeInt,
-		Description: "The amount of time in seconds before this Domain should be refreshed. Valid " +
-			"values are 0, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, " +
-			"and 2419200 - any other value will be rounded to the nearest valid value.",
+		Description: "The amount of time in seconds before this Domain should be refreshed. " +
+			domainSecondsDescription,
 		Optional:         true,
-		DiffSuppressFunc: secondsDiffSuppressor,
+		DiffSuppressFunc: helper.DomainSecondsDiffSuppressor(),
 	},
 	"soa_email": {
 		Type:        schema.TypeString,

--- a/linode/domain/tmpl/template.go
+++ b/linode/domain/tmpl/template.go
@@ -25,6 +25,11 @@ func RoundedSec(t *testing.T, domain string) string {
 		"domain_rounded_sec", TemplateData{Domain: domain})
 }
 
+func ZeroSec(t *testing.T, domain string) string {
+	return acceptance.ExecuteTemplate(t,
+		"domain_zero_sec", TemplateData{Domain: domain})
+}
+
 func IPS(t *testing.T, domain string) string {
 	return acceptance.ExecuteTemplate(t,
 		"domain_ips", TemplateData{Domain: domain})

--- a/linode/domain/tmpl/zero_sec.gotf
+++ b/linode/domain/tmpl/zero_sec.gotf
@@ -1,0 +1,16 @@
+{{ define "domain_zero_sec" }}
+
+resource "linode_domain" "foobar" {
+    domain = "{{.Domain}}"
+    type = "master"
+    status = "active"
+    soa_email = "example@{{.Domain}}"
+    description = "tf-testing"
+    ttl_sec = 0
+    refresh_sec = 0
+    retry_sec = 0
+    expire_sec = 0
+    tags = ["tf_test"]
+}
+
+{{ end }}

--- a/linode/domainrecord/resource_test.go
+++ b/linode/domainrecord/resource_test.go
@@ -72,6 +72,35 @@ func TestAccResourceDomainRecord_roundedTTLSec(t *testing.T) {
 	})
 }
 
+func TestAccResourceDomainRecord_TTLZero(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_domain_record.foobar"
+	domainRecordName := acctest.RandomWithPrefix("tf-test-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkDomainRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.TTL(t, domainRecordName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					checkDomainRecordExists,
+					resource.TestCheckResourceAttr(resName, "name", domainRecordName),
+					resource.TestCheckResourceAttr(resName, "ttl_sec", "0"),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateID,
+			},
+		},
+	})
+}
+
 func TestAccResourceDomainRecord_ANoName(t *testing.T) {
 	t.Parallel()
 

--- a/linode/domainrecord/schema_resource.go
+++ b/linode/domainrecord/schema_resource.go
@@ -6,7 +6,6 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
-var secondsDiffSuppressor = helper.DomainSecondsDiffSuppressor()
 var resourceSchema = map[string]*schema.Schema{
 	"domain_id": {
 		Type:        schema.TypeInt,
@@ -35,11 +34,11 @@ var resourceSchema = map[string]*schema.Schema{
 	"ttl_sec": {
 		Type: schema.TypeInt,
 		Description: "'Time to Live' - the amount of time in seconds that this Domain's records may be " +
-			"cached by resolvers or other domain servers. Valid values are 0, 300, 3600, 7200, 14400, 28800, 57600, " +
+			"cached by resolvers or other domain servers. Valid values are 30, 120, 300, 3600, 7200, 14400, 28800, 57600, " +
 			"86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest " +
 			"valid value.",
 		Optional:         true,
-		DiffSuppressFunc: secondsDiffSuppressor,
+		DiffSuppressFunc: helper.DomainSecondsDiffSuppressor(),
 	},
 	"target": {
 		Type: schema.TypeString,

--- a/linode/helper/domain.go
+++ b/linode/helper/domain.go
@@ -8,7 +8,7 @@ import (
 
 func DomainSecondsDiffSuppressor() schema.SchemaDiffSuppressFunc {
 	accepted := []int{
-		300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, 2419200,
+		30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, 2419200,
 	}
 
 	rounder := func(n int) int {

--- a/website/docs/r/domain.html.md
+++ b/website/docs/r/domain.html.md
@@ -53,13 +53,13 @@ The following arguments are supported:
 
 * `group` - (Optional) The group this Domain belongs to. This is for display purposes only.
 
-* `ttl_sec` - (Optional) 'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+* `ttl_sec` - (Optional) 'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 
-* `retry_sec` - (Optional) The interval, in seconds, at which a failed refresh should be retried. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+* `retry_sec` - (Optional) The interval, in seconds, at which a failed refresh should be retried. Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 
-* `expire_sec` - (Optional) The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+* `expire_sec` - (Optional) The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 
-* `refresh_sec` - (Optional) The amount of time in seconds before this Domain should be refreshed. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+* `refresh_sec` - (Optional) The amount of time in seconds before this Domain should be refreshed. Valid values are 0, 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 
 * `axfr_ips` - (Optional) The list of IPs that may perform a zone transfer for this Domain. This is potentially dangerous, and should be set to an empty list unless you intend to use it.
 

--- a/website/docs/r/domain_record.html.md
+++ b/website/docs/r/domain_record.html.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 - - -
 
-* `ttl_sec` - (Optional) 'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
+* `ttl_sec` - (Optional) 'Time to Live' - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 30, 120, 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 
 * `priority` - (Optional) The priority of the target host. Lower values are preferred.
 


### PR DESCRIPTION
This pull request adds additional valid values for seconds-related fields in the `linode_domain` and `linode_domain_record` resources. These values are accepted by the API and are available in Cloud Manager. 

This pull request also adds additional test cases for TTLs of `0` in both resources.

Resolves #484  