### PR TITLE
Do not reattach already-attached volumes on `linode_instance` config updates

### DIFF
--- a/linode/helper/events.go
+++ b/linode/helper/events.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/linode/linodego"
 )
@@ -35,7 +34,7 @@ func GetLatestEvent(ctx context.Context, client *linodego.Client,
 	}
 
 	if len(events) < 1 {
-		return nil, fmt.Errorf("failed to get event %s of %s (%d)", action, entityType, entityID)
+		return nil, nil
 	}
 
 	return &events[0], nil

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -966,6 +966,44 @@ func TestAccResourceInstance_tag(t *testing.T) {
 	})
 }
 
+func TestAccResourceInstance_tagWithVolume(t *testing.T) {
+	t.Parallel()
+
+	var instance linodego.Instance
+
+	label := acctest.RandomWithPrefix("tf_test")
+
+	instanceResName := "linode_instance.foobar"
+	volumeResName := "linode_volume.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.TagVolume(t, label, "tf_test"),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(instanceResName, &instance),
+					resource.TestCheckResourceAttr(instanceResName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(instanceResName, "tags.0", "tf_test"),
+				),
+			},
+			{
+				Config: tmpl.TagVolume(t, label, "tf_test_updated"),
+				Check: resource.ComposeTestCheckFunc(
+					// Ensure the volume is not detached
+					acceptance.CheckEventAbsent(volumeResName, "volume", linodego.ActionVolumeDetach),
+
+					acceptance.CheckInstanceExists(instanceResName, &instance),
+					resource.TestCheckResourceAttr(instanceResName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(instanceResName, "tags.0", "tf_test_updated"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceInstance_diskRawDeleted(t *testing.T) {
 	t.Parallel()
 	var instance linodego.Instance

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -12,6 +12,7 @@ type TemplateData struct {
 	Type   string
 	Image  string
 	Group  string
+	Tag    string
 
 	SwapSize int
 
@@ -170,6 +171,14 @@ func TagUpdate(t *testing.T, label string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_tag_update", TemplateData{
 			Label: label,
+		})
+}
+
+func TagVolume(t *testing.T, label, tag string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_tag_volume", TemplateData{
+			Label: label,
+			Tag:   tag,
 		})
 }
 

--- a/linode/instance/tmpl/templates/tag_volume.gotf
+++ b/linode/instance/tmpl/templates/tag_volume.gotf
@@ -1,0 +1,26 @@
+{{ define "instance_tag_volume" }}
+
+resource "linode_volume" "foobar" {
+    label  = "{{.Label}}"
+    region = "us-southeast"
+    size = 20
+}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    tags = ["{{.Tag}}"]
+    type = "g6-nanode-1"
+    region = "us-southeast"
+
+    config {
+        label = "config"
+        kernel = "linode/latest-64bit"
+        devices {
+            sda {
+                volume_id = linode_volume.foobar.id
+            }
+        }
+    }
+}
+
+{{ end }}


### PR DESCRIPTION
This pull request reduces the number of hidden Block Storage volume reattachments by only detaching/attaching a volume if it is not already attached to the Instance.