### PR TITLE
fix: Reduce k8sUpgrade config pool size to two nodes

### DIFF
--- a/linode/lke/tmpl/many_pools.gotf
+++ b/linode/lke/tmpl/many_pools.gotf
@@ -8,11 +8,6 @@ resource "linode_lke_cluster" "test" {
 
     pool {
         type  = "g6-standard-2"
-        count = 3
-    }
-
-    pool {
-        type = "g6-standard-2"
         count = 1
     }
 


### PR DESCRIPTION
This pull request reduces the number of nodes used in `TestAccResourceLKECluster_k8sUpgrade` from `5` to `2`. This should significantly reduce the number of context deadline failures when running LKE tests in parallel.