### PR TITLE
Update Terraform logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
+<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-terraform-main.svg" width="600px">
 
 ## Maintainers
 


### PR DESCRIPTION
The name of the upstream Terraform logo has been changed from `logo-hashicorp.svg` to `logo-terraform-main.svg`.