### PR TITLE
fix: Add explicit go version to integration test workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - uses: actions/setup-go@37335c7bb261b353407cff977110895fa0b4f7d8 # pin@v2
+        with:
+          go-version: '1.17'
+      - run: go version
       - run: make testacc
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}


### PR DESCRIPTION
As newer versions of `terraform-plugin-go` require `>= go 1.16`, we need to ensure that the integration tests workflow is using a newer version of go.