### PR TITLE
Allow ForceNew disk attributes to be updated 

### DIFF
--- a/linode/instance/flatten.go
+++ b/linode/instance/flatten.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"fmt"
+
 	"github.com/linode/linodego"
 )
 

--- a/linode/instance/flatten.go
+++ b/linode/instance/flatten.go
@@ -3,7 +3,6 @@ package instance
 import (
 	"context"
 	"fmt"
-
 	"github.com/linode/linodego"
 )
 

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -404,6 +404,84 @@ func TestAccResourceInstance_disk(t *testing.T) {
 	})
 }
 
+func TestAccResourceInstance_diskMultiple(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_instance.foobar"
+	var instance linodego.Instance
+	instanceName := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CheckInstanceDestroy,
+
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Disk(t, instanceName, acceptance.PublicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
+					resource.TestCheckResourceAttr(resName, "region", "us-east"),
+					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
+					resource.TestCheckResourceAttr(resName, "swap_size", "0"),
+					resource.TestCheckResourceAttr(resName, "status", "offline"),
+					resource.TestCheckResourceAttr(resName, "config.#", "0"),
+					resource.TestCheckResourceAttr(resName, "disk.#", "1"),
+					resource.TestCheckResourceAttr(resName, "disk.0.size", "3000"),
+					resource.TestCheckResourceAttr(resName, "disk.0.label", "disk"),
+					checkComputeInstanceDisk(&instance, "disk", 3000),
+				),
+			},
+			{
+				Config: tmpl.DiskMultipleReadOnly(t, instanceName, acceptance.PublicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
+					resource.TestCheckResourceAttr(resName, "region", "us-east"),
+					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
+					resource.TestCheckResourceAttr(resName, "swap_size", "512"),
+					resource.TestCheckResourceAttr(resName, "status", "offline"),
+					resource.TestCheckResourceAttr(resName, "config.#", "0"),
+					resource.TestCheckResourceAttr(resName, "disk.#", "2"),
+					resource.TestCheckResourceAttr(resName, "disk.0.size", "3000"),
+					resource.TestCheckResourceAttr(resName, "disk.0.label", "disk"),
+					resource.TestCheckResourceAttr(resName, "disk.1.size", "512"),
+					resource.TestCheckResourceAttr(resName, "disk.1.label", "swap"),
+					resource.TestCheckResourceAttr(resName, "disk.1.read_only", "true"),
+					resource.TestCheckResourceAttr(resName, "disk.1.filesystem", "swap"),
+					checkComputeInstanceDisk(&instance, "disk", 3000),
+				),
+			},
+			{
+				Config: tmpl.Disk(t, instanceName, acceptance.PublicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
+					resource.TestCheckResourceAttr(resName, "region", "us-east"),
+					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
+					resource.TestCheckResourceAttr(resName, "swap_size", "0"),
+					resource.TestCheckResourceAttr(resName, "status", "offline"),
+					resource.TestCheckResourceAttr(resName, "config.#", "0"),
+					resource.TestCheckResourceAttr(resName, "disk.#", "1"),
+					resource.TestCheckResourceAttr(resName, "disk.0.size", "3000"),
+					resource.TestCheckResourceAttr(resName, "disk.0.label", "disk"),
+					checkComputeInstanceDisk(&instance, "disk", 3000),
+				),
+			},
+
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceInstance_diskImage(t *testing.T) {
 	t.Parallel()
 

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -583,7 +583,6 @@ var resourceSchema = map[string]*schema.Schema{
 					Type:         schema.TypeString,
 					Description:  "The Disk filesystem can be one of: raw, swap, ext3, ext4, initrd (max 32mb)",
 					Optional:     true,
-					ForceNew:     true,
 					Computed:     true,
 					ValidateFunc: validation.StringInSlice([]string{"raw", "swap", "ext3", "ext4", "initrd"}, false),
 				},
@@ -592,7 +591,6 @@ var resourceSchema = map[string]*schema.Schema{
 					Description: "If true, this Disk is read-only.",
 					Optional:    true,
 					Computed:    true,
-					ForceNew:    true,
 				},
 				"image": {
 					Type: schema.TypeString,
@@ -600,23 +598,13 @@ var resourceSchema = map[string]*schema.Schema{
 						"while your Images start with private/.",
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						// the API does not return this field for existing disks, so must be ignored for diffs/updates
-						return !d.HasChange("label")
-					},
 				},
 				"authorized_keys": {
 					Type: schema.TypeList,
 					Elem: &schema.Schema{Type: schema.TypeString},
 					Description: "A list of SSH public keys to deploy for the root user on the newly created Linode. " +
 						"Only accepted if 'image' is provided.",
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						// the API does not return this field for existing disks, so must be ignored for diffs/updates
-						return !d.HasChange("label")
-					},
 					Optional:  true,
-					ForceNew:  true,
 					StateFunc: sshKeyState,
 				},
 				"authorized_users": {
@@ -625,13 +613,7 @@ var resourceSchema = map[string]*schema.Schema{
 					Description: "A list of Linode usernames. If the usernames have associated SSH keys, " +
 						"the keys will be appended to the `root` user's `~/.ssh/authorized_keys` file automatically. " +
 						"Only accepted if 'image' is provided.",
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						// the API does not return this field for existing disks, so must be ignored for diffs/updates
-						return !d.HasChange("label")
-					},
-					Optional:  true,
-					ForceNew:  true,
-					StateFunc: sshKeyState,
+					Optional: true,
 				},
 				"stackscript_id": {
 					Type: schema.TypeInt,
@@ -639,12 +621,6 @@ var resourceSchema = map[string]*schema.Schema{
 						"must also be provided, and must be an Image that is compatible with this StackScript.",
 					Computed: true,
 					Optional: true,
-					ForceNew: true,
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						// the API does not return this field for existing disks, so must be ignored for diffs/updates
-						return !d.HasChange("label")
-					},
-					Default: nil,
 				},
 				"stackscript_data": {
 					Type: schema.TypeMap,
@@ -653,24 +629,13 @@ var resourceSchema = map[string]*schema.Schema{
 						"The required values depend on the StackScript being deployed.",
 					Optional:  true,
 					Computed:  true,
-					ForceNew:  true,
 					Sensitive: true,
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						// the API does not return this field for existing disks, so must be ignored for diffs/updates
-						return !d.HasChange("label")
-					},
-					Default: nil,
 				},
 				"root_pass": {
-					Type:        schema.TypeString,
-					Description: "The password that will be initialially assigned to the 'root' user account.",
-					Sensitive:   true,
-					Optional:    true,
-					ForceNew:    true,
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						// the API does not return this field for existing disks, so must be ignored for diffs/updates
-						return !d.HasChange("label")
-					},
+					Type:         schema.TypeString,
+					Description:  "The password that will be initialially assigned to the 'root' user account.",
+					Sensitive:    true,
+					Optional:     true,
 					ValidateFunc: validation.StringLenBetween(6, 128),
 					StateFunc:    rootPasswordState,
 				},

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -196,6 +196,14 @@ func DiskMultiple(t *testing.T, label, pubKey string) string {
 		})
 }
 
+func DiskMultipleReadOnly(t *testing.T, label, pubKey string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_disk_multiple_readonly", TemplateData{
+			Label:  label,
+			PubKey: pubKey,
+		})
+}
+
 func DiskConfig(t *testing.T, label, pubKey string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_config", TemplateData{

--- a/linode/instance/tmpl/templates/disk_config_multiple_readonly.gotf
+++ b/linode/instance/tmpl/templates/disk_config_multiple_readonly.gotf
@@ -1,0 +1,25 @@
+{{ define "instance_disk_multiple_readonly" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    type = "g6-nanode-1"
+    region = "us-east"
+    group = "tf_test"
+
+    disk {
+        label = "disk"
+        image = "linode/ubuntu18.04"
+        root_pass = "b4d_p4s5"
+        authorized_keys = ["{{.PubKey}}"]
+        size = 3000
+    }
+
+    disk {
+        label = "swap"
+        filesystem = "swap"
+        size = 512
+        read_only = true
+    }
+}
+
+{{ end }}


### PR DESCRIPTION
This pull request fixes previously nonfunctional update logic for certain `ForceNew` disk fields in `linode_instance`.

Changes:
TODO 

Resolves #525 
Resolves #520 