### PR TITLE
fix: Resolve `resize_disk` update issue

### DIFF
--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -1137,6 +1137,11 @@ func validateImplicitDisks(ctx context.Context,
 		return fmt.Errorf("failed to get instance disks: %s", err)
 	}
 
+	// No disks are an acceptable case
+	if len(disks) < 1 {
+		return nil
+	}
+
 	if getFirstDiskWithFilesystem(disks,
 		[]linodego.DiskFilesystem{linodego.FilesystemExt4, linodego.FilesystemExt3}) == nil || len(disks) > 2 {
 		return fmt.Errorf("invalid implicit disk configuration: %s", invalidImplicitDiskConfigMessage)

--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -1117,10 +1117,12 @@ func getDiskSizeSum(ctx context.Context, d *schema.ResourceData,
 }
 
 func getFirstDiskWithFilesystem(disks []linodego.InstanceDisk,
-	filesystem linodego.DiskFilesystem) *linodego.InstanceDisk {
+	filesystems []linodego.DiskFilesystem) *linodego.InstanceDisk {
 	for _, disk := range disks {
-		if disk.Filesystem == filesystem {
-			return &disk
+		for _, filesystem := range filesystems {
+			if disk.Filesystem == filesystem {
+				return &disk
+			}
 		}
 	}
 
@@ -1135,7 +1137,8 @@ func validateImplicitDisks(ctx context.Context,
 		return fmt.Errorf("failed to get instance disks: %s", err)
 	}
 
-	if getFirstDiskWithFilesystem(disks, linodego.FilesystemExt4) == nil || len(disks) > 2 {
+	if getFirstDiskWithFilesystem(disks,
+		[]linodego.DiskFilesystem{linodego.FilesystemExt4, linodego.FilesystemExt3}) == nil || len(disks) > 2 {
 		return fmt.Errorf("invalid implicit disk configuration: %s", invalidImplicitDiskConfigMessage)
 	}
 
@@ -1153,7 +1156,8 @@ func getPrimaryImplicitDisk(ctx context.Context, d *schema.ResourceData,
 		return nil, fmt.Errorf("invalid implicit disk configuration: %s", invalidImplicitDiskConfigMessage)
 	}
 
-	targetDisk := getFirstDiskWithFilesystem(disks, linodego.FilesystemExt4)
+	targetDisk := getFirstDiskWithFilesystem(disks,
+		[]linodego.DiskFilesystem{linodego.FilesystemExt4, linodego.FilesystemExt3})
 
 	return targetDisk, nil
 }

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -16,6 +16,14 @@ an explicit disk configuration.
 Take a look at the example here:
 https://www.terraform.io/docs/providers/linode/r/instance.html#linode-instance-with-explicit-configs-and-disks`
 
+const invalidImplicitDiskConfigMessage = `
+Did you try to resize a Linode's implicit disks with more than two disks? 
+When resize_disk is true, your linode must have a single swap disk and a single ext4 disk.
+
+You may need to switch to an explicit disk configuration.
+Take a look at the example here:
+https://www.terraform.io/docs/providers/linode/r/instance.html#linode-instance-with-explicit-configs-and-disks`
+
 func resourceDeviceDisk() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -18,7 +18,7 @@ https://www.terraform.io/docs/providers/linode/r/instance.html#linode-instance-w
 
 const invalidImplicitDiskConfigMessage = `
 Did you try to resize a Linode's implicit disks with more than two disks? 
-When resize_disk is true, your linode must have a single ext4 disk as well as an optional swap disk.
+When resize_disk is true, your linode must have a single ext disk as well as an optional swap disk.
 
 You may need to switch to an explicit disk configuration.
 Take a look at the example here:

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -18,7 +18,7 @@ https://www.terraform.io/docs/providers/linode/r/instance.html#linode-instance-w
 
 const invalidImplicitDiskConfigMessage = `
 Did you try to resize a Linode's implicit disks with more than two disks? 
-When resize_disk is true, your linode must have a single swap disk and a single ext4 disk.
+When resize_disk is true, your linode must have a single ext4 disk as well as an optional swap disk.
 
 You may need to switch to an explicit disk configuration.
 Take a look at the example here:

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -408,6 +408,15 @@ func TypeChangeDiskExplicit(t *testing.T, label, instanceType string, resizeDisk
 		})
 }
 
+func TypeChangeDiskNone(t *testing.T, label, instanceType string, resizeDisk bool) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_type_change_disk_none", TemplateData{
+			Label:      label,
+			Type:       instanceType,
+			ResizeDisk: resizeDisk,
+		})
+}
+
 func DataBasic(t *testing.T, label string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_data_basic", TemplateData{

--- a/linode/instance/tmpl/templates/type_change_disk_none.gotf
+++ b/linode/instance/tmpl/templates/type_change_disk_none.gotf
@@ -1,0 +1,11 @@
+{{ define "instance_type_change_disk_none" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "{{.Type}}"
+    region = "us-southeast"
+    resize_disk = {{.ResizeDisk}}
+}
+
+{{ end }}


### PR DESCRIPTION
This pull request resolves an issue that results in implicit disk configurations being overridden by Terraform. This was not an issue until we introduced `resize_disk`, which modifies implicit disks through Linode's API and expects state to be updated again during the read step.

Relevant integration tests are passing: https://github.com/linode/terraform-provider-linode/actions/runs/1970542574