### PR TITLE
new: Add manual acceptance test workflow

### DIFF
--- a/.github/workflows/acctest_command.yml
+++ b/.github/workflows/acctest_command.yml
@@ -1,0 +1,29 @@
+name: AccTest Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  acctest-command:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Generate App Installation Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.DX_ACCTEST_APP_ID }}
+          private_key: ${{ secrets.DX_ACCTEST_PRIV_KEY }}
+
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v1
+        env:
+          TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          token: ${{ env.TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: acctest
+          named-args: true
+          permission: write

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -1,0 +1,63 @@
+on:
+  pull_request:
+  repository_dispatch:
+    types: [acctest-command]
+
+name: Integration tests
+
+jobs:
+  # Maintainer has commented /acctest on a pull request
+  integration-fork:
+    runs-on: ubuntu-latest
+    if:
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.sha != '' &&
+      github.event.client_payload.slash_command.pkg != '' &&
+      contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.sha)
+
+    steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: validate-pkg
+        with:
+          text: ${{ github.event.client_payload.slash_command.pkg }}
+          regex: '[^a-z.\/]'
+          flags: gi
+
+      # Check out merge commit
+      - name: Checkout PR
+        uses: actions/checkout@v2
+        with:
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+
+      - run: make PKG_NAME="${{ github.event.client_payload.slash_command.pkg }}" testacc
+        if: ${{ steps.validate-pkg.outputs.match == '' }}
+        env:
+          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+
+      - uses: actions/github-script@v5
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+            return result;


### PR DESCRIPTION
This change allows maintainers to run integration tests on pull requests using the following syntax:
```/acctest sha=latestcommithash pkg=desiredpackage```


**Examples:**

Testing a single package:
```/acctest sha=c405e65 pkg=linode/instance```

Testing all packages:
```/acctest sha=c405e65 pkg=linode/...```