### PR TITLE
Resolve issue with 'linode_resize' event polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ website/vendor
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/
+
+# Binary exclusions
+terraform-provider-linode

--- a/linode/helper/events.go
+++ b/linode/helper/events.go
@@ -1,0 +1,42 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/linode/linodego"
+)
+
+// GetLatestEvent returns the latest Linode event with the given arguments.
+func GetLatestEvent(ctx context.Context, client *linodego.Client,
+	entityID int, entityType linodego.EntityType, action linodego.EventAction) (*linodego.Event, error) {
+	filter := linodego.Filter{
+		Order:   linodego.Descending,
+		OrderBy: "created",
+	}
+	filter.AddField(linodego.Eq, "action", action)
+	filter.AddField(linodego.Eq, "entity.id", entityID)
+	filter.AddField(linodego.Eq, "entity.type", entityType)
+
+	filterStr, err := filter.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	listOptions := linodego.ListOptions{
+		PageOptions: &linodego.PageOptions{Page: 1},
+		PageSize:    25,
+		Filter:      string(filterStr),
+	}
+
+	events, err := client.ListEvents(ctx, &listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(events) < 1 {
+		return nil, fmt.Errorf("failed to get event %s of %s (%d)", action, entityType, entityID)
+	}
+
+	return &events[0], nil
+}


### PR DESCRIPTION
This pull request is necessary as `linode_resize` events are scheduled to be created long after the initial resize request. When a Linode resize is triggered, a `linode_resize_create` event is created to show that a `linode_resize` event has been scheduled to be created. In order to ensure we're polling on the correct event, we need use the creation date of the pre-resize event.

#545 