### PR TITLE
Add `wait_for_available` field to `linode_rdns` resource

### DIFF
--- a/linode/rdns/resource.go
+++ b/linode/rdns/resource.go
@@ -3,13 +3,14 @@ package rdns
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper"
-	"log"
-	"strings"
-	"time"
 )
 
 const updateRDNSTimeout = time.Minute * 10

--- a/linode/rdns/resource.go
+++ b/linode/rdns/resource.go
@@ -13,8 +13,6 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
-const updateRDNSTimeout = time.Minute * 10
-
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		Schema:        resourceSchema,
@@ -24,10 +22,6 @@ func Resource() *schema.Resource {
 		UpdateContext: updateResource,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(updateRDNSTimeout),
-			Update: schema.DefaultTimeout(updateRDNSTimeout),
 		},
 	}
 }
@@ -136,7 +130,7 @@ func updateIPAddress(ctx context.Context, d *schema.ResourceData, meta interface
 	retry := d.Get("wait_for_available").(bool)
 
 	if retry {
-		return updateIPAddressWithRetries(ctx, &client, address, updateOpts, time.Second)
+		return updateIPAddressWithRetries(ctx, &client, address, updateOpts, time.Second*5)
 	}
 
 	return client.UpdateIPAddress(ctx, address, updateOpts)

--- a/linode/rdns/schema_resource.go
+++ b/linode/rdns/schema_resource.go
@@ -20,4 +20,10 @@ var resourceSchema = map[string]*schema.Schema{
 		Required:     true,
 		ValidateFunc: validation.StringLenBetween(3, 254),
 	},
+	"wait_for_available": {
+		Type:        schema.TypeBool,
+		Description: "If true, the RDNS assignment will be retried within the operation timeout period.",
+		Optional:    true,
+		Default:     false,
+	},
 }

--- a/website/docs/r/rdns.html.md
+++ b/website/docs/r/rdns.html.md
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `rdns` - The name of the RDNS address.
 
+* `wait_for_available` - (Optional) If true, the RDNS assignment will be retried within the operation timeout period.
+
 ## Import
 
 Linodes RDNS resources can be imported using the address as the `id`.


### PR DESCRIPTION
This pull request adds a `wait_for_available` field to the `linode_rdns` resource. When set to true, the RDNS assignment will be retried within the resource's operation timeout (default 10 minutes).

For example:
```hcl
resource "linode_rdns" "foo" {
  depends_on = [linode_domain_record.foobar]

  address = linode_instance.foo.ip_address
  rdns = "myrecord.mydomain.com"
  wait_for_available = true
}

resource "linode_domain_record" "foobar" {
  domain_id = 12345
  name = "myrecord"
  record_type = "A"
  target = linode_instance.foo.ip_address
}

resource "linode_instance" "foo" {
  image = "linode/alpine3.14"
  region = "us-southeast"
  type = "g6-standard-2"
}
```