### PR TITLE
fix: Add DiffSuppressFunc for firewall IPv6 fields

### DIFF
--- a/examples/mysql_adminer/main.tf
+++ b/examples/mysql_adminer/main.tf
@@ -37,7 +37,7 @@ resource "linode_instance" "mysql" {
   label = "my-mysql-server"
   type = data.linode_instance_type.default.id
   region = var.region
-  image = "linode/alpine3.13"
+  image = "linode/alpine3.15"
   authorized_keys = [
     chomp(file(var.public_ssh_key))
   ]
@@ -84,7 +84,7 @@ resource "linode_instance" "adminer" {
   label = "my-adminer-server"
   type = data.linode_instance_type.default.id
   region = var.region
-  image = "linode/alpine3.13"
+  image = "linode/alpine3.15"
   authorized_keys = [
     chomp(file(var.public_ssh_key))
   ]

--- a/linode/backup/datasource_test.go
+++ b/linode/backup/datasource_test.go
@@ -79,7 +79,7 @@ func resourceInstanceBasic(label string) string {
 resource "linode_instance" "foobar" {
 	label = "%s"
 	type = "g6-nanode-1"
-	image = "linode/alpine3.13"
+	image = "linode/alpine3.15"
 	region = "us-east"
 	root_pass = "terraform-test"
 	swap_size = 256

--- a/linode/firewall/schema_resource.go
+++ b/linode/firewall/schema_resource.go
@@ -1,6 +1,9 @@
 package firewall
 
 import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/linode/terraform-provider-linode/linode/helper"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -44,6 +47,19 @@ var resourceRuleSchema = map[string]*schema.Schema{
 		Type: schema.TypeList,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
+			ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+				err := helper.ValidateIPv6Range(i.(string))
+				if err != nil {
+					return diag.FromErr(err)
+				}
+
+				return nil
+			},
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				// We handle validation separately
+				result, _ := helper.CompareIPv6Ranges(oldValue, newValue)
+				return result
+			},
 		},
 		Description: "A list of IPv6 addresses or networks this rule applies to.",
 		Optional:    true,

--- a/linode/firewall/schema_resource.go
+++ b/linode/firewall/schema_resource.go
@@ -1,13 +1,13 @@
 package firewall
 
 import (
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/linode/terraform-provider-linode/linode/helper"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
 var resourceRuleSchema = map[string]*schema.Schema{

--- a/linode/firewall/tmpl/inst.gotf
+++ b/linode/firewall/tmpl/inst.gotf
@@ -7,7 +7,7 @@ resource "linode_instance" "{{.ID}}" {
     region = "ca-central"
     disk {
         label = "disk"
-        image = "linode/alpine3.11"
+        image = "linode/alpine3.15"
         root_pass = "b4d_p4s5"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000

--- a/linode/helper/normalize.go
+++ b/linode/helper/normalize.go
@@ -1,0 +1,24 @@
+package helper
+
+import (
+	"net"
+)
+
+func CompareIPv6Ranges(i, v string) (bool, error) {
+	ipi, ipneti, err := net.ParseCIDR(i)
+	if err != nil {
+		return false, err
+	}
+
+	ipv, ipnetv, err := net.ParseCIDR(v)
+	if err != nil {
+		return false, err
+	}
+
+	return ipi.Equal(ipv) && ipneti.Mask.String() == ipnetv.Mask.String(), nil
+}
+
+func ValidateIPv6Range(i string) error {
+	_, _, err := net.ParseCIDR(i)
+	return err
+}

--- a/linode/helper/normalize_test.go
+++ b/linode/helper/normalize_test.go
@@ -1,8 +1,9 @@
 package helper_test
 
 import (
-	"github.com/linode/terraform-provider-linode/linode/helper"
 	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
 func TestCompareIPv6Ranges(t *testing.T) {

--- a/linode/helper/normalize_test.go
+++ b/linode/helper/normalize_test.go
@@ -1,0 +1,32 @@
+package helper_test
+
+import (
+	"github.com/linode/terraform-provider-linode/linode/helper"
+	"testing"
+)
+
+func TestCompareIPv6Ranges(t *testing.T) {
+	ips := []string{
+		"1111:1111::1111:1111:1111:f88/128",
+		"1111:1111::1111:1111:1111:0f88/128",
+	}
+
+	result, err := helper.CompareIPv6Ranges(ips[0], ips[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result {
+		t.Fatalf("ranges are reported as different despite being equal")
+	}
+
+	ips[1] = "1111:1111::1111:1211:1111:0f88/126"
+	result, err = helper.CompareIPv6Ranges(ips[0], ips[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result {
+		t.Fatalf("ranges are reported as equal despite being different")
+	}
+}

--- a/linode/helper/normalize_test.go
+++ b/linode/helper/normalize_test.go
@@ -21,13 +21,23 @@ func TestCompareIPv6Ranges(t *testing.T) {
 		t.Fatalf("ranges are reported as different despite being equal")
 	}
 
-	ips[1] = "1111:1111::1111:1211:1111:0f88/126"
+	ips[1] = "1111:1111::1111:1211:1111:0f88/128"
 	result, err = helper.CompareIPv6Ranges(ips[0], ips[1])
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if result {
-		t.Fatalf("ranges are reported as equal despite being different")
+		t.Fatalf("ranges are reported as equal despite having different ips")
+	}
+
+	ips[1] = "1111:1111::1111:1111:1111:0f88/127"
+	result, err = helper.CompareIPv6Ranges(ips[0], ips[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result {
+		t.Fatalf("ranges are reported as equal despite having different masks")
 	}
 }

--- a/linode/rdns/tmpl/changed.gotf
+++ b/linode/rdns/tmpl/changed.gotf
@@ -3,7 +3,7 @@
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.12"
+    image = "linode/alpine3.15"
     type = "g6-standard-1"
     region = "us-east"
 }

--- a/linode/rdns/tmpl/deleted.gotf
+++ b/linode/rdns/tmpl/deleted.gotf
@@ -3,7 +3,7 @@
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.12"
+    image = "linode/alpine3.15"
     type = "g6-standard-1"
     region = "us-east"
 }

--- a/linode/vlan/tmpl/data_basic.gotf
+++ b/linode/vlan/tmpl/data_basic.gotf
@@ -3,7 +3,7 @@
 resource "linode_instance" "fooinst" {
     label = "{{.InstLabel}}"
     type = "g6-standard-1"
-    image = "linode/alpine3.13"
+    image = "linode/alpine3.15"
     region = "us-southeast"
 
     interface {

--- a/linode/vlan/tmpl/data_regex.gotf
+++ b/linode/vlan/tmpl/data_regex.gotf
@@ -3,7 +3,7 @@
 resource "linode_instance" "fooinst" {
     label = "{{.InstLabel}}"
     type = "g6-standard-1"
-    image = "linode/alpine3.13"
+    image = "linode/alpine3.15"
     region = "us-southeast"
 
     interface {


### PR DESCRIPTION
This change will suppress diffs on different but equivalent IPv6 ranges in the `linode_firewall` resource.

Resolves #634