### PR TITLE
Add ID field to linode_instances data source

### DIFF
--- a/linode/instance/datasource.go
+++ b/linode/instance/datasource.go
@@ -53,6 +53,9 @@ func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 			return diag.Errorf("failed to translate instance to map: %s", err)
 		}
 
+		// Merge additional fields
+		instanceMap["id"] = instance.ID
+
 		flattenedInstances[i] = instanceMap
 	}
 

--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -24,6 +24,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 				Config: tmpl.DataBasic(t, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "instances.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "instances.0.id"),
 					resource.TestCheckResourceAttr(resName, "instances.0.type", "g6-nanode-1"),
 					resource.TestCheckResourceAttr(resName, "instances.0.tags.#", "2"),
 					resource.TestCheckResourceAttr(resName, "instances.0.image", "linode/ubuntu18.04"),

--- a/linode/instance/schema_datasource.go
+++ b/linode/instance/schema_datasource.go
@@ -3,6 +3,11 @@ package instance
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 var instanceDataSourceSchema = map[string]*schema.Schema{
+	"id": {
+		Type:        schema.TypeInt,
+		Description: "The ID of the Linode instance.",
+		Computed:    true,
+	},
 	"image": {
 		Type: schema.TypeString,
 		Description: "An Image ID to deploy the Disk from. Official Linode Images start with linode/, while " +

--- a/website/docs/d/instances.html.md
+++ b/website/docs/d/instances.html.md
@@ -50,6 +50,8 @@ The following arguments are supported:
 
 Each Linode instance will be stored in the `instances` attribute and will export the following attributes:
 
+* `id` - The ID of the Linode instance.
+
 * `region` - This is the location where the Linode is deployed. Examples are `"us-east"`, `"us-west"`, `"ap-south"`, etc. See all regions [here](https://api.linode.com/v4/regions).
 
 * `type` - The Linode type defines the pricing, CPU, disk, and RAM specs of the instance. Examples are `"g6-nanode-1"`, `"g6-standard-2"`, `"g6-highmem-16"`, `"g6-dedicated-16"`, etc. See all types [here](https://api.linode.com/v4/linode/types).


### PR DESCRIPTION
This pull request adds the ID of each Linode instance to each result of the `linode_instances` data source.

Resolves #522 