### PR TITLE
Add support for LKE Autoscalers

### DIFF
--- a/linode/lke/cluster_test.go
+++ b/linode/lke/cluster_test.go
@@ -92,6 +92,30 @@ func TestReconcileLKEClusterPoolSpecs(t *testing.T) {
 				126: {Count: 9}, // +5
 			},
 		},
+		{
+			name: "scaler",
+			provisionedPools: []linodego.LKEClusterPool{
+				{ID: 123, Type: "g6-standard-3", Count: 3},
+			},
+			specs: []lke.ClusterPoolSpec{
+				{Type: "g6-standard-3", Count: 3, AutoScalerEnabled: true, AutoScalerMin: 3, AutoScalerMax: 7},
+			},
+			expectedToUpdate: map[int]linodego.LKEClusterPoolUpdateOptions{
+				123: {Count: 3, Autoscaler: &linodego.LKEClusterPoolAutoscaler{Enabled: true, Min: 3, Max: 7}}, // -1
+			},
+		},
+		{
+			name: "scaler drop",
+			provisionedPools: []linodego.LKEClusterPool{
+				{ID: 123, Type: "g6-standard-3", Count: 3, Autoscaler: linodego.LKEClusterPoolAutoscaler{Enabled: true, Min: 3, Max: 7}},
+			},
+			specs: []lke.ClusterPoolSpec{
+				{Type: "g6-standard-3", Count: 3, AutoScalerEnabled: false},
+			},
+			expectedToUpdate: map[int]linodego.LKEClusterPoolUpdateOptions{
+				123: {Count: 3, Autoscaler: &linodego.LKEClusterPoolAutoscaler{Enabled: false, Min: 3, Max: 3}}, // -1
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			updates := lke.ReconcileLKEClusterPoolSpecs(tc.specs, tc.provisionedPools)

--- a/linode/lke/datasource_test.go
+++ b/linode/lke/datasource_test.go
@@ -32,8 +32,42 @@ func TestAccDataSourceLKECluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.type", "g6-standard-2"),
 					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.count", "3"),
 					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.nodes.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.autoscaler.#", "0"),
 					resource.TestCheckResourceAttrSet(dataSourceClusterName, "pools.0.id"),
 					resource.TestCheckResourceAttrSet(dataSourceClusterName, "kubeconfig"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceLKECluster_autoscaler(t *testing.T) {
+	t.Parallel()
+
+	clusterName := acctest.RandomWithPrefix("tf_test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CheckLKEClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataAutoscaler(t, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceClusterName, "label", clusterName),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "region", "us-central"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "k8s_version", "1.20"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "status", "ready"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.type", "g6-standard-2"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.count", "3"),
+					resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.nodes.#", "3"),
+					resource.TestCheckResourceAttrSet(dataSourceClusterName, "pools.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceClusterName, "kubeconfig"),
+
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.min", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.max", "5"),
 				),
 			},
 		},

--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -249,3 +249,72 @@ func TestAccResourceLKECluster_removeUnmanagedPool(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLinodeLKECluster_autoScaler(t *testing.T) {
+	t.Parallel()
+
+	clusterName := acctest.RandomWithPrefix("tf_test")
+	//newClusterName := acctest.RandomWithPrefix("tf_test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CheckLKEClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Basic(t, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "3"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.#", "0"),
+				),
+			},
+			{
+				Config: tmpl.Autoscaler(t, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "3"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.min", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.max", "5"),
+				),
+			},
+			{
+				Config: tmpl.AutoscalerUpdates(t, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "3"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.min", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.max", "8"),
+				),
+			},
+			{
+				Config: tmpl.AutoscalerManyPools(t, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.#", "2"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "5"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.min", "3"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.0.max", "8"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.1.count", "3"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.1.autoscaler.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.1.autoscaler.0.min", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.1.autoscaler.0.max", "8"),
+				),
+			},
+			{
+				Config: tmpl.Basic(t, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "3"),
+					resource.TestCheckResourceAttr(resourceClusterName, "pool.0.autoscaler.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -250,7 +250,7 @@ func TestAccResourceLKECluster_removeUnmanagedPool(t *testing.T) {
 	})
 }
 
-func TestAccLinodeLKECluster_autoScaler(t *testing.T) {
+func TestAccResourceLKECluster_autoScaler(t *testing.T) {
 	t.Parallel()
 
 	clusterName := acctest.RandomWithPrefix("tf_test")

--- a/linode/lke/schema_datasource.go
+++ b/linode/lke/schema_datasource.go
@@ -91,6 +91,26 @@ var dataSourceSchema = map[string]*schema.Schema{
 					Computed:    true,
 					Description: "The nodes in the node pool.",
 				},
+				"autoscaler": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"min": {
+								Type:        schema.TypeInt,
+								Description: "The minimum number of nodes to autoscale to.",
+								Required:    true,
+							},
+							"max": {
+								Type:        schema.TypeInt,
+								Description: "The maximum number of nodes to autoscale to.",
+								Required:    true,
+							},
+						},
+					},
+					Description: "When specified, the number of nodes autoscales within " +
+						"the defined minimum and maximum values.",
+				},
 			},
 		},
 		Computed:    true,

--- a/linode/lke/schema_resource.go
+++ b/linode/lke/schema_resource.go
@@ -90,6 +90,27 @@ var resourceSchema = map[string]*schema.Schema{
 					Computed:    true,
 					Description: "The nodes in the node pool.",
 				},
+				"autoscaler": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"min": {
+								Type:        schema.TypeInt,
+								Description: "The minimum number of nodes to autoscale to.",
+								Required:    true,
+							},
+							"max": {
+								Type:        schema.TypeInt,
+								Description: "The maximum number of nodes to autoscale to.",
+								Required:    true,
+							},
+						},
+					},
+					Description: "When specified, the number of nodes autoscales within " +
+						"the defined minimum and maximum values.",
+				},
 			},
 		},
 		MinItems:    1,

--- a/linode/lke/tmpl/autoscaler.gotf
+++ b/linode/lke/tmpl/autoscaler.gotf
@@ -1,0 +1,18 @@
+{{ define "lke_cluster_autoscaler" }}
+
+resource "linode_lke_cluster" "test" {
+    label       = "{{.Label}}"
+    region      = "us-central"
+    k8s_version = "1.20"
+    tags        = ["test"]
+    pool {
+        autoscaler {
+            min = 1
+            max = 5
+        }
+        type  = "g6-standard-2"
+        count = 3
+    }
+}
+
+{{ end }}

--- a/linode/lke/tmpl/autoscaler_many_pools.gotf
+++ b/linode/lke/tmpl/autoscaler_many_pools.gotf
@@ -1,0 +1,26 @@
+{{ define "lke_cluster_autoscaler_many_pools" }}
+
+resource "linode_lke_cluster" "test" {
+    label       = "{{.Label}}"
+    region      = "us-central"
+    k8s_version = "1.20"
+    tags        = ["test"]
+    pool {
+        autoscaler {
+            min = 3
+            max = 8
+        }
+        type  = "g6-standard-4"
+        count = 5
+    }
+    pool {
+        autoscaler {
+            min = 1
+            max = 8
+        }
+        type  = "g6-standard-2"
+        count = 3
+    }
+}
+
+{{ end }}

--- a/linode/lke/tmpl/autoscaler_updates.gotf
+++ b/linode/lke/tmpl/autoscaler_updates.gotf
@@ -1,0 +1,18 @@
+{{ define "lke_cluster_autoscaler_updates" }}
+
+resource "linode_lke_cluster" "test" {
+    label       = "{{.Label}}"
+    region      = "us-central"
+    k8s_version = "1.20"
+    tags        = ["test"]
+    pool {
+        autoscaler {
+            min = 1
+            max = 8
+        }
+        type  = "g6-standard-2"
+        count = 3
+    }
+}
+
+{{ end }}

--- a/linode/lke/tmpl/data_autoscaler.gotf
+++ b/linode/lke/tmpl/data_autoscaler.gotf
@@ -1,0 +1,9 @@
+{{ define "lke_cluster_data_autoscaler" }}
+
+{{ template "lke_cluster_autoscaler" . }}
+
+data "linode_lke_cluster" "test" {
+    id = linode_lke_cluster.test.id
+}
+
+{{ end }}

--- a/linode/lke/tmpl/template.go
+++ b/linode/lke/tmpl/template.go
@@ -34,7 +34,27 @@ func ComplexPools(t *testing.T, name string) string {
 		"lke_cluster_complex_pools", TemplateData{Label: name})
 }
 
+func Autoscaler(t *testing.T, name string) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_cluster_autoscaler", TemplateData{Label: name})
+}
+
+func AutoscalerUpdates(t *testing.T, name string) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_cluster_autoscaler_updates", TemplateData{Label: name})
+}
+
+func AutoscalerManyPools(t *testing.T, name string) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_cluster_autoscaler_many_pools", TemplateData{Label: name})
+}
+
 func DataBasic(t *testing.T, name string) string {
 	return acceptance.ExecuteTemplate(t,
 		"lke_cluster_data_basic", TemplateData{Label: name})
+}
+
+func DataAutoscaler(t *testing.T, name string) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_cluster_data_autoscaler", TemplateData{Label: name})
 }

--- a/website/docs/d/lke_cluster.html.md
+++ b/website/docs/d/lke_cluster.html.md
@@ -55,3 +55,9 @@ In addition to all arguments above, the following attributes are exported:
     * `instance_id` - The ID of the underlying Linode instance.
 
     * `status` - The status of the node. (`ready`, `not_ready`)
+
+  * `autoscaler` - The configuration options for the autoscaler. This field only contains an autoscaler configuration if autoscaling is enabled on this cluster.
+
+    * `min` - The minimum number of nodes to autoscale to.
+
+    * `max` - The maximum number of nodes to autoscale to.

--- a/website/docs/r/lke_cluster.html.md
+++ b/website/docs/r/lke_cluster.html.md
@@ -12,16 +12,39 @@ Manages an LKE cluster.
 
 ## Example Usage
 
+Creating a basic LKE cluster:
+
 ```terraform
 resource "linode_lke_cluster" "my-cluster" {
     label       = "my-cluster"
-    k8s_version = "1.20"
+    k8s_version = "1.21"
     region      = "us-central"
     tags        = ["prod"]
 
     pool {
         type  = "g6-standard-2"
         count = 3
+    }
+}
+```
+
+Creating an LKE cluster with autoscaler:
+
+```terraform
+resource "linode_lke_cluster" "my-cluster" {
+    label       = "my-cluster"
+    k8s_version = "1.21"
+    region      = "us-central"
+    tags        = ["prod"]
+
+    pool {
+        type  = "g6-standard-2"
+        count = 3
+
+        autoscaler {
+          min = 3
+          max = 10
+        }
     }
 }
 ```

--- a/website/docs/r/lke_cluster.html.md
+++ b/website/docs/r/lke_cluster.html.md
@@ -48,6 +48,16 @@ The following arguments are supported in the pool specification block:
 
 * `count` - (Required) The number of nodes in the Node Pool.
 
+* [`autoscaler`](#autoscaler) - (Optional) If defined, an autoscaler will be enabled with the given configuration.
+
+### autoscaler
+
+The following arguments are supported in the autoscaler specification block:
+
+* `min` - (Required) The minimum number of nodes to autoscale to.
+
+* `max` - (Required) The maximum number of nodes to autoscale to.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
This pull request adds support for configuring LKE cluster autoscalers through the `linode_lke_cluster` resource.

Example:
```hcl
resource "linode_lke_cluster" "test" {
    label       = "my-cluster"
    region      = "us-central"
    k8s_version = "1.21"
    tags        = ["test"]
    pool {
        autoscaler {
            min = 3
            max = 8
        }
        type  = "g6-standard-2"
        count = 3
    }
}
```

