### PR TITLE
new: Add `linode_instance_shared_ips` resource

### DIFF
--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -278,6 +278,7 @@ var resourceSchema = map[string]*schema.Schema{
 			},
 		},
 		Optional: true,
+		Computed: true,
 	},
 	"specs": {
 		Computed:    true,

--- a/linode/instancesharedips/resource.go
+++ b/linode/instancesharedips/resource.go
@@ -1,0 +1,101 @@
+package instancesharedips
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func Resource() *schema.Resource {
+	return &schema.Resource{
+		Schema:        resourceSchema,
+		ReadContext:   readResource,
+		CreateContext: createResource,
+		UpdateContext: updateResource,
+		DeleteContext: deleteResource,
+	}
+}
+
+func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	linodeID := d.Get("linode_id").(int)
+	sharedIPs, err := GetSharedIPsForLinode(ctx, client, linodeID)
+	if err != nil {
+		return diag.Errorf("failed to get shared ips for linode %d: %s", linodeID, err)
+	}
+
+	d.Set("addresses", sharedIPs)
+	return nil
+}
+
+func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId(strconv.Itoa(d.Get("linode_id").(int)))
+
+	return updateResource(ctx, d, meta)
+}
+
+func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	linodeID := d.Get("linode_id").(int)
+	ips := helper.ExpandStringSet(d.Get("addresses").(*schema.Set))
+
+	if d.HasChange("addresses") {
+		err := client.ShareIPAddresses(ctx, linodego.IPAddressesShareOptions{
+			LinodeID: linodeID,
+			IPs:      ips,
+		})
+
+		if err != nil {
+			return diag.Errorf("failed to update ips for linode %d: %s", linodeID, err)
+		}
+	}
+
+	return readResource(ctx, d, meta)
+}
+
+func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	linodeID := d.Get("linode_id").(int)
+
+	err := client.ShareIPAddresses(ctx, linodego.IPAddressesShareOptions{
+		LinodeID: linodeID,
+		IPs:      []string{},
+	})
+
+	if err != nil {
+		return diag.Errorf("failed to update ips for linode %d: %s", linodeID, err)
+	}
+
+	return nil
+}
+
+func GetSharedIPsForLinode(ctx context.Context, client linodego.Client, linodeID int) ([]string, error) {
+	networking, err := client.GetInstanceIPAddresses(ctx, linodeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance (%d) networking: %s", linodeID, err)
+	}
+
+	result := make([]string, 0)
+	for _, ip := range networking.IPv4.Shared {
+		result = append(result, ip.Address)
+	}
+
+	for _, ip := range networking.IPv6.Global {
+		// BGP ips will not have a route target
+		if ip.RouteTarget != "" {
+			continue
+		}
+
+		result = append(result, ip.Range)
+	}
+
+	return result, nil
+}

--- a/linode/instancesharedips/resource_test.go
+++ b/linode/instancesharedips/resource_test.go
@@ -1,0 +1,105 @@
+package instancesharedips_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+	"github.com/linode/terraform-provider-linode/linode/instancesharedips"
+	"github.com/linode/terraform-provider-linode/linode/instancesharedips/tmpl"
+)
+
+const resourcePrimaryNode = "linode_instance.primary"
+const resourceSecondaryNode = "linode_instance.secondary"
+const resourcePrimaryShare = "linode_instance_shared_ips.share-primary"
+const resourceSecondaryShare = "linode_instance_shared_ips.share-secondary"
+
+func TestAccInstanceSharedIPs_update(t *testing.T) {
+	t.Parallel()
+
+	var primaryInstance, secondaryInstance linodego.Instance
+
+	name := acctest.RandomWithPrefix("tf_test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.SingleNode(t, name),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resourcePrimaryNode, &primaryInstance),
+					acceptance.CheckInstanceExists(resourceSecondaryNode, &secondaryInstance),
+
+					checkInstanceSharedIPCount(resourcePrimaryNode, 1),
+					checkInstanceSharedIPCount(resourceSecondaryNode, 0),
+
+					resource.TestCheckResourceAttr(resourcePrimaryShare, "addresses.#", "1"),
+				),
+			},
+			{
+				Config: tmpl.DualNode(t, name),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resourcePrimaryNode, &primaryInstance),
+					acceptance.CheckInstanceExists(resourceSecondaryNode, &secondaryInstance),
+
+					checkInstanceSharedIPCount(resourcePrimaryNode, 1),
+					checkInstanceSharedIPCount(resourceSecondaryNode, 1),
+
+					resource.TestCheckResourceAttr(resourcePrimaryShare, "addresses.#", "1"),
+					resource.TestCheckResourceAttr(resourceSecondaryShare, "addresses.#", "1"),
+				),
+			},
+			{
+				Config: tmpl.SingleNode(t, name),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resourcePrimaryNode, &primaryInstance),
+					acceptance.CheckInstanceExists(resourceSecondaryNode, &secondaryInstance),
+
+					checkInstanceSharedIPCount(resourcePrimaryNode, 1),
+					checkInstanceSharedIPCount(resourceSecondaryNode, 0),
+
+					resource.TestCheckResourceAttr(resourcePrimaryShare, "addresses.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func checkInstanceSharedIPCount(name string, length int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.TestAccProvider.Meta().(*helper.ProviderMeta).Client
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		ips, err := instancesharedips.GetSharedIPsForLinode(context.Background(), client, id)
+		if err != nil {
+			return err
+		}
+
+		if len(ips) != length {
+			return fmt.Errorf("lengths do not match: %d != %d", len(ips), length)
+		}
+
+		return nil
+	}
+}

--- a/linode/instancesharedips/schema_resource.go
+++ b/linode/instancesharedips/schema_resource.go
@@ -1,0 +1,18 @@
+package instancesharedips
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+var resourceSchema = map[string]*schema.Schema{
+	"linode_id": {
+		Type:        schema.TypeInt,
+		Description: "The ID of the Linode to share these IP addresses with.",
+		Required:    true,
+		ForceNew:    true,
+	},
+	"addresses": {
+		Type:        schema.TypeSet,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Description: "A set of IP addresses to share to the Linode",
+		Required:    true,
+	},
+}

--- a/linode/instancesharedips/tmpl/configs.gotf
+++ b/linode/instancesharedips/tmpl/configs.gotf
@@ -1,0 +1,61 @@
+{{ define "instance_shared_ips_single_node" }}
+
+# Share with primary node
+resource "linode_instance_shared_ips" "share-primary" {
+    linode_id = linode_instance.primary.id
+    addresses = [linode_ipv6_range.foobar.range]
+}
+
+resource "linode_ipv6_range" "foobar" {
+    prefix_length = 64
+    linode_id = linode_instance.primary.id
+}
+
+resource "linode_instance" "primary" {
+    label = "{{.Label}}-primary"
+    type = "g6-nanode-1"
+    region = "eu-central"
+}
+
+resource "linode_instance" "secondary" {
+    label = "{{.Label}}-secondary"
+    type = "g6-nanode-1"
+    region = "eu-central"
+}
+
+{{ end }}
+
+{{ define "instance_shared_ips_dual_node" }}
+
+# Share with primary node
+resource "linode_instance_shared_ips" "share-primary" {
+    linode_id = linode_instance.primary.id
+    addresses = [linode_ipv6_range.foobar.range]
+}
+
+# Share with secondary nodes
+resource "linode_instance_shared_ips" "share-secondary" {
+    depends_on = [linode_instance_shared_ips.share-primary]
+
+    linode_id = linode_instance.secondary.id
+    addresses = [linode_ipv6_range.foobar.range]
+}
+
+resource "linode_ipv6_range" "foobar" {
+    prefix_length = 64
+    linode_id = linode_instance.primary.id
+}
+
+resource "linode_instance" "primary" {
+    label = "{{.Label}}-primary"
+    type = "g6-nanode-1"
+    region = "eu-central"
+}
+
+resource "linode_instance" "secondary" {
+    label = "{{.Label}}-secondary"
+    type = "g6-nanode-1"
+    region = "eu-central"
+}
+
+{{ end }}

--- a/linode/instancesharedips/tmpl/template.go
+++ b/linode/instancesharedips/tmpl/template.go
@@ -1,0 +1,25 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+type TemplateData struct {
+	Label string
+}
+
+func SingleNode(t *testing.T, instanceLabel string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_shared_ips_single_node", TemplateData{
+			Label: instanceLabel,
+		})
+}
+
+func DualNode(t *testing.T, instanceLabel string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_shared_ips_dual_node", TemplateData{
+			Label: instanceLabel,
+		})
+}

--- a/linode/ipv6range/resource.go
+++ b/linode/ipv6range/resource.go
@@ -30,7 +30,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	r, err := client.GetIPv6Range(ctx, d.Id())
 	if err != nil {
-		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
+		if lerr, ok := err.(*linodego.Error); ok && (lerr.Code == 404 || lerr.Code == 405) {
 			d.SetId("")
 			log.Printf("[WARN] IPv6 range \"%s\" does not exist, removing from state.", d.Id())
 			return nil

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/images"
 	"github.com/linode/terraform-provider-linode/linode/instance"
 	"github.com/linode/terraform-provider-linode/linode/instanceip"
+	"github.com/linode/terraform-provider-linode/linode/instancesharedips"
 	"github.com/linode/terraform-provider-linode/linode/instancetype"
 	"github.com/linode/terraform-provider-linode/linode/instancetypes"
 	"github.com/linode/terraform-provider-linode/linode/ipv6range"
@@ -168,6 +169,7 @@ func Provider() *schema.Provider {
 			"linode_image":                    image.Resource(),
 			"linode_instance":                 instance.Resource(),
 			"linode_instance_ip":              instanceip.Resource(),
+			"linode_instance_shared_ips":      instancesharedips.Resource(),
 			"linode_ipv6_range":               ipv6range.Resource(),
 			"linode_lke_cluster":              lke.Resource(),
 			"linode_nodebalancer":             nb.Resource(),

--- a/website/docs/r/instance_shared_ips.html.md
+++ b/website/docs/r/instance_shared_ips.html.md
@@ -1,0 +1,101 @@
+---
+layout: "linode"
+page_title: "Linode: linode_instance_shared_ips"
+sidebar_current: "docs-linode-instance-shared-ips"
+description: |-
+  Manages IP addresses shared to a Linode.
+---
+
+# linode\_instance\_shared\_ips
+
+~> **NOTICE:** This resource should only be defined once per-instance and should not be used alongside the `shared_ipv4` field in `linode_instance`.
+
+~> **NOTICE:** IPv6 sharing is currently available through early access. To learn more, see the [early access documentation](https://github.com/linode/terraform-provider-linode/tree/main/EARLY_ACCESS.md).
+
+Manages IPs shared to a Linode instance.
+
+## Example Usage
+
+Share in IPv4 address between two instances:
+
+```terraform
+# Share the IP with the secondary node
+resource "linode_instance_shared_ips" "share-primary" {
+  linode_id = linode_instance.secondary.id
+  addresses = [linode_instance_ip.primary.address]
+}
+
+# Allocate an IP under the primary node
+resource "linode_instance_ip" "primary" {
+  linode_id = linode_instance.primary.id
+}
+
+# Create a single primary node
+resource "linode_instance" "primary" {
+  label = "node-primary"
+  type = "g6-nanode-1"
+  region = "eu-central"
+}
+
+# Create a secondary node
+resource "linode_instance" "secondary" {
+  label = "node-secondary"
+  type = "g6-nanode-1"
+  region = "eu-central"
+}
+```
+
+Share an IPv6 address among a primary node and its replicas:
+
+```terraform
+# Share with primary node
+resource "linode_instance_shared_ips" "share-primary" {
+  linode_id = linode_instance.primary.id
+  addresses = [linode_ipv6_range.range.range]
+}
+
+# Share with secondary nodes
+resource "linode_instance_shared_ips" "share-secondary" {
+  count = var.number_replicas
+
+  # Ranges must be shared with their primary node before being shared with a secondary
+  depends_on = [linode_instance_shared_ips.share-primary]
+
+  linode_id = linode_instance.secondary[count.index].id
+  addresses = [linode_ipv6_range.range.range]
+}
+
+# Allocate an IPv6 range pointing at the primary node
+resource "linode_ipv6_range" "range" {
+  prefix_length = 64
+  linode_id = linode_instance.primary.id
+}
+
+# Create a single primary node
+resource "linode_instance" "primary" {
+  label = "node-primary"
+  type = "g6-nanode-1"
+  region = "eu-central"
+}
+
+# Create two secondary nodes
+resource "linode_instance" "secondary" {
+  count = var.number_replicas
+
+  label = "node-secondary-${count.index}"
+  type = "g6-nanode-1"
+  region = "eu-central"
+}
+
+variable "number_replicas" {
+  default = 2
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `linode_id` - (Required) The ID of the Linode to share the IPs to.
+
+* `addresses` - (Required) The set of IPs to share with the Linode.

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -130,6 +130,9 @@
             <li<%= sidebar_current("docs-linode-resource-instance-ip") %>>
               <a href="/docs/providers/linode/r/instance_ip.html">linode_instance_ip</a>
             </li>
+            <li<%= sidebar_current("docs-linode-resource-instance-shared-ips") %>>
+              <a href="/docs/providers/linode/r/instance_shared_ips.html">linode_instance_shared_ips</a>
+            </li>
             <li<%= sidebar_current("docs-linode-resource-ipv6-range") %>>
               <a href="/docs/providers/linode/r/ipv6_range.html">linode_ipv6_range</a>
             </li>


### PR DESCRIPTION
This pull request adds experimental support for a `linode_instance_shared_ips` resource. This resource allows users to manage all IPs shared to an instance. Only one of this resource should be declared per-instance and it should not be used alongside the `shared_ipv4` field.