### PR TITLE
Add `linode_stackscripts` data source

### DIFF
--- a/linode/helper/filter.go
+++ b/linode/helper/filter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -258,4 +259,30 @@ func validateFilterRegex(values []string, result string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func GetLatestCreated(data []map[string]interface{}) map[string]interface{} {
+	var latestCreated time.Time
+	var latestEntity map[string]interface{}
+
+	for _, image := range data {
+		created, ok := image["created"]
+		if !ok {
+			continue
+		}
+
+		createdTime, err := time.Parse(time.RFC3339, created.(string))
+		if err != nil {
+			return nil
+		}
+
+		if latestEntity != nil && !createdTime.After(latestCreated) {
+			continue
+		}
+
+		latestCreated = createdTime
+		latestEntity = image
+	}
+
+	return latestEntity
 }

--- a/linode/images/datasource.go
+++ b/linode/images/datasource.go
@@ -1,15 +1,14 @@
 package images
 
 import (
+	"context"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper"
-
-	"context"
-	"strconv"
 )
 
 func DataSource() *schema.Resource {
@@ -52,7 +51,7 @@ func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	if latestFlag {
-		latestImage := getLatestImage(imagesFiltered)
+		latestImage := helper.GetLatestCreated(imagesFiltered)
 
 		if latestImage != nil {
 			imagesFiltered = []map[string]interface{}{latestImage}
@@ -100,30 +99,4 @@ func imageValueToFilterType(filterName, value string) (interface{}, error) {
 	}
 
 	return value, nil
-}
-
-func getLatestImage(images []map[string]interface{}) map[string]interface{} {
-	var latestCreated time.Time
-	var latestImage map[string]interface{}
-
-	for _, image := range images {
-		created, ok := image["created"]
-		if !ok {
-			continue
-		}
-
-		createdTime, err := time.Parse(time.RFC3339, created.(string))
-		if err != nil {
-			return nil
-		}
-
-		if latestImage != nil && !createdTime.After(latestCreated) {
-			continue
-		}
-
-		latestCreated = createdTime
-		latestImage = image
-	}
-
-	return latestImage
 }

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/region"
 	"github.com/linode/terraform-provider-linode/linode/sshkey"
 	"github.com/linode/terraform-provider-linode/linode/stackscript"
+	"github.com/linode/terraform-provider-linode/linode/stackscripts"
 	"github.com/linode/terraform-provider-linode/linode/token"
 	"github.com/linode/terraform-provider-linode/linode/user"
 	"github.com/linode/terraform-provider-linode/linode/vlan"
@@ -139,6 +140,7 @@ func Provider() *schema.Provider {
 			"linode_region":                 region.DataSource(),
 			"linode_sshkey":                 sshkey.DataSource(),
 			"linode_stackscript":            stackscript.DataSource(),
+			"linode_stackscripts":           stackscripts.DataSource(),
 			"linode_user":                   user.DataSource(),
 			"linode_vlans":                  vlan.DataSource(),
 			"linode_volume":                 volume.DataSource(),

--- a/linode/stackscript/helpers.go
+++ b/linode/stackscript/helpers.go
@@ -11,16 +11,26 @@ func setStackScriptUserDefinedFields(d *schema.ResourceData, ss *linodego.Stacks
 		return
 	}
 
-	udfs := []map[string]string{}
-	for _, udf := range *ss.UserDefinedFields {
-		udfs = append(udfs, map[string]string{
+	udfs := GetStackScriptUserDefinedFields(ss)
+	d.Set("user_defined_fields", udfs)
+}
+
+func GetStackScriptUserDefinedFields(ss *linodego.Stackscript) []map[string]string {
+	if ss.UserDefinedFields == nil {
+		return nil
+	}
+
+	result := make([]map[string]string, len(*ss.UserDefinedFields))
+	for i, udf := range *ss.UserDefinedFields {
+		result[i] = map[string]string{
 			"default": udf.Default,
 			"example": udf.Example,
 			"many_of": udf.ManyOf,
 			"one_of":  udf.OneOf,
 			"label":   udf.Label,
 			"name":    udf.Name,
-		})
+		}
 	}
-	d.Set("user_defined_fields", udfs)
+
+	return result
 }

--- a/linode/stackscripts/datasource.go
+++ b/linode/stackscripts/datasource.go
@@ -1,0 +1,106 @@
+package stackscripts
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+	"github.com/linode/terraform-provider-linode/linode/stackscript"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		Schema:      dataSourceSchema,
+		ReadContext: readDataSource,
+	}
+}
+
+func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	latestFlag := d.Get("latest").(bool)
+
+	filterID, err := helper.GetFilterID(d)
+	if err != nil {
+		return diag.Errorf("failed to generate filter id: %s", err)
+	}
+
+	filter, err := helper.ConstructFilterString(d, scriptValueToFilterType)
+	if err != nil {
+		return diag.Errorf("failed to construct filter: %s", err)
+	}
+
+	scripts, err := client.ListStackscripts(ctx, &linodego.ListOptions{
+		Filter: filter,
+	})
+	if err != nil {
+		return diag.Errorf("failed to list linode scripts: %s", err)
+	}
+
+	scriptsFlattened := make([]interface{}, len(scripts))
+	for i, image := range scripts {
+		scriptsFlattened[i] = flattenStackScript(&image)
+	}
+
+	scriptsFiltered, err := helper.FilterResults(d, scriptsFlattened)
+	if err != nil {
+		return diag.Errorf("failed to filter returned scripts: %s", err)
+	}
+
+	if latestFlag {
+		latestScript := helper.GetLatestCreated(scriptsFiltered)
+
+		if latestScript != nil {
+			scriptsFiltered = []map[string]interface{}{latestScript}
+		}
+	}
+
+	d.SetId(filterID)
+	d.Set("stackscripts", scriptsFiltered)
+
+	return nil
+}
+
+func flattenStackScript(script *linodego.Stackscript) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	result["id"] = script.ID
+	result["label"] = script.Label
+	result["script"] = script.Script
+	result["description"] = script.Description
+	result["rev_note"] = script.RevNote
+	result["is_public"] = script.IsPublic
+	result["images"] = script.Images
+	result["user_gravatar_id"] = script.UserGravatarID
+	result["deployments_active"] = script.DeploymentsActive
+	result["deployments_total"] = script.DeploymentsTotal
+	result["username"] = script.Username
+
+	if script.Created != nil {
+		result["created"] = script.Created.Format(time.RFC3339)
+	}
+
+	if script.Updated != nil {
+		result["updated"] = script.Updated.Format(time.RFC3339)
+	}
+
+	result["user_defined_fields"] = stackscript.GetStackScriptUserDefinedFields(script)
+
+	return result
+}
+
+func scriptValueToFilterType(filterName, value string) (interface{}, error) {
+	switch filterName {
+	case "deprecated", "mine":
+		return strconv.ParseBool(value)
+
+	case "deployments_total":
+		return strconv.Atoi(value)
+	}
+
+	return value, nil
+}

--- a/linode/stackscripts/datasource_test.go
+++ b/linode/stackscripts/datasource_test.go
@@ -1,0 +1,74 @@
+package stackscripts_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/stackscripts/tmpl"
+)
+
+var basicStackScript = `#!/bin/bash
+#<UDF name="name" label="Your name" example="Linus Torvalds" default="user">
+# NAME=
+echo "Hello, $NAME!"
+`
+
+func TestAccDataSourceStackscripts_basic(t *testing.T) {
+	t.Parallel()
+
+	stackScriptName := acctest.RandomWithPrefix("tf_test")
+
+	resourceName := "data.linode_stackscripts.stackscript"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, stackScriptName, basicStackScript),
+				Check: resource.ComposeTestCheckFunc(
+					validateStackscript(resourceName, stackScriptName),
+				),
+			},
+			{
+				Config: tmpl.DataSubString(t, stackScriptName, basicStackScript),
+				Check: resource.ComposeTestCheckFunc(
+					validateStackscript(resourceName, stackScriptName),
+				),
+			},
+			{
+				Config: tmpl.DataLatest(t, stackScriptName, basicStackScript),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "stackscripts.#", "1"),
+					validateStackscript(resourceName, stackScriptName),
+				),
+			},
+		},
+	})
+}
+
+func validateStackscript(resourceName, stackScriptName string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttrSet(resourceName, "stackscripts.0.id"),
+		resource.TestCheckResourceAttrSet(resourceName, "stackscripts.0.deployments_active"),
+		resource.TestCheckResourceAttrSet(resourceName, "stackscripts.0.deployments_total"),
+		resource.TestCheckResourceAttrSet(resourceName, "stackscripts.0.username"),
+		resource.TestCheckResourceAttrSet(resourceName, "stackscripts.0.created"),
+		resource.TestCheckResourceAttrSet(resourceName, "stackscripts.0.updated"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.label", stackScriptName),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.description", "test"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.is_public", "false"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.rev_note", "initial"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.script", basicStackScript),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.images.#", "2"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.images.0", "linode/ubuntu18.04"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.images.1", "linode/ubuntu16.04lts"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.user_defined_fields.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.user_defined_fields.0.name", "name"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.user_defined_fields.0.label", "Your name"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.user_defined_fields.0.default", "user"),
+		resource.TestCheckResourceAttr(resourceName, "stackscripts.0.user_defined_fields.0.example", "Linus Torvalds"),
+	)
+}

--- a/linode/stackscripts/schema_datasource.go
+++ b/linode/stackscripts/schema_datasource.go
@@ -1,0 +1,146 @@
+package stackscripts
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+var filterableFields = []string{"deployments_total", "description",
+	"is_public", "label", "mine", "rev_note"}
+
+var dataSourceSchema = map[string]*schema.Schema{
+	"latest": {
+		Type:        schema.TypeBool,
+		Description: "If true, only the latest StackScript will be returned.",
+		Optional:    true,
+		Default:     false,
+	},
+	"order_by": helper.OrderBySchema(filterableFields),
+	"order":    helper.OrderSchema(),
+	"filter":   helper.FilterSchema(filterableFields),
+	"stackscripts": {
+		Type:        schema.TypeList,
+		Description: "The returned list of StackScripts.",
+		Computed:    true,
+		Elem:        stackScriptSchema(),
+	},
+}
+
+func stackScriptSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeInt,
+				Description: "The unique ID of this Stackscript.",
+				Computed:    true,
+			},
+			"label": {
+				Type:        schema.TypeString,
+				Description: "The StackScript's label is for display purposes only.",
+				Computed:    true,
+			},
+			"script": {
+				Type:        schema.TypeString,
+				Description: "The script to execute when provisioning a new Linode with this StackScript.",
+				Computed:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "A description for the StackScript.",
+				Computed:    true,
+			},
+			"rev_note": {
+				Type:        schema.TypeString,
+				Description: "This field allows you to add notes for the set of revisions made to this StackScript.",
+				Computed:    true,
+			},
+			"is_public": {
+				Type: schema.TypeBool,
+				Description: "This determines whether other users can use your StackScript. Once a StackScript is " +
+					"made public, it cannot be made private.",
+				Computed: true,
+			},
+			"images": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{Type: schema.TypeString},
+				Description: "An array of Image IDs representing the Images that this StackScript is compatible for " +
+					"deploying with.",
+				Computed: true,
+			},
+
+			"deployments_active": {
+				Type:        schema.TypeInt,
+				Description: "Count of currently active, deployed Linodes created from this StackScript.",
+				Computed:    true,
+			},
+			"user_gravatar_id": {
+				Type:        schema.TypeString,
+				Description: "The Gravatar ID for the User who created the StackScript.",
+				Computed:    true,
+			},
+			"deployments_total": {
+				Type:        schema.TypeInt,
+				Description: "The total number of times this StackScript has been deployed.",
+				Computed:    true,
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Description: "The User who created the StackScript.",
+				Computed:    true,
+			},
+			"created": {
+				Type:        schema.TypeString,
+				Description: "The date this StackScript was created.",
+				Computed:    true,
+			},
+			"updated": {
+				Type:        schema.TypeString,
+				Description: "The date this StackScript was updated.",
+				Computed:    true,
+			},
+			"user_defined_fields": {
+				Description: "This is a list of fields defined with a special syntax inside this StackScript that " +
+					"allow for supplying customized parameters during deployment.",
+				Type:       schema.TypeList,
+				Computed:   true,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"label": {
+							Type: schema.TypeString,
+							Description: "A human-readable label for the field that will serve as the " +
+								"input prompt for entering the value during deployment.",
+							Computed: true,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "The name of the field.",
+							Computed:    true,
+						},
+						"example": {
+							Type:        schema.TypeString,
+							Description: "An example value for the field.",
+							Computed:    true,
+						},
+						"one_of": {
+							Type:        schema.TypeString,
+							Description: "A list of acceptable single values for the field.",
+							Computed:    true,
+						},
+						"many_of": {
+							Type:        schema.TypeString,
+							Description: "A list of acceptable values for the field in any quantity, combination or order.",
+							Computed:    true,
+						},
+						"default": {
+							Type:        schema.TypeString,
+							Description: "The default value. If not specified, this value will be used.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/linode/stackscripts/tmpl/data_basic.gotf
+++ b/linode/stackscripts/tmpl/data_basic.gotf
@@ -1,0 +1,24 @@
+{{ define "stackscripts_data_basic" }}
+
+resource "linode_stackscript" "stackscript" {
+    label = "{{.Label}}"
+    script = <<EOF
+{{.Script}}EOF
+	images = ["linode/ubuntu18.04", "linode/ubuntu16.04lts"]
+	description = "test"
+	rev_note = "initial"
+}
+
+data "linode_stackscripts" "stackscript" {
+	filter {
+		name = "label"
+		values = [linode_stackscript.stackscript.label]
+	}
+
+	filter {
+		name = "is_public"
+		values = [false]
+	}
+}
+
+{{ end }}

--- a/linode/stackscripts/tmpl/data_latest.gotf
+++ b/linode/stackscripts/tmpl/data_latest.gotf
@@ -1,0 +1,38 @@
+{{ define "stackscripts_data_latest" }}
+
+resource "linode_stackscript" "stackscript" {
+    label = "{{.Label}}"
+    script = <<EOF
+{{.Script}}EOF
+	images = ["linode/ubuntu18.04", "linode/ubuntu16.04lts"]
+	description = "test"
+	rev_note = "initial"
+}
+
+resource "linode_stackscript" "stackscript2" {
+	depends_on = [linode_stackscript.stackscript]
+
+	label = "{{.Label}}-1"
+	script = <<EOF
+{{.Script}}EOF
+	images = ["linode/ubuntu18.04", "linode/ubuntu16.04lts"]
+	description = "test"
+	rev_note = "initial"
+}
+
+data "linode_stackscripts" "stackscript" {
+	latest = true
+
+	filter {
+		name = "label"
+		values = [linode_stackscript.stackscript.label]
+		match_by = "substring"
+	}
+
+	filter {
+		name = "is_public"
+		values = [false]
+	}
+}
+
+{{ end }}

--- a/linode/stackscripts/tmpl/data_substring.gotf
+++ b/linode/stackscripts/tmpl/data_substring.gotf
@@ -1,0 +1,25 @@
+{{ define "stackscripts_data_substring" }}
+
+resource "linode_stackscript" "stackscript" {
+    label = "{{.Label}}"
+    script = <<EOF
+{{.Script}}EOF
+	images = ["linode/ubuntu18.04", "linode/ubuntu16.04lts"]
+	description = "test"
+	rev_note = "initial"
+}
+
+data "linode_stackscripts" "stackscript" {
+	filter {
+		name = "label"
+		values = [linode_stackscript.stackscript.label]
+		match_by = "substring"
+	}
+
+	filter {
+		name = "is_public"
+		values = [false]
+	}
+}
+
+{{ end }}

--- a/linode/stackscripts/tmpl/template.go
+++ b/linode/stackscripts/tmpl/template.go
@@ -1,0 +1,36 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+type TemplateData struct {
+	Label  string
+	Script string
+}
+
+func DataBasic(t *testing.T, label, script string) string {
+	return acceptance.ExecuteTemplate(t,
+		"stackscripts_data_basic", TemplateData{
+			Label:  label,
+			Script: script,
+		})
+}
+
+func DataSubString(t *testing.T, label, script string) string {
+	return acceptance.ExecuteTemplate(t,
+		"stackscripts_data_substring", TemplateData{
+			Label:  label,
+			Script: script,
+		})
+}
+
+func DataLatest(t *testing.T, label, script string) string {
+	return acceptance.ExecuteTemplate(t,
+		"stackscripts_data_latest", TemplateData{
+			Label:  label,
+			Script: script,
+		})
+}

--- a/website/docs/d/stackscripts.html.md
+++ b/website/docs/d/stackscripts.html.md
@@ -1,0 +1,107 @@
+---
+layout: "linode"
+page_title: "Linode: linode_stackscripts"
+sidebar_current: "docs-linode-datasource-stackscripts"
+description: |-
+Provides information about Linode StackScripts that match a set of filters.
+---
+
+# linode\_stackscripts
+
+Provides information about Linode StackScripts that match a set of filters.
+
+## Example Usage
+
+The following example shows how one might use this data source to access information about a Linode StackScript.
+
+```hcl
+data "linode_stackscripts" "specific-stackscripts" {
+  filter {
+    name = "label"
+    values = ["my-cool-stackscript"]
+  }
+
+  filter {
+    name = "is_public"
+    values = [false]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `latest` - (Optional) If true, only the latest StackScript will be returned. StackScripts without a valid `created` field are not included in the result.
+
+* [`filter`](#filter) - (Optional) A set of filters used to select Linode StackScripts that meet certain requirements.
+
+* `order_by` - (Optional) The attribute to order the results by. See the [Filterable Fields section](#filterable-fields) for a list of valid fields.
+
+* `order` - (Optional) The order in which results should be returned. (`asc`, `desc`; default `asc`)
+
+### Filter
+
+* `name` - (Required) The name of the field to filter by. See the [Filterable Fields section](#filterable-fields) for a complete list of filterable fields.
+
+* `values` - (Required) A list of values for the filter to allow. These values should all be in string form.
+
+* `match_by` - (Optional) The method to match the field by. (`exact`, `regex`, `substring`; default `exact`)
+
+## Attributes
+
+Each Linode StackScript will be stored in the `stackscripts` attribute and will export the following attributes:
+
+* `id` - The unique ID of the StackScript.
+
+* `label` - The StackScript's label is for display purposes only.
+
+* `script` - The script to execute when provisioning a new Linode with this StackScript.
+
+* `description` - A description for the StackScript.
+
+* `rev_note` - This field allows you to add notes for the set of revisions made to this StackScript.
+
+* `is_public` - This determines whether other users can use your StackScript. Once a StackScript is made public, it cannot be made private.
+
+* `images` - An array of Image IDs representing the Images that this StackScript is compatible for deploying with.
+
+* `deployments_active` - Count of currently active, deployed Linodes created from this StackScript.
+
+* `user_gravatar_id` - The Gravatar ID for the User who created the StackScript.
+
+* `deployments_total` - The total number of times this StackScript has been deployed.
+
+* `username` - The User who created the StackScript.
+
+* `created` - The date this StackScript was created.
+
+* `updated` - The date this StackScript was updated.
+
+* `user_defined_fields` - This is a list of fields defined with a special syntax inside this StackScript that allow for supplying customized parameters during deployment.
+
+  * `label` - A human-readable label for the field that will serve as the input prompt for entering the value during deployment.
+
+  * `name` - The name of the field.
+
+  * `example` - An example value for the field.
+
+  * `one_of` - A list of acceptable single values for the field.
+
+  * `many_of` - A list of acceptable values for the field in any quantity, combination or order.
+
+  * `default` - The default value. If not specified, this value will be used.
+
+## Filterable Fields
+
+* `deployments_total`
+
+* `description`
+
+* `is_public`
+
+* `label`
+
+* `mine`
+
+* `rev_note`

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -70,8 +70,11 @@
             <li<%= sidebar_current("docs-linode-datasource-sshkey") %>>
               <a href="/docs/providers/linode/d/sshkey.html">linode_sshkey</a>
             </li>
-            <li<%= sidebar_current("docs-linode-resource-stackscript") %>>
+            <li<%= sidebar_current("docs-linode-datasource-stackscript") %>>
               <a href="/docs/providers/linode/d/stackscript.html">linode_stackscript</a>
+            </li>
+            <li<%= sidebar_current("docs-linode-datasource-stackscripts") %>>
+              <a href="/docs/providers/linode/d/stackscripts.html">linode_stackscripts</a>
             </li>
             <li<%= sidebar_current("docs-linode-datasource-user") %>>
               <a href="/docs/providers/linode/d/user.html">linode_user</a>


### PR DESCRIPTION
This pull request allows users to obtain a filtered list of StackScripts using the provider's filter data source framework.

For example:
```hcl
data "linode_stackscripts" "specific-stackscripts" {
  filter {
    name = "label"
    values = ["my-cool-stackscript"]
  }

  filter {
    name = "is_public"
    values = [false]
  }
}
```