### PR TITLE
ref: Dynamically resolve MySQL engine version for tests

### DIFF
--- a/linode/databaseaccesscontrols/resource_test.go
+++ b/linode/databaseaccesscontrols/resource_test.go
@@ -3,6 +3,7 @@ package databaseaccesscontrols_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"testing"
 
@@ -15,10 +16,21 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
-// TODO: resolve this dynamically
-const engineVersion = "mysql/8.0.26"
+var engineVersion string
 
-func init() {}
+func init() {
+	client, err := acceptance.GetClientForSweepers()
+	if err != nil {
+		log.Fatalf("failed to get client: %s", err)
+	}
+
+	v, err := helper.ResolveValidDBEngine(context.Background(), *client, "mysql")
+	if err != nil {
+		log.Fatalf("failde to get db engine version: %s", err)
+	}
+
+	engineVersion = v.ID
+}
 
 func TestAccResourceDatabaseMySQLAccessControls_basic(t *testing.T) {
 	t.Parallel()

--- a/linode/databasemysql/resource_test.go
+++ b/linode/databasemysql/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper"
+	"log"
 	"strconv"
 	"strings"
 	"testing"
@@ -16,14 +17,25 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/databasemysql/tmpl"
 )
 
-// TODO: resolve this dynamically
-const engineVersion = "mysql/8.0.26"
+var engineVersion string
 
 func init() {
 	resource.AddTestSweepers("linode_database_mysql", &resource.Sweeper{
 		Name: "linode_database_mysql",
 		F:    sweep,
 	})
+
+	client, err := acceptance.GetClientForSweepers()
+	if err != nil {
+		log.Fatalf("failed to get client: %s", err)
+	}
+
+	v, err := helper.ResolveValidDBEngine(context.Background(), *client, "mysql")
+	if err != nil {
+		log.Fatalf("failde to get db engine version: %s", err)
+	}
+
+	engineVersion = v.ID
 }
 
 func sweep(prefix string) error {

--- a/linode/databases/tmpl/template.go
+++ b/linode/databases/tmpl/template.go
@@ -13,21 +13,18 @@ type TemplateData struct {
 	Label  string
 }
 
-// TODO: resolve this dynamically at runtime
-const engineSlug = "mysql/8.0.26"
-
-func ByLabel(t *testing.T, instLabel, dsLabel string) string {
+func ByLabel(t *testing.T, engineVersion, instLabel, dsLabel string) string {
 	return acceptance.ExecuteTemplate(t,
 		"databases_data_by_label", TemplateData{
-			DB:    databasemysqltmpl.TemplateData{Engine: engineSlug, Label: instLabel},
+			DB:    databasemysqltmpl.TemplateData{Engine: engineVersion, Label: instLabel},
 			Label: dsLabel,
 		})
 }
 
-func ByEngine(t *testing.T, label, engine string) string {
+func ByEngine(t *testing.T, engineVersion, label, engine string) string {
 	return acceptance.ExecuteTemplate(t,
 		"databases_data_by_engine", TemplateData{
-			DB:     databasemysqltmpl.TemplateData{Engine: engineSlug, Label: label},
+			DB:     databasemysqltmpl.TemplateData{Engine: engineVersion, Label: label},
 			Engine: engine,
 		})
 }

--- a/linode/helper/database.go
+++ b/linode/helper/database.go
@@ -1,0 +1,27 @@
+package helper
+
+import (
+	"context"
+
+	"github.com/linode/linodego"
+)
+
+func ResolveValidDBEngine(
+	ctx context.Context, client linodego.Client, engine string) (*linodego.DatabaseEngine, error) {
+	filter := linodego.Filter{}
+	filter.AddField(linodego.Eq, "engine", engine)
+
+	filterBytes, err := filter.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	engines, err := client.ListDatabaseEngines(ctx, &linodego.ListOptions{
+		Filter: string(filterBytes),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &engines[0], nil
+}


### PR DESCRIPTION
This change allows acceptance tests to dynamically pull a valid database engine version. This prevents the need for us to update this manually in the future. 