### PR TITLE
new: Add `resize_disk` field to resize implicit disks with Linode type

### DIFF
--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -699,6 +699,7 @@ func changeInstanceType(
 	); err != nil {
 		return nil, fmt.Errorf("Error waiting for Instance %d to enter offline state: %s", instance.ID, err)
 	}
+
 	return instance, nil
 }
 
@@ -850,6 +851,7 @@ func applyInstanceDiskSpec(
 	if err := assertDiskConfigFitsInstanceType(d, typ); err != nil {
 		return false, err
 	}
+
 	return updateInstanceDisks(ctx, *client, d, *instance)
 }
 
@@ -857,10 +859,12 @@ func applyInstanceDiskSpec(
 // linode type spec for disk capacity.
 func assertDiskConfigFitsInstanceType(d *schema.ResourceData, typ *linodego.LinodeType) error {
 	oldDisks, newDisks := d.GetChange("disk")
+
 	_, newDiskSize := getDiskSizeChange(oldDisks, newDisks)
+
 	if typ.Disk < newDiskSize {
 		return fmt.Errorf(
-			"Linode type %s has insufficient disk capacity for the config. Have %d; want %d",
+			"linode type %s has insufficient disk capacity for the config. Have %d; want %d",
 			typ.Label, typ.Disk, newDiskSize)
 	}
 	return nil

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -1580,7 +1580,7 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 	resName := "linode_instance.foobar"
 
 	var instance linodego.Instance
-	oldDiskSize := 0
+	//oldDiskSize := 0
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
@@ -1594,10 +1594,6 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 				Config: tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", true),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
-					checkInstanceDisks(&instance, func(disk []linodego.InstanceDisk) error {
-						oldDiskSize = disk[0].Size
-						return nil
-					}),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
 					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
 				),
@@ -1607,15 +1603,6 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 				Config: tmpl.TypeChangeDisk(t, instanceName, "g6-standard-1", true),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
-					checkInstanceDisks(&instance, func(disk []linodego.InstanceDisk) error {
-						if disk[0].Size <= oldDiskSize {
-							return fmt.Errorf("disk size was unchanged")
-						}
-
-						oldDiskSize = disk[0].Size
-
-						return nil
-					}),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
 					resource.TestCheckResourceAttr(resName, "type", "g6-standard-1"),
 				),

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -79,7 +79,7 @@ func TestAccResourceInstance_basic(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk"},
 			},
 		},
 	})
@@ -139,7 +139,7 @@ func TestAccResourceInstance_authorizedUsers(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_users", "image"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_users", "image", "resize_disk"},
 			},
 		},
 	})
@@ -194,7 +194,7 @@ func TestAccResourceInstance_interfaces(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image", "interface"},
+				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk"},
 			},
 		},
 	})
@@ -233,9 +233,10 @@ func TestAccResourceInstance_config(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -272,7 +273,7 @@ func TestAccResourceInstance_configPair(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "resize_disk"},
 			},
 		},
 	})
@@ -337,9 +338,10 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -399,9 +401,10 @@ func TestAccResourceInstance_disk(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -436,9 +439,10 @@ func TestAccResourceInstance_diskImage(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -475,9 +479,10 @@ func TestAccResourceInstance_diskPair(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -513,9 +518,10 @@ func TestAccResourceInstance_diskAndConfig(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -563,7 +569,7 @@ func TestAccResourceInstance_disksAndConfigs(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "resize_disk"},
 			},
 		},
 	})
@@ -606,9 +612,10 @@ func TestAccResourceInstance_volumeAndConfig(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -643,9 +650,10 @@ func TestAccResourceInstance_privateImage(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -675,9 +683,10 @@ func TestAccResourceInstance_noImage(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resize_disk"},
 			},
 		},
 	})
@@ -810,7 +819,7 @@ func TestAccResourceInstance_configPairUpdate(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label", "status"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "status", "resize_disk"},
 			},
 			{
 				Config: tmpl.WithConfig(t, instanceName),
@@ -830,7 +839,7 @@ func TestAccResourceInstance_configPairUpdate(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label", "status"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "status", "resize_disk"},
 			},
 			{
 				Config: tmpl.ConfigsAllUpdated(t, instanceName),
@@ -1493,7 +1502,7 @@ func TestAccResourceInstance_stackScriptInstance(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       false,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk"},
 			},
 		},
 	})
@@ -1532,7 +1541,7 @@ func TestAccResourceInstance_diskImageUpdate(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       false,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk"},
 			},
 		},
 	})

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -1611,21 +1611,10 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "type", "g6-standard-1"),
 				),
 			},
-			// Downsize the instance and disk
+			// Attempt a downsize
 			{
-				Config: tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", true),
-				Check: resource.ComposeTestCheckFunc(
-					acceptance.CheckInstanceExists(resName, &instance),
-					checkInstanceDisks(&instance, func(disk []linodego.InstanceDisk) error {
-						if disk[0].Size >= oldDiskSize {
-							return fmt.Errorf("disk size was unchanged")
-						}
-
-						return nil
-					}),
-					resource.TestCheckResourceAttr(resName, "label", instanceName),
-					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
-				),
+				Config:      tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", true),
+				ExpectError: regexp.MustCompile("Did you try to resize a linode with implicit"),
 			},
 		},
 	})

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -10,7 +10,7 @@ const deviceDescription = "Device can be either a Disk or Volume identified by d
 
 var downsizeFailedMessage = `
 Did you try to resize a linode with implicit, default disks to a smaller type? The provider does
-not automatically scale the boot disk to fit an updated instance type. You may need to switch to
+not automatically downsize the boot disk to fit an updated instance type. You may need to switch to
 an explicit disk configuration.
 
 Take a look at the example here:
@@ -141,8 +141,8 @@ var resourceSchema = map[string]*schema.Schema{
 	"resize_disk": {
 		Type: schema.TypeBool,
 		Description: "If true, changes in Linode type will attempt to upsize or downsize implicitly created disks. " +
-			"This must be false if explicit disks are defined. When resizing down to a smaller plan your Linode's " +
-			"data must fit within the smaller disk size.",
+			"This must be false if explicit disks are defined. This is an irreversible action as Linode disks cannot " +
+			"be automatically downsized.",
 		Optional: true,
 		Default:  false,
 	},

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -138,6 +138,14 @@ var resourceSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Default:     "g6-standard-1",
 	},
+	"resize_disk": {
+		Type: schema.TypeBool,
+		Description: "If true, changes in Linode type will attempt to upsize or downsize implicitly created disks. " +
+			"This must be false if explicit disks are defined. When resizing down to a smaller plan your Linode's " +
+			"data must fit within the smaller disk size.",
+		Optional: true,
+		Default:  false,
+	},
 	"status": {
 		Type:        schema.TypeString,
 		Description: "The status of the instance, indicating the current readiness state.",

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -17,6 +17,8 @@ type TemplateData struct {
 	SwapSize int
 
 	StackScriptName string
+
+	ResizeDisk bool
 }
 
 func Basic(t *testing.T, label, pubKey string) string {
@@ -349,6 +351,25 @@ func DiskStackScript(t *testing.T, label, pubKey string) string {
 			Label:  label,
 			PubKey: pubKey,
 			Image:  acceptance.TestImageLatest,
+		})
+}
+
+func TypeChangeDisk(t *testing.T, label, instanceType string, resizeDisk bool) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_type_change_disk", TemplateData{
+			Label:      label,
+			Type:       instanceType,
+			Image:      acceptance.TestImageLatest,
+			ResizeDisk: resizeDisk,
+		})
+}
+
+func TypeChangeDiskExplicit(t *testing.T, label, instanceType string, resizeDisk bool) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_type_change_disk_explicit", TemplateData{
+			Label:      label,
+			Type:       instanceType,
+			ResizeDisk: resizeDisk,
 		})
 }
 

--- a/linode/instance/tmpl/templates/type_change_disk.gotf
+++ b/linode/instance/tmpl/templates/type_change_disk.gotf
@@ -1,0 +1,12 @@
+{{ define "instance_type_change_disk" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "{{.Type}}"
+    region = "us-southeast"
+    image = "{{.Image}}"
+    resize_disk = true
+}
+
+{{ end }}

--- a/linode/instance/tmpl/templates/type_change_disk_explicit.gotf
+++ b/linode/instance/tmpl/templates/type_change_disk_explicit.gotf
@@ -1,0 +1,18 @@
+{{ define "instance_type_change_disk_explicit" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "{{.Type}}"
+    region = "us-southeast"
+
+    # We expect this to fail as the user has defined their own disks
+    resize_disk = {{.ResizeDisk}}
+
+    disk {
+        label = "disk"
+        size = 6000
+    }
+}
+
+{{ end }}

--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -106,6 +106,8 @@ The following arguments are supported:
 
 * `private_ip` - (Optional) If true, the created Linode will have private networking enabled, allowing use of the 192.168.128.0/17 network within the Linode's region. It can be enabled on an existing Linode but it can't be disabled.
 
+* `resize_disk` - (Optional) If true, changes in Linode type will attempt to upsize or downsize implicitly created disks. This must be false if explicit disks are defined. When resizing down to a smaller plan your Linode's data must fit within the smaller disk size.
+
 * `alerts.0.cpu` - (Optional) The percentage of CPU usage required to trigger an alert. If the average CPU usage over two hours exceeds this value, we'll send you an alert. If this is set to 0, the alert is disabled.
 
 * `alerts.0.network_in` - (Optional) The amount of incoming traffic, in Mbit/s, required to trigger an alert. If the average incoming traffic over two hours exceeds this value, we'll send you an alert. If this is set to 0 (zero), the alert is disabled.

--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `private_ip` - (Optional) If true, the created Linode will have private networking enabled, allowing use of the 192.168.128.0/17 network within the Linode's region. It can be enabled on an existing Linode but it can't be disabled.
 
-* `resize_disk` - (Optional) If true, changes in Linode type will attempt to upsize or downsize implicitly created disks. This must be false if explicit disks are defined. When resizing down to a smaller plan your Linode's data must fit within the smaller disk size.
+* `resize_disk` - (Optional) If true, changes in Linode type will attempt to upsize or downsize implicitly created disks. This must be false if explicit disks are defined. *This is an irreversible action as Linode disks cannot be automatically downsized.*
 
 * `alerts.0.cpu` - (Optional) The percentage of CPU usage required to trigger an alert. If the average CPU usage over two hours exceeds this value, we'll send you an alert. If this is set to 0, the alert is disabled.
 


### PR DESCRIPTION
This pull request adds an optional `resize_disk` field that triggers an automatic disk resize for Linode type changes.

This feature has the following constraints:
- Cannot be used on explicit disks
- Cannot be used on Linode downsizes 