### PR TITLE
new: Add linode_ipv6_range resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/linode/terraform-provider-linode
 require (
 	github.com/aws/aws-sdk-go v1.42.16
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/linode/linodego v1.2.1
+	github.com/linode/linodego v1.3.0
 	github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
@@ -20,7 +20,7 @@ require (
 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,9 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -320,8 +321,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/linode/linodego v0.20.1/go.mod h1:XOWXRHjqeU2uPS84tKLgfWIfTlv3TYzCS0io4GOQzEI=
-github.com/linode/linodego v1.2.1 h1:v0vS/n9dGMA9evG+fhLJcy7hsf6TUVmacfYiYzARhts=
-github.com/linode/linodego v1.2.1/go.mod h1:x/7+BoaKd4unViBmS2umdjYyVAmpFtBtEXZ0wou7FYQ=
+github.com/linode/linodego v1.3.0 h1:77BPapuzhfIhXodiDUt/M76H46UiFYOytEupVN2auDI=
+github.com/linode/linodego v1.3.0/go.mod h1:PVsRxSlOiJyvG4/scTszpmZDTdgS+to3X6eS8pRrWI8=
 github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947 h1:e+tpC7AIiEgfYGEDq9Rjtdybq+V10S6OXzWjeGV/CEk=
 github.com/linode/linodego/k8s v0.0.0-20200831124119-58d5d5bb7947/go.mod h1:MWI0tFyaJqRpirMv0VO7CGYT4V3IhHvml2rs/DlRQmY=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/linode/ipv6range/resource.go
+++ b/linode/ipv6range/resource.go
@@ -1,0 +1,81 @@
+package ipv6range
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+	"log"
+	"strings"
+)
+
+func Resource() *schema.Resource {
+	return &schema.Resource{
+		Schema:        resourceSchema,
+		ReadContext:   readResource,
+		CreateContext: createResource,
+		DeleteContext: deleteResource,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+	}
+}
+
+func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	r, err := client.GetIPv6Range(ctx, d.Id())
+	if err != nil {
+		log.Printf("[WARN] removing ipv6 range %q from state because it no longer exists", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("prefix_length", r.Prefix)
+	d.Set("is_bgp", r.IsBGP)
+	d.Set("linodes", r.Linodes)
+	d.Set("range", r.Range)
+	d.Set("region", r.Region)
+
+	return nil
+}
+
+func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	linodeID, linodeIDExists := d.GetOk("linode_id")
+	routeTarget, routeTargetExists := d.GetOk("route_target")
+
+	createOpts := linodego.IPv6RangeCreateOptions{
+		PrefixLength: d.Get("prefix_length").(int),
+	}
+
+	if linodeIDExists {
+		createOpts.LinodeID = linodeID.(int)
+	} else if routeTargetExists {
+		// Strip the prefix if provided
+		createOpts.RouteTarget = strings.Split(routeTarget.(string), "/")[0]
+	} else {
+		return diag.Errorf("either linode_id or route_target must be specified")
+	}
+
+	r, err := client.CreateIPv6Range(ctx, createOpts)
+	if err != nil {
+		return diag.Errorf("failed to create ipv6 range: %s", err)
+	}
+
+	d.SetId(strings.TrimSuffix(r.Range, fmt.Sprintf("/%d", createOpts.PrefixLength)))
+
+	return readResource(ctx, d, meta)
+}
+
+func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	if err := client.DeleteIPv6Range(ctx, d.Id()); err != nil {
+		return diag.Errorf("failed to delete ipv6 range %s: %s", d.Id(), err)
+	}
+	return nil
+}

--- a/linode/ipv6range/resource.go
+++ b/linode/ipv6range/resource.go
@@ -3,12 +3,13 @@ package ipv6range
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper"
-	"log"
-	"strings"
 )
 
 func Resource() *schema.Resource {

--- a/linode/ipv6range/resource_test.go
+++ b/linode/ipv6range/resource_test.go
@@ -1,0 +1,146 @@
+package ipv6range_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+	"github.com/linode/terraform-provider-linode/linode/ipv6range/tmpl"
+	"regexp"
+	"testing"
+)
+
+func TestAccIPv6Range_basic(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_ipv6_range.foobar"
+	instLabel := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkIPv6RangeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Basic(t, instLabel),
+				Check: resource.ComposeTestCheckFunc(
+					checkIPv6RangeExists(resName, nil),
+					resource.TestCheckResourceAttr(resName, "prefix_length", "64"),
+					resource.TestCheckResourceAttr(resName, "is_bgp", "false"),
+					resource.TestCheckResourceAttr(resName, "region", "us-southeast"),
+
+					resource.TestCheckResourceAttrSet(resName, "range"),
+					resource.TestCheckResourceAttrSet(resName, "linode_id"),
+					resource.TestCheckResourceAttrSet(resName, "linodes.0"),
+				),
+			},
+			{
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"linode_id", "route_target"},
+			},
+		},
+	})
+}
+
+func TestAccIPv6Range_routeTarget(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_ipv6_range.foobar"
+	instLabel := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkIPv6RangeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.RouteTarget(t, instLabel),
+				Check: resource.ComposeTestCheckFunc(
+					checkIPv6RangeExists(resName, nil),
+					resource.TestCheckResourceAttr(resName, "prefix_length", "64"),
+					resource.TestCheckResourceAttr(resName, "is_bgp", "false"),
+					resource.TestCheckResourceAttr(resName, "region", "us-southeast"),
+
+					resource.TestCheckResourceAttrSet(resName, "range"),
+					resource.TestCheckResourceAttrSet(resName, "route_target"),
+					resource.TestCheckResourceAttrSet(resName, "linodes.0"),
+				),
+			},
+			{
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"linode_id", "route_target"},
+			},
+		},
+	})
+}
+
+func TestAccIPv6Range_noID(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkIPv6RangeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      tmpl.NoID(t),
+				ExpectError: regexp.MustCompile("either linode_id or route_target must be specified"),
+			},
+		},
+	})
+}
+
+func checkIPv6RangeExists(name string, ipv6Range *linodego.IPv6Range) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.TestAccProvider.Meta().(*helper.ProviderMeta).Client
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		found, err := client.GetIPv6Range(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve state of ipv6 range %s: %s", rs.Primary.Attributes["range"], err)
+		}
+
+		if ipv6Range != nil {
+			*ipv6Range = *found
+		}
+
+		return nil
+	}
+}
+
+func checkIPv6RangeDestroy(s *terraform.State) error {
+	client := acceptance.TestAccProvider.Meta().(*helper.ProviderMeta).Client
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "linode_ipv6_range" {
+			continue
+		}
+
+		_, err := client.GetIPv6Range(context.Background(), rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Linode IPv6 range with id %s still exists", rs.Primary.ID)
+		}
+
+		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code != 404 && apiErr.Code != 405 {
+			return fmt.Errorf("error requesting Linode IPv6 range with id %s: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}

--- a/linode/ipv6range/resource_test.go
+++ b/linode/ipv6range/resource_test.go
@@ -3,6 +3,9 @@ package ipv6range_test
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -10,8 +13,6 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/linode/helper"
 	"github.com/linode/terraform-provider-linode/linode/ipv6range/tmpl"
-	"regexp"
-	"testing"
 )
 
 func TestAccIPv6Range_basic(t *testing.T) {

--- a/linode/ipv6range/schema_resource.go
+++ b/linode/ipv6range/schema_resource.go
@@ -1,0 +1,51 @@
+package ipv6range
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var resourceSchema = map[string]*schema.Schema{
+	"prefix_length": {
+		Type:         schema.TypeInt,
+		Description:  "The prefix length of the IPv6 range.",
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.IntInSlice([]int{56, 64}),
+	},
+	"linode_id": {
+		Type:          schema.TypeInt,
+		Description:   "The ID of the Linode to assign this range to.",
+		Optional:      true,
+		ForceNew:      true,
+		ConflictsWith: []string{"route_target"},
+	},
+	"route_target": {
+		Type:          schema.TypeString,
+		Description:   "The IPv6 SLAAC address to assign this range to.",
+		Optional:      true,
+		ForceNew:      true,
+		ConflictsWith: []string{"linode_id"},
+	},
+	"is_bgp": {
+		Type:        schema.TypeBool,
+		Description: "Whether this IPv6 range is shared.",
+		Computed:    true,
+	},
+	"linodes": {
+		Type:        schema.TypeSet,
+		Elem:        &schema.Schema{Type: schema.TypeInt},
+		Description: "A list of Linodes targeted by this IPv6 range. Includes Linodes with IP sharing.",
+		Computed:    true,
+	},
+	"range": {
+		Type:        schema.TypeString,
+		Description: "The IPv6 range of addresses in this pool.",
+		Computed:    true,
+	},
+	"region": {
+		Type:        schema.TypeString,
+		Description: "The region for this range of IPv6 addresses.",
+		Computed:    true,
+	},
+}

--- a/linode/ipv6range/tmpl/basic.gotf
+++ b/linode/ipv6range/tmpl/basic.gotf
@@ -1,0 +1,16 @@
+{{ define "ipv6range_basic" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    image = "linode/alpine3.14"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+}
+
+resource "linode_ipv6_range" "foobar" {
+    linode_id = linode_instance.foobar.id
+
+    prefix_length = 64
+}
+
+{{ end }}

--- a/linode/ipv6range/tmpl/no_id.gotf
+++ b/linode/ipv6range/tmpl/no_id.gotf
@@ -1,0 +1,7 @@
+{{ define "ipv6range_no_id" }}
+
+resource "linode_ipv6_range" "foobar" {
+    prefix_length = 64
+}
+
+{{ end }}

--- a/linode/ipv6range/tmpl/route_target.gotf
+++ b/linode/ipv6range/tmpl/route_target.gotf
@@ -1,0 +1,16 @@
+{{ define "ipv6range_route_target" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    image = "linode/alpine3.14"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+}
+
+resource "linode_ipv6_range" "foobar" {
+    route_target = linode_instance.foobar.ipv6
+
+    prefix_length = 64
+}
+
+{{ end }}

--- a/linode/ipv6range/tmpl/template.go
+++ b/linode/ipv6range/tmpl/template.go
@@ -1,0 +1,29 @@
+package tmpl
+
+import (
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"testing"
+)
+
+type TemplateData struct {
+	Label string
+}
+
+func Basic(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"ipv6range_basic", TemplateData{
+			Label: label,
+		})
+}
+
+func RouteTarget(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"ipv6range_route_target", TemplateData{
+			Label: label,
+		})
+}
+
+func NoID(t *testing.T) string {
+	return acceptance.ExecuteTemplate(t,
+		"ipv6range_no_id", nil)
+}

--- a/linode/ipv6range/tmpl/template.go
+++ b/linode/ipv6range/tmpl/template.go
@@ -1,8 +1,9 @@
 package tmpl
 
 import (
-	"github.com/linode/terraform-provider-linode/linode/acceptance"
 	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
 )
 
 type TemplateData struct {

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/instanceip"
 	"github.com/linode/terraform-provider-linode/linode/instancetype"
 	"github.com/linode/terraform-provider-linode/linode/instancetypes"
+	"github.com/linode/terraform-provider-linode/linode/ipv6range"
 	"github.com/linode/terraform-provider-linode/linode/kernel"
 	"github.com/linode/terraform-provider-linode/linode/lke"
 	"github.com/linode/terraform-provider-linode/linode/nb"
@@ -155,6 +156,7 @@ func Provider() *schema.Provider {
 			"linode_image":                 image.Resource(),
 			"linode_instance":              instance.Resource(),
 			"linode_instance_ip":           instanceip.Resource(),
+			"linode_ipv6_range":            ipv6range.Resource(),
 			"linode_lke_cluster":           lke.Resource(),
 			"linode_nodebalancer":          nb.Resource(),
 			"linode_nodebalancer_node":     nbnode.Resource(),

--- a/website/docs/r/ipv6_range.html.md
+++ b/website/docs/r/ipv6_range.html.md
@@ -1,0 +1,52 @@
+---
+layout: "linode"
+page_title: "Linode: linode_ipv6_range"
+sidebar_current: "docs-linode-resource-ipv6-range"
+description: |-
+  Manages a Linode IPv6 range.
+---
+
+# linode\_ipv6\_range
+
+Manages a Linode IPv6 range.
+
+## Example Usage
+
+```terraform
+resource "linode_instance" "foobar" {
+  label = "my-linode"
+  image = "linode/alpine3.14"
+  type = "g6-nanode-1"
+  region = "us-southeast"
+}
+
+resource "linode_ipv6_range" "foobar" {
+  linode_id = linode_instance.foobar.id
+
+  prefix_length = 64
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+**Note:** Only one of`linode_id` and `route_target` should be specified.
+
+* `prefix_length` - (Required) The prefix length of the IPv6 range.
+
+* `linode_id` - (Required) The ID of the Linode to assign this range to.
+
+* `route_target` - (Required) The IPv6 SLAAC address to assign this range to.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `is_bgp` - Whether this IPv6 range is shared.
+
+* `linodes` - A list of Linodes targeted by this IPv6 range. Includes Linodes with IP sharing.
+
+* `range` - The IPv6 range of addresses in this pool.
+
+* `region` - The region for this range of IPv6 addresses.

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -112,6 +112,9 @@
             <li<%= sidebar_current("docs-linode-resource-instance-ip") %>>
               <a href="/docs/providers/linode/r/instance_ip.html">linode_instance_ip</a>
             </li>
+            <li<%= sidebar_current("docs-linode-resource-ipv6-range") %>>
+              <a href="/docs/providers/linode/r/ipv6_range.html">linode_ipv6_range</a>
+            </li>
             <li<%= sidebar_current("docs-linode-resource-lke-cluster") %>>
               <a href="/docs/providers/linode/r/lke_cluster.html">linode_lke_cluster</a>
             </li>


### PR DESCRIPTION
This pull request adds a `linode_ipv6_range` resource corresponding to the [/networking/ipv6/ranges](https://www.linode.com/docs/api/networking/#ipv6-range-create) Linode endpoints.

All integration tests are passing.