### PR TITLE
Add linode_instance_types data source

### DIFF
--- a/linode/instancetypes/datasource.go
+++ b/linode/instancetypes/datasource.go
@@ -1,0 +1,91 @@
+package instancetypes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+
+	"context"
+	"strconv"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		Schema:      dataSourceSchema,
+		ReadContext: readDataSource,
+	}
+}
+
+func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	filter, err := helper.ConstructFilterString(d, typeValueToFilterType)
+	if err != nil {
+		return diag.Errorf("failed to construct filter: %s", err)
+	}
+
+	types, err := client.ListTypes(ctx, &linodego.ListOptions{
+		Filter: filter,
+	})
+
+	if err != nil {
+		return diag.Errorf("failed to list linode types: %s", err)
+	}
+
+	typesFlattened := make([]interface{}, len(types))
+	for i, t := range types {
+		typesFlattened[i] = flattenType(&t)
+	}
+
+	d.SetId(filter)
+	d.Set("types", typesFlattened)
+
+	return nil
+}
+
+func flattenType(t *linodego.LinodeType) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	result["id"] = t.ID
+	result["label"] = t.Label
+	result["disk"] = t.Disk
+	result["class"] = t.Class
+	result["network_out"] = t.NetworkOut
+	result["memory"] = t.Memory
+	result["transfer"] = t.Transfer
+	result["vcpus"] = t.VCPUs
+
+	result["price"] = []map[string]float32{
+		{
+			"hourly":  t.Price.Hourly,
+			"monthly": t.Price.Monthly,
+		},
+	}
+
+	result["addons"] = []map[string]interface{}{
+		{
+			"backups": []map[string]interface{}{
+				{
+					"price": []map[string]float32{
+						{
+							"hourly":  t.Addons.Backups.Price.Hourly,
+							"monthly": t.Addons.Backups.Price.Monthly,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return result
+}
+
+func typeValueToFilterType(filterName, value string) (interface{}, error) {
+	switch filterName {
+	case "disk", "gpus", "memory", "transfer", "vcpus":
+		return strconv.Atoi(value)
+	}
+
+	return value, nil
+}

--- a/linode/instancetypes/datasource_test.go
+++ b/linode/instancetypes/datasource_test.go
@@ -1,0 +1,39 @@
+package instancetypes_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/instancetypes/tmpl"
+)
+
+func TestAccDataSourceInstanceTypes_basic(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_instance_types.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "types.0.id", "g6-standard-2"),
+					resource.TestCheckResourceAttr(resourceName, "types.0.label", "Linode 4GB"),
+					resource.TestCheckResourceAttr(resourceName, "types.0.class", "standard"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.disk"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.network_out"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.memory"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.transfer"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.vcpus"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.price.0.hourly"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.price.0.monthly"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.addons.0.backups.0.price.0.hourly"),
+					resource.TestCheckResourceAttrSet(resourceName, "types.0.addons.0.backups.0.price.0.monthly"),
+				),
+			},
+		},
+	})
+}

--- a/linode/instancetypes/schema_datasource.go
+++ b/linode/instancetypes/schema_datasource.go
@@ -1,0 +1,18 @@
+package instancetypes
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+	"github.com/linode/terraform-provider-linode/linode/instancetype"
+)
+
+var dataSourceSchema = map[string]*schema.Schema{
+	"filter": helper.FilterSchema([]string{"class", "disk", "gpus", "label",
+		"memory", "network_out", "transfer", "vcpus"}),
+	"types": {
+		Type:        schema.TypeList,
+		Description: "The returned list of Types.",
+		Computed:    true,
+		Elem:        instancetype.DataSource(),
+	},
+}

--- a/linode/instancetypes/tmpl/data_basic.gotf
+++ b/linode/instancetypes/tmpl/data_basic.gotf
@@ -1,0 +1,10 @@
+{{ define "instance_types_data_basic" }}
+
+data "linode_instance_types" "foobar" {
+    filter {
+        name = "label"
+        values = ["Linode 4GB"]
+    }
+}
+
+{{ end }}

--- a/linode/instancetypes/tmpl/template.go
+++ b/linode/instancetypes/tmpl/template.go
@@ -1,0 +1,12 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+func DataBasic(t *testing.T) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_types_data_basic", nil)
+}

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/instance"
 	"github.com/linode/terraform-provider-linode/linode/instanceip"
 	"github.com/linode/terraform-provider-linode/linode/instancetype"
+	"github.com/linode/terraform-provider-linode/linode/instancetypes"
 	"github.com/linode/terraform-provider-linode/linode/kernel"
 	"github.com/linode/terraform-provider-linode/linode/lke"
 	"github.com/linode/terraform-provider-linode/linode/nb"
@@ -126,6 +127,7 @@ func Provider() *schema.Provider {
 			"linode_instances":              instance.DataSource(),
 			"linode_instance_backups":       backup.DataSource(),
 			"linode_instance_type":          instancetype.DataSource(),
+			"linode_instance_types":         instancetypes.DataSource(),
 			"linode_kernel":                 kernel.DataSource(),
 			"linode_lke_cluster":            lke.DataSource(),
 			"linode_networking_ip":          networkingip.DataSource(),

--- a/website/docs/d/instance_types.html.md
+++ b/website/docs/d/instance_types.html.md
@@ -1,0 +1,88 @@
+---
+layout: "linode"
+page_title: "Linode: linode_instance_types"
+sidebar_current: "docs-linode-datasource-instance-types"
+description: |-
+Provides information about Linode Instance types that match a set of filters.
+---
+
+# Data Source: linode\_instance_types
+
+Provides information about Linode Instance types that match a set of filters.
+
+## Example Usage
+
+Get information about all Linode Instance types with a certain number of VCPUs:
+
+```hcl
+data "linode_instance_types" "specific-types" {
+  filter {
+    name = "vcpus"
+    values = [2]
+  }
+}
+```
+
+Get information about all Linode Instance types:
+
+```hcl
+data "linode_instance_types" "all-types" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* [`filter`](#filter) - (Optional) A set of filters used to select Linode Instance types that meet certain requirements.
+
+### Filter
+
+* `name` - (Required) The name of the field to filter by. See the [Filterable Fields section](#filterable-fields) for a complete list of filterable fields.
+
+* `values` - (Required) A list of values for the filter to allow. These values should all be in string form.
+
+## Attributes
+
+Each Linode Instance type will be stored in the `types` attribute and will export the following attributes:
+
+* `id` - The ID representing the Linode Type.
+
+* `label` - The Linode Type's label is for display purposes only.
+
+* `class` - The class of the Linode Type. See all classes [here](https://www.linode.com/docs/api/linode-types/#type-view__responses).
+
+* `disk` - The Disk size, in MB, of the Linode Type.
+
+* `price.0.hourly` -  Cost (in US dollars) per hour.
+
+* `price.0.monthly` - Cost (in US dollars) per month.
+
+* `addons.0.backups.0.price.0.hourly` - The cost (in US dollars) per hour to add Backups service.
+
+* `addons.0.backups.0.price.0.monthly` - The cost (in US dollars) per month to add Backups service.
+
+* `network_out` - The Mbits outbound bandwidth allocation.
+
+* `memory` - The amount of RAM included in this Linode Type.
+
+* `transfer` - The monthly outbound transfer amount, in MB.
+
+* `vcpus` - The number of VCPU cores this Linode Type offers.
+
+## Filterable Fields
+
+* `class`
+
+* `disk`
+
+* `gpus`
+
+* `label`
+
+* `memory`
+
+* `network_out`
+
+* `transfer`
+
+* `vcpus`

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -40,6 +40,9 @@
             <li<%= sidebar_current("docs-linode-datasource-instance-type") %>>
               <a href="/docs/providers/linode/d/instance_type.html">linode_instance_type</a>
             </li>
+            <li<%= sidebar_current("docs-linode-datasource-instance-types") %>>
+              <a href="/docs/providers/linode/d/instance_types.html">linode_instance_types</a>
+            </li>
             <li<%= sidebar_current("docs-linode-datasource-lke-cluster") %>>
               <a href="/docs/providers/linode/d/lke_cluster.html">linode_lke_cluster</a>
             </li>


### PR DESCRIPTION
This feature allows users to query all available Instance types using filters.

For example:

**Retrieving all Instance types**
```hcl
data "linode_instance_types" "specific-types" {}
```

**Retrieving all Instance types with two VCPUs**
```hcl
data "linode_instance_types" "specific-types" {
  filter {
    name = "vcpus"
    values = [2]
  }
}
```

Closes #501 