### PR TITLE
Add `linode_firewall_device` resource

### DIFF
--- a/linode/acceptance/test_util.go
+++ b/linode/acceptance/test_util.go
@@ -313,6 +313,35 @@ func CheckVolumeExists(name string, volume *linodego.Volume) resource.TestCheckF
 	}
 }
 
+func CheckFirewallExists(name string, firewall *linodego.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := TestAccProvider.Meta().(*helper.ProviderMeta).Client
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error parsing %v to int", rs.Primary.ID)
+		}
+
+		found, err := client.GetFirewall(context.Background(), id)
+		if err != nil {
+			return fmt.Errorf("Error retrieving state of Firewall %s: %s", rs.Primary.Attributes["label"], err)
+		}
+
+		*firewall = *found
+
+		return nil
+	}
+}
+
 func ExecuteTemplate(t *testing.T, templateName string, data interface{}) string {
 	var b bytes.Buffer
 

--- a/linode/firewall/resource_test.go
+++ b/linode/firewall/resource_test.go
@@ -3,12 +3,10 @@ package firewall_test
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/linode/firewall/tmpl"
@@ -361,7 +359,7 @@ func TestAccLinodeFirewall_externalDelete(t *testing.T) {
 						acceptance.SkipInstanceReadyPollKey: true,
 					}),
 				Check: resource.ComposeTestCheckFunc(
-					checkFirewallExists(testFirewallResName, &firewall),
+					acceptance.CheckFirewallExists(testFirewallResName, &firewall),
 					resource.TestCheckResourceAttr(testFirewallResName, "label", name),
 					resource.TestCheckResourceAttr(testFirewallResName, "disabled", "false"),
 					resource.TestCheckResourceAttr(testFirewallResName, "inbound_policy", "DROP"),
@@ -403,7 +401,7 @@ func TestAccLinodeFirewall_externalDelete(t *testing.T) {
 						acceptance.SkipInstanceReadyPollKey: true,
 					}),
 				Check: resource.ComposeTestCheckFunc(
-					checkFirewallExists(testFirewallResName, &firewall),
+					acceptance.CheckFirewallExists(testFirewallResName, &firewall),
 					resource.TestCheckResourceAttr(testFirewallResName, "label", name),
 					resource.TestCheckResourceAttr(testFirewallResName, "disabled", "false"),
 					resource.TestCheckResourceAttr(testFirewallResName, "inbound_policy", "DROP"),
@@ -468,33 +466,4 @@ func TestAccLinodeFirewall_emptyIPv6(t *testing.T) {
 			},
 		},
 	})
-}
-
-func checkFirewallExists(name string, firewall *linodego.Firewall) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.TestAccProvider.Meta().(*helper.ProviderMeta).Client
-
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		id, err := strconv.Atoi(rs.Primary.ID)
-		if err != nil {
-			return fmt.Errorf("Error parsing %v to int", rs.Primary.ID)
-		}
-
-		found, err := client.GetFirewall(context.Background(), id)
-		if err != nil {
-			return fmt.Errorf("Error retrieving state of Firewall %s: %s", rs.Primary.Attributes["label"], err)
-		}
-
-		*firewall = *found
-
-		return nil
-	}
 }

--- a/linode/firewall/schema_resource.go
+++ b/linode/firewall/schema_resource.go
@@ -128,6 +128,7 @@ var resourceSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeInt},
 		Description: "The IDs of Linodes to apply this firewall to.",
 		Optional:    true,
+		Computed:    true,
 		Set:         schema.HashInt,
 	},
 	"devices": {

--- a/linode/firewalldevice/resource.go
+++ b/linode/firewalldevice/resource.go
@@ -113,7 +113,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	firewallID, ok := d.Get("firewall_id").(int)
 	if !ok {
-		return diag.Errorf("Error parsing Linode Firewall Device ID %v as int", d.Get("nodebalancer_id"))
+		return diag.Errorf("Error parsing Linode Firewall Device ID %v as int", d.Get("firewall_id"))
 	}
 
 	err = client.DeleteFirewallDevice(ctx, firewallID, int(id))

--- a/linode/firewalldevice/resource.go
+++ b/linode/firewalldevice/resource.go
@@ -1,0 +1,124 @@
+package firewalldevice
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func Resource() *schema.Resource {
+	return &schema.Resource{
+		Schema:        resourceSchema,
+		ReadContext:   readResource,
+		CreateContext: createResource,
+		DeleteContext: deleteResource,
+		Importer: &schema.ResourceImporter{
+			StateContext: importResource,
+		},
+	}
+}
+
+func importResource(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if strings.Contains(d.Id(), ",") {
+		s := strings.Split(d.Id(), ",")
+		_, err := strconv.Atoi(s[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid firewall device ID: %v", err)
+		}
+
+		firewallID, err := strconv.Atoi(s[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid firewall ID: %v", err)
+		}
+
+		d.SetId(s[1])
+		d.Set("firewall_id", firewallID)
+	}
+
+	err := readResource(ctx, d, meta)
+	if err != nil {
+		return nil, fmt.Errorf("unable to import %v as firewall_device: %v", d.Id(), err)
+	}
+
+	results := make([]*schema.ResourceData, 0)
+	results = append(results, d)
+
+	return results, nil
+}
+
+func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return diag.Errorf("Error parsing Linode Firewall ID %s as int: %s", d.Id(), err)
+	}
+
+	firewallID := d.Get("firewall_id").(int)
+
+	device, err := client.GetFirewallDevice(ctx, firewallID, int(id))
+	if err != nil {
+		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
+			log.Printf("[WARN] removing Firewall Device ID %q from state because it no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error finding the specified Linode Firewall Device: %s", err)
+	}
+
+	d.Set("entity_id", device.Entity.ID)
+	d.Set("entity_type", device.Entity.Type)
+	d.Set("created", device.Created.String())
+	d.Set("updated", device.Updated.String())
+
+	return nil
+}
+
+func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	firewallID := d.Get("firewall_id").(int)
+	entityID := d.Get("entity_id").(int)
+	entityType := d.Get("entity_type").(string)
+
+	createOpts := linodego.FirewallDeviceCreateOptions{
+		ID:   entityID,
+		Type: linodego.FirewallDeviceType(entityType),
+	}
+
+	device, err := client.CreateFirewallDevice(ctx, firewallID, createOpts)
+	if err != nil {
+		return diag.Errorf("Error creating a Linode Firewall Device: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%d", device.ID))
+
+	return readResource(ctx, d, meta)
+}
+
+func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return diag.Errorf("Error parsing Linode Firewall Device ID %s as int: %s", d.Id(), err)
+	}
+
+	firewallID, ok := d.Get("firewall_id").(int)
+	if !ok {
+		return diag.Errorf("Error parsing Linode Firewall Device ID %v as int", d.Get("nodebalancer_id"))
+	}
+
+	err = client.DeleteFirewallDevice(ctx, firewallID, int(id))
+	if err != nil {
+		return diag.Errorf("Error deleting Linode Firewall Device %d: %s", id, err)
+	}
+	return nil
+}

--- a/linode/firewalldevice/resource_test.go
+++ b/linode/firewalldevice/resource_test.go
@@ -1,0 +1,92 @@
+package firewalldevice_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/firewalldevice/tmpl"
+)
+
+func TestAccResourceFirewallDevice_basic(t *testing.T) {
+	t.Parallel()
+
+	var firewall linodego.Firewall
+
+	firewallName := "linode_firewall.foobar"
+	instanceName := "linode_instance.foobar"
+	deviceName := "linode_firewall_device.foobar"
+
+	label := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreventPostDestroyRefresh: true,
+		PreCheck:                  func() { acceptance.PreCheck(t) },
+		Providers:                 acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Basic(t, label),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acceptance.CheckFirewallExists(firewallName, &firewall),
+					resource.TestCheckResourceAttrSet(deviceName, "created"),
+				),
+			},
+			// Refresh the state and verify the attachment
+			{
+				Config: tmpl.Basic(t, label),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acceptance.CheckFirewallExists(firewallName, &firewall),
+					resource.TestCheckResourceAttr(firewallName, "devices.#", "1"),
+					resource.TestCheckResourceAttrPair(firewallName, "linodes.0", instanceName, "id"),
+				),
+			},
+			{
+				ResourceName:      deviceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: resourceImportStateID,
+			},
+			{
+				Config: tmpl.Detached(t, label),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acceptance.CheckFirewallExists(firewallName, &firewall),
+				),
+			},
+			// Refresh the state and verify the detachment
+			{
+				Config: tmpl.Detached(t, label),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acceptance.CheckFirewallExists(firewallName, &firewall),
+					resource.TestCheckResourceAttr(firewallName, "devices.#", "0"),
+					resource.TestCheckResourceAttr(firewallName, "linodes.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func resourceImportStateID(s *terraform.State) (string, error) {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "linode_firewall_device" {
+			continue
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return "", fmt.Errorf("Error parsing ID %v to int", rs.Primary.ID)
+		}
+
+		firewallID, err := strconv.Atoi(rs.Primary.Attributes["firewall_id"])
+		if err != nil {
+			return "", fmt.Errorf("Error parsing firewall_id %v to int", rs.Primary.Attributes["firewall_id"])
+		}
+		return fmt.Sprintf("%d,%d", firewallID, id), nil
+	}
+
+	return "", fmt.Errorf("Error finding firewall_device")
+}

--- a/linode/firewalldevice/schema_resource.go
+++ b/linode/firewalldevice/schema_resource.go
@@ -1,0 +1,37 @@
+package firewalldevice
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var resourceSchema = map[string]*schema.Schema{
+	"firewall_id": {
+		Type:        schema.TypeInt,
+		Description: "The ID of the Firewall to access.",
+		Required:    true,
+		ForceNew:    true,
+	},
+	"entity_id": {
+		Type:        schema.TypeInt,
+		Description: "The ID of the entity to create a Firewall device for.",
+		Required:    true,
+		ForceNew:    true,
+	},
+	"entity_type": {
+		Type:        schema.TypeString,
+		Description: "The type of the entity to create a Firewall device for.",
+		Default:     "linode",
+		Optional:    true,
+		ForceNew:    true,
+	},
+	"created": {
+		Type:        schema.TypeString,
+		Description: "When this Firewall Device was created.",
+		Computed:    true,
+	},
+	"updated": {
+		Type:        schema.TypeString,
+		Description: "When this Firewall Device was updated.",
+		Computed:    true,
+	},
+}

--- a/linode/firewalldevice/tmpl/basic.gotf
+++ b/linode/firewalldevice/tmpl/basic.gotf
@@ -1,0 +1,12 @@
+{{ define "firewall_device_basic" }}
+
+{{ template "firewall_device_firewall" . }}
+
+{{ template "firewall_device_instance" . }}
+
+resource "linode_firewall_device" "foobar" {
+    firewall_id = linode_firewall.foobar.id
+    entity_id = linode_instance.foobar.id
+}
+
+{{ end }}

--- a/linode/firewalldevice/tmpl/detached.gotf
+++ b/linode/firewalldevice/tmpl/detached.gotf
@@ -1,0 +1,7 @@
+{{ define "firewall_device_detached" }}
+
+{{ template "firewall_device_firewall" . }}
+
+{{ template "firewall_device_instance" . }}
+
+{{ end }}

--- a/linode/firewalldevice/tmpl/firewall.gotf
+++ b/linode/firewalldevice/tmpl/firewall.gotf
@@ -1,0 +1,30 @@
+# Template firewall for use with firewall devices
+
+{{ define "firewall_device_firewall" }}
+
+resource "linode_firewall" "foobar" {
+    label = "{{.Label}}"
+    tags  = ["test"]
+
+    inbound {
+        label    = "tf-test-in"
+        action = "ACCEPT"
+        protocol  = "TCP"
+        ports     = "80"
+        ipv4 = ["0.0.0.0/0"]
+        ipv6 = ["::/0"]
+    }
+    inbound_policy = "DROP"
+
+    outbound {
+        label    = "tf-test-out"
+        action = "ACCEPT"
+        protocol  = "TCP"
+        ports     = "80"
+        ipv4 = ["0.0.0.0/0"]
+        ipv6 = ["2001:db8::/32"]
+    }
+    outbound_policy = "DROP"
+}
+
+{{ end }}

--- a/linode/firewalldevice/tmpl/instance.gotf
+++ b/linode/firewalldevice/tmpl/instance.gotf
@@ -1,0 +1,11 @@
+# Template instance for use with firewall devices
+
+{{ define "firewall_device_instance" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+}
+
+{{ end }}

--- a/linode/firewalldevice/tmpl/template.go
+++ b/linode/firewalldevice/tmpl/template.go
@@ -1,0 +1,25 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+type TemplateData struct {
+	Label string
+}
+
+func Basic(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"firewall_device_basic", TemplateData{
+			Label: label,
+		})
+}
+
+func Detached(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"firewall_device_detached", TemplateData{
+			Label: label,
+		})
+}

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/domain"
 	"github.com/linode/terraform-provider-linode/linode/domainrecord"
 	"github.com/linode/terraform-provider-linode/linode/firewall"
+	"github.com/linode/terraform-provider-linode/linode/firewalldevice"
 	"github.com/linode/terraform-provider-linode/linode/helper"
 	"github.com/linode/terraform-provider-linode/linode/image"
 	"github.com/linode/terraform-provider-linode/linode/images"
@@ -150,6 +151,7 @@ func Provider() *schema.Provider {
 			"linode_domain":                domain.Resource(),
 			"linode_domain_record":         domainrecord.Resource(),
 			"linode_firewall":              firewall.Resource(),
+			"linode_firewall_device":       firewalldevice.Resource(),
 			"linode_image":                 image.Resource(),
 			"linode_instance":              instance.Resource(),
 			"linode_instance_ip":           instanceip.Resource(),

--- a/website/docs/r/firewall_device.html.md
+++ b/website/docs/r/firewall_device.html.md
@@ -1,0 +1,60 @@
+---
+layout: "linode"
+page_title: "Linode: linode_firewall_device"
+sidebar_current: "docs-linode-firewall-device"
+description: |-
+  Manages a Linode Firewall Device.
+---
+
+# linode\_firewall\_device
+
+Manages a Linode Firewall Device.
+
+## Example Usage
+
+```terraform
+resource "linode_firewall_device" "my_device" {
+  firewall_id = linode_firewall.my_firewall.id
+  entity_id = linode_instance.my_instance.id
+}
+
+resource "linode_firewall" "my_firewall" {
+  label = "my_firewall"
+
+  inbound {
+    label    = "http"
+    action = "ACCEPT"
+    protocol  = "TCP"
+    ports     = "80"
+    ipv4 = ["0.0.0.0/0"]
+    ipv6 = ["::/0"]
+  }
+  
+  inbound_policy = "DROP"
+  outbound_policy = "ACCEPT"
+}
+
+resource "linode_instance" "my_instance" {
+  label      = "my_instance"
+  region     = "us-southeast"
+  type       = "g6-standard-1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `firewall_id` - (Required) The unique ID of the target Firewall.
+
+* `entity_id` - (Required) The unique ID of the entity to attach.
+
+* `entity_type` - (Optional) The type of the entity to attach. (default: `linode`)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `created` - When the Firewall Device was last created.
+
+* `updated` - When the Firewall Device was last updated.

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -100,6 +100,9 @@
             <li<%= sidebar_current("docs-linode-resource-firewall") %>>
               <a href="/docs/providers/linode/r/firewall.html">linode_firewall</a>
             </li>
+            <li<%= sidebar_current("docs-linode-resource-firewall-device") %>>
+              <a href="/docs/providers/linode/r/firewall_device.html">linode_firewall_device</a>
+            </li>
             <li<%= sidebar_current("docs-linode-resource-image") %>>
               <a href="/docs/providers/linode/r/image.html">linode_image</a>
             </li>


### PR DESCRIPTION
This pull request adds a `linode_firewall_device` resource that can optionally be used to attach entities to a Firewall without a monolithic `linode_firewall` resource. Additionally, this resource allows for Terraform-managed entities to be attached to external Linode Firewalls.

For example:

```hcl
resource "linode_firewall_device" "my_device" {
  firewall_id = linode_firewall.my_firewall.id
  entity_id = linode_instance.my_instance.id
}

resource "linode_firewall" "my_firewall" {
  label = "my_firewall"

  inbound {
    label    = "http"
    action = "ACCEPT"
    protocol  = "TCP"
    ports     = "80"
    ipv4 = ["0.0.0.0/0"]
    ipv6 = ["::/0"]
  }
  
  inbound_policy = "DROP"
  outbound_policy = "ACCEPT"
}

resource "linode_instance" "my_instance" {
  label      = "my_instance"
  region     = "us-southeast"
  type       = "g6-standard-1"
}
```

Resolves #544 