### PR TITLE
Honor boot_config_label upon new resource creation

### DIFF
--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -325,6 +325,14 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 
 			configIDLabelMap[v.Label] = k
 		}
+		bootConfigLabel := d.Get("boot_config_label").(string)
+		if bootConfigLabel != "" {
+			if foundConfig, found := configIDLabelMap[bootConfigLabel]; found {
+				bootConfig = foundConfig
+			} else {
+				return diag.Errorf("Error setting boot_config_label: Config label '%s' not found", bootConfigLabel)
+			}
+		}
 	}
 
 	if ipv4Shared, ok := d.GetOk("shared_ipv4"); ok {


### PR DESCRIPTION
Previously cases with multiple Linode configurations would boot into whatever the last configuration happened to be in the internal configIDMap.  This would result in new Linode resources randomly booting into the incorrect configuration, including configurations not yet in a bootable state.  This change makes the behavior consistent with resource updates and honors boot_config_label to determine the preferred configuration if present.
