### PR TITLE
fix: Resolve segfault in ID matching logic for linode_object_storage_bucket

### DIFF
--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -477,15 +477,15 @@ func matchRulesWithSchema(rules []*s3.LifecycleRule, declaredRules []interface{}
 	for _, declaredRule := range declaredRules {
 		declaredRule := declaredRule.(map[string]interface{})
 
-		declaredId, ok := declaredRule["id"]
+		declaredID, ok := declaredRule["id"]
 
-		if !ok || len(declaredId.(string)) < 1 {
+		if !ok || len(declaredID.(string)) < 1 {
 			continue
 		}
 
-		if rule, ok := ruleMap[declaredId.(string)]; ok {
+		if rule, ok := ruleMap[declaredID.(string)]; ok {
 			result = append(result, rule)
-			delete(ruleMap, declaredId.(string))
+			delete(ruleMap, declaredID.(string))
 		}
 	}
 

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -467,27 +467,29 @@ func expandLifecycleRules(ruleSpecs []interface{}) ([]*s3.LifecycleRule, error) 
 }
 
 func matchRulesWithSchema(rules []*s3.LifecycleRule, declaredRules []interface{}) []*s3.LifecycleRule {
-	result := make([]*s3.LifecycleRule, len(declaredRules))
+	result := make([]*s3.LifecycleRule, 0)
 
 	ruleMap := make(map[string]*s3.LifecycleRule, len(declaredRules))
 	for _, rule := range rules {
 		ruleMap[*rule.ID] = rule
 	}
 
-	for i, declaredRule := range declaredRules {
+	for _, declaredRule := range declaredRules {
 		declaredRule := declaredRule.(map[string]interface{})
 
-		for key, rule := range ruleMap {
-			if *rule.ID != declaredRule["id"] {
-				continue
-			}
+		declaredId, ok := declaredRule["id"]
 
-			result[i] = rule
-			delete(ruleMap, key)
-			break
+		if !ok || len(declaredId.(string)) < 1 {
+			continue
+		}
+
+		if rule, ok := ruleMap[declaredId.(string)]; ok {
+			result = append(result, rule)
+			delete(ruleMap, declaredId.(string))
 		}
 	}
 
+	// populate remaining values
 	for _, rule := range ruleMap {
 		result = append(result, rule)
 	}

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -282,6 +282,36 @@ func TestAccResourceBucket_lifecycle(t *testing.T) {
 	})
 }
 
+func TestAccResourceBucket_lifecycleNoID(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_object_storage_bucket.foobar"
+	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
+	objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.LifeCycleNoID(t, objectStorageBucketName, objectStorageKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "label", objectStorageBucketName),
+					resource.TestCheckResourceAttr(resName, "cluster", "us-east-1"),
+					resource.TestCheckResourceAttr(resName, "lifecycle_rule.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "lifecycle_rule.0.id"),
+					resource.TestCheckResourceAttr(resName, "lifecycle_rule.0.prefix", "tf"),
+					resource.TestCheckResourceAttr(resName, "lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resName, "lifecycle_rule.0.expiration.#", "1"),
+					resource.TestCheckResourceAttr(resName, "lifecycle_rule.0.abort_incomplete_multipart_upload_days", "5"),
+					resource.TestCheckResourceAttrSet(resName, "lifecycle_rule.0.expiration.0.date"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceBucket_cert(t *testing.T) {
 	t.Parallel()
 

--- a/linode/objbucket/tmpl/lifecycle_no_id.gotf
+++ b/linode/objbucket/tmpl/lifecycle_no_id.gotf
@@ -1,0 +1,24 @@
+{{ define "object_bucket_lifecycle_no_id" }}
+
+{{ template "object_key_basic" .Key }}
+
+resource "linode_object_storage_bucket" "foobar" {
+    access_key = linode_object_storage_key.foobar.access_key
+    secret_key = linode_object_storage_key.foobar.secret_key
+
+    cluster = "us-east-1"
+    label = "{{.Label}}"
+
+    lifecycle_rule {
+        prefix = "tf"
+        enabled = true
+
+        abort_incomplete_multipart_upload_days = 5
+
+        expiration {
+            date = "2021-06-21"
+        }
+    }
+}
+
+{{ end }}

--- a/linode/objbucket/tmpl/template.go
+++ b/linode/objbucket/tmpl/template.go
@@ -64,6 +64,14 @@ func LifeCycle(t *testing.T, label, keyName string) string {
 		})
 }
 
+func LifeCycleNoID(t *testing.T, label, keyName string) string {
+	return acceptance.ExecuteTemplate(t,
+		"object_bucket_lifecycle_no_id", TemplateData{
+			Key:   objkey.TemplateData{Label: keyName},
+			Label: label,
+		})
+}
+
 func LifeCycleUpdates(t *testing.T, label, keyName string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_bucket_lifecycle_updates", TemplateData{


### PR DESCRIPTION
This pull request resolves a change introduced in `v1.27.0` that would cause segfaults when attempting to create lifecycle rules with unspecified IDs.

Resolves #630 