### PR TITLE
fix: Add missing fields to `linode_instance` config creation

### DIFF
--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -51,6 +51,9 @@ func createInstanceConfigsFromSet(
 		configOpts.Kernel = config["kernel"].(string)
 		configOpts.Label = config["label"].(string)
 		configOpts.Comments = config["comments"].(string)
+		configOpts.VirtMode = config["virt_mode"].(string)
+		configOpts.MemoryLimit = config["memory_limit"].(int)
+		configOpts.RunLevel = config["run_level"].(string)
 
 		if helpers, ok := config["helpers"].([]interface{}); ok {
 			for _, helper := range helpers {
@@ -88,6 +91,7 @@ func createInstanceConfigsFromSet(
 		if rootDevice != "" {
 			configOpts.RootDevice = &rootDevice
 		}
+
 		// configOpts.InitRD = config["initrd"].(string)
 		// TODO(displague) need a disk_label to initrd lookup?
 		devices, ok := config["devices"].([]interface{})

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -223,7 +223,10 @@ func TestAccResourceInstance_config(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
 					resource.TestCheckResourceAttr(resName, "swap_size", "0"),
 					resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "60"),
-					resource.TestCheckResourceAttr(resName, "config.0.helpers.0.network", "true"),
+
+					resource.TestCheckResourceAttr(resName, "config.0.run_level", "binbash"),
+					resource.TestCheckResourceAttr(resName, "config.0.virt_mode", "fullvirt"),
+					resource.TestCheckResourceAttr(resName, "config.0.memory_limit", "1024"),
 
 					checkComputeInstanceConfigs(&instance, testConfig("config", testConfigKernel("linode/latest-64bit"))),
 				),

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -542,7 +542,6 @@ var resourceSchema = map[string]*schema.Schema{
 					Optional:    true,
 					Description: "Optional field for arbitrary User comments on this Config.",
 				},
-
 				"memory_limit": {
 					Type:        schema.TypeInt,
 					Optional:    true,

--- a/linode/instance/tmpl/templates/with_config.gotf
+++ b/linode/instance/tmpl/templates/with_config.gotf
@@ -12,6 +12,11 @@ resource "linode_instance" "foobar" {
         label = "config"
         kernel = "linode/latest-64bit"
         root_device = "/dev/sda"
+
+        run_level = "binbash"
+        virt_mode = "fullvirt"
+        memory_limit = 1024
+
         helpers {
             network = true
         }


### PR DESCRIPTION
This pull request addresses an issue that would prevent `linode_instance` configs from being created with certain fields.

Resolves #581 