### PR TITLE
Use supported k8s version for lke_cluster doc

### DIFF
--- a/website/docs/r/lke_cluster.html.md
+++ b/website/docs/r/lke_cluster.html.md
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `label` - (Required) This Kubernetes cluster's unique label.
 
-* `k8s_version` - (Required) The desired Kubernetes version for this Kubernetes cluster in the format of `major.minor` (e.g. `1.17`), and the latest supported patch version will be deployed.
+* `k8s_version` - (Required) The desired Kubernetes version for this Kubernetes cluster in the format of `major.minor` (e.g. `1.21`), and the latest supported patch version will be deployed.
 
 * `region` - (Required) This Kubernetes cluster's location.
 


### PR DESCRIPTION
1.17 is not a supported version of LKE, at least in us-east which supports only 1.21 and 1.22

Picked 1.21 because 1.21 is referenced earlier in this doc (lines 20 and 36).