### PR TITLE
new: Add linode_database_mysql data source

### DIFF
--- a/linode/databasemysql/datasource.go
+++ b/linode/databasemysql/datasource.go
@@ -1,0 +1,63 @@
+package databasemysql
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		Schema:      dataSourceSchema,
+		ReadContext: readDataSource,
+	}
+}
+
+func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	id := d.Get("database_id").(int)
+
+	db, err := client.GetMySQLDatabase(ctx, id)
+	if err != nil {
+		return diag.Errorf("failed to get mysql database: %s", err)
+	}
+
+	cert, err := client.GetMySQLDatabaseSSL(ctx, int(id))
+	if err != nil {
+		return diag.Errorf("failed to get cert for the specified mysql database: %s", err)
+	}
+
+	creds, err := client.GetMySQLDatabaseCredentials(ctx, int(id))
+	if err != nil {
+		return diag.Errorf("failed to get credentials for mysql database: %s", err)
+	}
+
+	d.Set("engine_id", createEngineSlug(db.Engine, db.Version))
+	d.Set("engine", db.Engine)
+	d.Set("label", db.Label)
+	d.Set("region", db.Region)
+	d.Set("type", db.Type)
+	d.Set("allow_list", db.AllowList)
+	d.Set("cluster_size", db.ClusterSize)
+	d.Set("encrypted", db.Encrypted)
+	d.Set("replication_type", db.ReplicationType)
+	d.Set("ssl_connection", db.SSLConnection)
+	d.Set("ca_cert", string(cert.CACertificate))
+	d.Set("created", db.Created.Format(time.RFC3339))
+	d.Set("host_primary", db.Hosts.Primary)
+	d.Set("host_secondary", db.Hosts.Secondary)
+	d.Set("root_password", creds.Password)
+	d.Set("status", db.Status)
+	d.Set("updated", db.Updated.Format(time.RFC3339))
+	d.Set("root_username", creds.Username)
+	d.Set("version", db.Version)
+
+	d.SetId(strconv.Itoa(db.ID))
+
+	return nil
+}

--- a/linode/databasemysql/datasource_test.go
+++ b/linode/databasemysql/datasource_test.go
@@ -1,0 +1,64 @@
+package databasemysql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/databasemysql/tmpl"
+)
+
+func TestAccDataSourceDatabaseMySQL_basic(t *testing.T) {
+	t.Parallel()
+
+	resName := "data.linode_database_mysql.foobar"
+	dbName := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, tmpl.TemplateData{
+					Engine:          engineVersion,
+					Label:           dbName,
+					AllowedIP:       "0.0.0.0/0",
+					ClusterSize:     1,
+					Encrypted:       true,
+					ReplicationType: "none",
+					SSLConnection:   true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					checkMySQLDatabaseExists,
+					resource.TestCheckResourceAttr(resName, "engine_id", engineVersion),
+					resource.TestCheckResourceAttr(resName, "label", dbName),
+					resource.TestCheckResourceAttr(resName, "region", "us-southeast"),
+					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
+
+					resource.TestCheckResourceAttr(resName, "allow_list.#", "1"),
+					resource.TestCheckResourceAttr(resName, "allow_list.0", "0.0.0.0/0"),
+
+					resource.TestCheckResourceAttr(resName, "cluster_size", "1"),
+					resource.TestCheckResourceAttr(resName, "encrypted", "true"),
+					resource.TestCheckResourceAttr(resName, "replication_type", "none"),
+					resource.TestCheckResourceAttr(resName, "ssl_connection", "true"),
+
+					resource.TestCheckResourceAttrSet(resName, "ca_cert"),
+					resource.TestCheckResourceAttrSet(resName, "created"),
+					resource.TestCheckResourceAttrSet(resName, "host_primary"),
+					resource.TestCheckResourceAttrSet(resName, "host_secondary"),
+					resource.TestCheckResourceAttrSet(resName, "root_password"),
+					resource.TestCheckResourceAttr(resName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resName, "updated"),
+					resource.TestCheckResourceAttrSet(resName, "root_password"),
+
+					resource.TestCheckResourceAttr(resName, "engine", strings.Split(engineVersion, "/")[0]),
+					resource.TestCheckResourceAttr(resName, "version", strings.Split(engineVersion, "/")[1]),
+				),
+			},
+		},
+	})
+}

--- a/linode/databasemysql/schema_datasource.go
+++ b/linode/databasemysql/schema_datasource.go
@@ -1,0 +1,114 @@
+package databasemysql
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var dataSourceSchema = map[string]*schema.Schema{
+	"database_id": {
+		Type:        schema.TypeInt,
+		Required:    true,
+		Description: "The ID of the MySQL database.",
+	},
+
+	"engine_id": {
+		Type:        schema.TypeString,
+		Description: "The Managed Database engine in engine/version format. (e.g. mysql/8.0.26)",
+		Computed:    true,
+	},
+	"label": {
+		Type:        schema.TypeString,
+		Description: "A unique, user-defined string referring to the Managed Database.",
+		Computed:    true,
+	},
+	"region": {
+		Type:        schema.TypeString,
+		Description: "The region to use for the Managed Database.",
+		Computed:    true,
+	},
+	"type": {
+		Type:        schema.TypeString,
+		Description: "The Linode Instance type used by the Managed Database for its nodes.",
+		Computed:    true,
+	},
+	"allow_list": {
+		Type: schema.TypeSet,
+		Description: "A list of IP addresses that can access the Managed Database. " +
+			"Each item can be a single IP address or a range in CIDR format.",
+		Computed: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	},
+	"cluster_size": {
+		Type:        schema.TypeInt,
+		Description: "The number of Linode Instance nodes deployed to the Managed Database. Defaults to 1.",
+		Computed:    true,
+	},
+	"encrypted": {
+		Type:        schema.TypeBool,
+		Description: "Whether the Managed Databases is encrypted.",
+		Computed:    true,
+	},
+	"replication_type": {
+		Type:        schema.TypeString,
+		Description: "The replication method used for the Managed Database.",
+		Computed:    true,
+	},
+	"ssl_connection": {
+		Type:        schema.TypeBool,
+		Description: "Whether to require SSL credentials to establish a connection to the Managed Database.",
+		Computed:    true,
+	},
+	"ca_cert": {
+		Type:        schema.TypeString,
+		Description: "The base64-encoded SSL CA certificate for the Managed Database instance.",
+		Computed:    true,
+		Sensitive:   true,
+	},
+	"created": {
+		Type:        schema.TypeString,
+		Description: "When this Managed Database was created.",
+		Computed:    true,
+	},
+	"engine": {
+		Type:        schema.TypeString,
+		Description: "The Managed Database engine.",
+		Computed:    true,
+	},
+	"host_primary": {
+		Type:        schema.TypeString,
+		Description: "The primary host for the Managed Database.",
+		Computed:    true,
+	},
+	"host_secondary": {
+		Type:        schema.TypeString,
+		Description: "The secondary host for the Managed Database.",
+		Computed:    true,
+	},
+	"root_password": {
+		Type:        schema.TypeString,
+		Description: "The randomly-generated root password for the Managed Database instance.",
+		Computed:    true,
+		Sensitive:   true,
+	},
+	"status": {
+		Type:        schema.TypeString,
+		Description: "The operating status of the Managed Database.",
+		Computed:    true,
+	},
+	"updated": {
+		Type:        schema.TypeString,
+		Description: "When this Managed Database was last updated.",
+		Computed:    true,
+	},
+	"root_username": {
+		Type:        schema.TypeString,
+		Description: "The root username for the Managed Database instance.",
+		Computed:    true,
+		Sensitive:   true,
+	},
+	"version": {
+		Type:        schema.TypeString,
+		Description: "The Managed Database engine version.",
+		Computed:    true,
+	},
+}

--- a/linode/databasemysql/tmpl/data_basic.gotf
+++ b/linode/databasemysql/tmpl/data_basic.gotf
@@ -1,0 +1,9 @@
+{{ define "database_mysql_data_basic" }}
+
+{{ template "database_mysql_complex" . }}
+
+data "linode_database_mysql" "foobar" {
+    database_id = linode_database_mysql.foobar.id
+}
+
+{{ end }}

--- a/linode/databasemysql/tmpl/template.go
+++ b/linode/databasemysql/tmpl/template.go
@@ -28,3 +28,8 @@ func Complex(t *testing.T, data TemplateData) string {
 	return acceptance.ExecuteTemplate(t,
 		"database_mysql_complex", data)
 }
+
+func DataBasic(t *testing.T, data TemplateData) string {
+	return acceptance.ExecuteTemplate(t,
+		"database_mysql_data_basic", data)
+}

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -128,6 +128,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"linode_account":                account.DataSource(),
 			"linode_database_engines":       databaseengines.DataSource(),
+			"linode_database_mysql":         databasemysql.DataSource(),
 			"linode_database_mysql_backups": databasemysqlbackups.DataSource(),
 			"linode_databases":              databases.DataSource(),
 			"linode_domain":                 domain.DataSource(),

--- a/website/docs/d/database_mysql.html.md
+++ b/website/docs/d/database_mysql.html.md
@@ -1,0 +1,71 @@
+---
+layout: "linode"
+page_title: "Linode: linode_database_mysql"
+sidebar_current: "docs-linode-datasource-database-mysql"
+description: |-
+Provides information about a Linode MySQL Database.
+---
+
+# Data Source: linode\_database\_mysql
+
+**NOTICE:** Managed Databases are currently in beta. Ensure `api_version` is set to `v4beta` in order to use this data source.
+
+Provides information about a Linode MySQL Database.
+
+## Example Usage
+
+Get information about a MySQL database:
+
+```hcl
+data "linode_database_mysql" "my-db" {
+  database_id = 12345
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `database_id` - The ID of the MySQL database.
+
+## Attributes
+
+The `linode_database_mysql` data source exports the following attributes:
+
+* `allow_list` - A list of IP addresses that can access the Managed Database. Each item can be a single IP address or a range in CIDR format.
+
+* `ca_cert` - The base64-encoded SSL CA certificate for the Managed Database instance.
+
+* `cluster_size` - The number of Linode Instance nodes deployed to the Managed Database.
+
+* `created` - When this Managed Database was created.
+
+* `encrypted` - Whether the Managed Databases is encrypted.
+
+* `engine` - The Managed Database engine. (e.g. `mysql`)
+
+* `engine_id` - The Managed Database engine in engine/version format. (e.g. `mysql/8.0.26`)
+
+* `host_primary` - The primary host for the Managed Database.
+
+* `host_secondary` - The secondary/private network host for the Managed Database.
+
+* `label` - A unique, user-defined string referring to the Managed Database.
+
+* `region` - The region that hosts this Linode Managed Database.
+
+* `root_password` - The randomly-generated root password for the Managed Database instance.
+
+* `root_username` - The root username for the Managed Database instance.
+
+* `replication_type` - The replication method used for the Managed Database. (`none`, `asynch`, `semi_synch`)
+
+* `ssl_connection` - Whether to require SSL credentials to establish a connection to the Managed Database.
+
+* `status` - The operating status of the Managed Database.
+
+* `type` - The Linode Instance type used for the nodes of the  Managed Database instance.
+
+* `updated` - When this Managed Database was last updated.
+
+* `version` - The Managed Database engine version. (e.g. `v8.0.26`)


### PR DESCRIPTION
This pull request adds a `linode_database_mysql` data source that can be used to retrieve information about a Linode MySQL Database.

Usage: 
```hcl
data "linode_database_mysql" "foobar" {
    database_id = 12345
}
```