### PR TITLE
Avoid unnecessary requests in `linode_instances` data source

### DIFF
--- a/linode/instance/flatten.go
+++ b/linode/instance/flatten.go
@@ -36,6 +36,7 @@ func flattenInstance(
 		result["private_ip_address"] = private[0].Address
 	}
 
+	result["id"] = instance.ID
 	result["label"] = instance.Label
 	result["status"] = instance.Status
 	result["type"] = instance.Type
@@ -196,4 +197,30 @@ func flattenInstanceSpecs(instance linodego.Instance) []map[string]int {
 		"memory":   instance.Specs.Memory,
 		"transfer": instance.Specs.Transfer,
 	}}
+}
+
+func flattenInstanceSimple(instance *linodego.Instance) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+
+	var ips []string
+	for _, ip := range instance.IPv4 {
+		ips = append(ips, ip.String())
+	}
+
+	result["id"] = instance.ID
+	result["ipv4"] = ips
+	result["ipv6"] = instance.IPv6
+	result["label"] = instance.Label
+	result["status"] = instance.Status
+	result["type"] = instance.Type
+	result["region"] = instance.Region
+	result["watchdog_enabled"] = instance.WatchdogEnabled
+	result["group"] = instance.Group
+	result["tags"] = instance.Tags
+	result["image"] = instance.Image
+	result["backups"] = flattenInstanceBackups(*instance)
+	result["specs"] = flattenInstanceSpecs(*instance)
+	result["alerts"] = flattenInstanceAlerts(*instance)
+
+	return result, nil
 }

--- a/linode/instance/tmpl/templates/data_multiple_regex.gotf
+++ b/linode/instance/tmpl/templates/data_multiple_regex.gotf
@@ -1,27 +1,9 @@
 {{ define "instance_data_multiple_regex" }}
 
-resource "linode_instance" "foobar-0" {
-    label = "{{.Label}}-0"
-    group = "{{.Group}}"
-    tags = ["cool", "cooler"]
-    type = "g6-nanode-1"
-    image = "linode/ubuntu18.04"
-    region = "us-east"
-    root_pass = "terraform-test"
-}
+resource "linode_instance" "foobar" {
+    count = 3
 
-resource "linode_instance" "foobar-1" {
-    label = "{{.Label}}-1"
-    group = "{{.Group}}"
-    tags = ["cool", "cooler"]
-    type = "g6-nanode-1"
-    image = "linode/ubuntu18.04"
-    region = "us-east"
-    root_pass = "terraform-test"
-}
-
-resource "linode_instance" "foobar-2" {
-    label = "{{.Label}}-2"
+    label = "{{.Label}}-${count.index}"
     group = "{{.Group}}"
     tags = ["cool", "cooler"]
     type = "g6-nanode-1"
@@ -32,9 +14,7 @@ resource "linode_instance" "foobar-2" {
 
 data "linode_instances" "foobar" {
     depends_on = [
-        linode_instance.foobar-0,
-        linode_instance.foobar-1,
-        linode_instance.foobar-2
+        linode_instance.foobar,
     ]
 
     filter {


### PR DESCRIPTION
This change prevents additional API requests from being made when collecting instances for client-side filtering. Instances are now flattened into a simple and filterable map for the initial filtering pass and additional requests are made for the remaining instances. This change additionally prevents race conditions between concurrent actions on separate Linodes.