### PR TITLE
new: Allow `ipv6_range` Linode ID reassignment

### DIFF
--- a/linode/ipv6range/schema_resource.go
+++ b/linode/ipv6range/schema_resource.go
@@ -17,7 +17,6 @@ var resourceSchema = map[string]*schema.Schema{
 		Type:          schema.TypeInt,
 		Description:   "The ID of the Linode to assign this range to.",
 		Optional:      true,
-		ForceNew:      true,
 		ConflictsWith: []string{"route_target"},
 	},
 	"route_target": {

--- a/linode/ipv6range/tmpl/reassignment.gotf
+++ b/linode/ipv6range/tmpl/reassignment.gotf
@@ -1,0 +1,43 @@
+{{ define "ipv6range_reassign_step1" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+}
+
+resource "linode_instance" "foobar2" {
+    label = "{{.Label}}-2"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+}
+
+resource "linode_ipv6_range" "foobar" {
+    linode_id = linode_instance.foobar.id
+
+    prefix_length = 64
+}
+
+{{ end }}
+
+{{ define "ipv6range_reassign_step2" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+}
+
+resource "linode_instance" "foobar2" {
+    label = "{{.Label}}-2"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+}
+
+resource "linode_ipv6_range" "foobar" {
+    linode_id = linode_instance.foobar2.id
+
+    prefix_length = 64
+}
+
+{{ end }}

--- a/linode/ipv6range/tmpl/template.go
+++ b/linode/ipv6range/tmpl/template.go
@@ -28,3 +28,17 @@ func NoID(t *testing.T) string {
 	return acceptance.ExecuteTemplate(t,
 		"ipv6range_no_id", nil)
 }
+
+func ReassignmentStep1(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"ipv6range_reassign_step1", TemplateData{
+			Label: label,
+		})
+}
+
+func ReassignmentStep2(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"ipv6range_reassign_step2", TemplateData{
+			Label: label,
+		})
+}

--- a/website/docs/r/ipv6_range.html.md
+++ b/website/docs/r/ipv6_range.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `prefix_length` - (Required) The prefix length of the IPv6 range.
 
-* `linode_id` - (Required) The ID of the Linode to assign this range to.
+* `linode_id` - (Required) The ID of the Linode to assign this range to. This field may be updated to reassign the IPv6 range.
 
 * `route_target` - (Required) The IPv6 SLAAC address to assign this range to.
 


### PR DESCRIPTION
This pull request allows users to update the `linode_id` field of a `linode_ipv6_range` resource. The new `linode_id` must be in the same `region` as the existing IPv6 range.