### PR TITLE
new: Add test to measure API request volume

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,7 +8,6 @@ MARKDOWNLINT_TAG := 0.19.0
 
 ACCTEST_COUNT?=1
 ACCTEST_PARALLELISM?=20
-ACCTEST_POLL_MS?=1000
 ACCTEST_TIMEOUT?=240m
 
 tooldeps:
@@ -47,7 +46,6 @@ test: fmtcheck
 testacc: fmtcheck
 	TF_ACC=1 \
 	LINODE_API_VERSION="v4beta" \
-	LINODE_EVENT_POLL_MS=$(ACCTEST_POLL_MS) \
 	go test -v ./$(PKG_NAME) $(TESTARGS) -count $(ACCTEST_COUNT) -timeout $(ACCTEST_TIMEOUT) -parallel=$(ACCTEST_PARALLELISM) -ldflags="-X=github.com/linode/terraform-provider-linode/version.ProviderVersion=acc"
 
 vet:

--- a/linode/acceptance/test_util.go
+++ b/linode/acceptance/test_util.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -436,4 +437,23 @@ func CreateTempFile(t *testing.T, name, content string) *os.File {
 	}
 
 	return file
+}
+
+type ProviderMetaModifier func(ctx context.Context, config *helper.ProviderMeta) error
+
+func ModifyProviderMeta(t *testing.T, provider *schema.Provider, modifier ProviderMetaModifier) {
+	oldConfigure := provider.ConfigureContextFunc
+
+	provider.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		config, err := oldConfigure(ctx, data)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := modifier(ctx, config.(*helper.ProviderMeta)); err != nil {
+			t.Fatal(err)
+		}
+
+		return config, nil
+	}
 }

--- a/linode/acceptance/test_util.go
+++ b/linode/acceptance/test_util.go
@@ -439,6 +439,14 @@ func CreateTempFile(t *testing.T, name, content string) *os.File {
 	return file
 }
 
+func CreateTestProvider() (*schema.Provider, map[string]*schema.Provider) {
+	provider := linode.Provider()
+	providerMap := map[string]*schema.Provider{
+		"linode": provider,
+	}
+	return provider, providerMap
+}
+
 type ProviderMetaModifier func(ctx context.Context, config *helper.ProviderMeta) error
 
 func ModifyProviderMeta(t *testing.T, provider *schema.Provider, modifier ProviderMetaModifier) {

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -1916,6 +1917,63 @@ func TestAccResourceInstance_ipv4Sharing(t *testing.T) {
 					acceptance.CheckInstanceExists(failoverResName, &instance),
 					resource.TestCheckResourceAttr(failoverResName, "shared_ipv4.#", "0"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceInstance_requestQuantity(t *testing.T) {
+	t.Parallel()
+
+	const maxRequests = 260
+
+	// We need to make sure we're not running into a race condition here
+	var numRequestsLock sync.Mutex
+	numRequests := 0
+	var startTime time.Time
+
+	instanceName := acctest.RandomWithPrefix("tf_test")
+
+	// Let's accumulate the number of Linodego requests made during apply
+	acceptance.ModifyProviderMeta(t, acceptance.TestAccProvider,
+		func(ctx context.Context, config *helper.ProviderMeta) error {
+			config.Client.OnBeforeRequest(func(request *linodego.Request) error {
+				if startTime.IsZero() {
+					startTime = time.Now()
+				}
+
+				numRequestsLock.Lock()
+				defer numRequestsLock.Unlock()
+				numRequests++
+
+				return nil
+			})
+
+			return nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CheckInstanceDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				// Provision a bunch of Linodes and wait for them to boot into an image
+				Config: tmpl.ManyLinodes(t, instanceName, acceptance.PublicKeyMaterial),
+			},
+			{
+				PreConfig: func() {
+					requestsPerMS := float64(numRequests) / float64(time.Since(startTime).Milliseconds())
+
+					t.Logf("\n[INFO] results from 12 linode parallel creation:\n"+
+						"total requests: %d\nfrequency: ~%f requests/second\n", numRequests, requestsPerMS*1000)
+
+					if numRequests > maxRequests {
+						t.Fatalf("too many requests: %d > %d", numRequests, maxRequests)
+					}
+				},
+				Config: tmpl.ManyLinodes(t, instanceName, acceptance.PublicKeyMaterial),
 			},
 		},
 	})

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -1934,8 +1934,9 @@ func TestAccResourceInstance_requestQuantity(t *testing.T) {
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
-	// Let's accumulate the number of Linodego requests made during apply
-	acceptance.ModifyProviderMeta(t, acceptance.TestAccProvider,
+	provider, providerMap := acceptance.CreateTestProvider()
+
+	acceptance.ModifyProviderMeta(t, provider,
 		func(ctx context.Context, config *helper.ProviderMeta) error {
 			config.Client.OnBeforeRequest(func(request *linodego.Request) error {
 				if startTime.IsZero() {
@@ -1954,7 +1955,7 @@ func TestAccResourceInstance_requestQuantity(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
+		Providers:    providerMap,
 		CheckDestroy: acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -445,6 +445,15 @@ func IPv4SharingBadInput(t *testing.T, label string) string {
 		})
 }
 
+func ManyLinodes(t *testing.T, label, pubKey string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_many_linodes", TemplateData{
+			Label:  label,
+			Image:  acceptance.TestImageLatest,
+			PubKey: pubKey,
+		})
+}
+
 func DataBasic(t *testing.T, label string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_data_basic", TemplateData{

--- a/linode/instance/tmpl/templates/many_linodes.gotf
+++ b/linode/instance/tmpl/templates/many_linodes.gotf
@@ -1,0 +1,14 @@
+{{ define "instance_many_linodes" }}
+
+resource "linode_instance" "foobar" {
+    count = 12
+    label = "{{.Label}}-${count.index}"
+    type = "g6-nanode-1"
+    image = "{{.Image}}"
+    region = "us-east"
+    root_pass = "terraform-test"
+    swap_size = 256
+    authorized_keys = ["{{.PubKey}}"]
+}
+
+{{ end }}

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -107,21 +107,21 @@ func Provider() *schema.Provider {
 			"event_poll_ms": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("LINODE_EVENT_POLL_MS", 300),
+				DefaultFunc: schema.EnvDefaultFunc("LINODE_EVENT_POLL_MS", 4000),
 				Description: "The rate in milliseconds to poll for events.",
 			},
 
 			"lke_event_poll_ms": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     300,
+				Default:     3000,
 				Description: "The rate in milliseconds to poll for LKE events.",
 			},
 
 			"lke_node_ready_poll_ms": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     500,
+				Default:     3000,
 				Description: "The rate in milliseconds to poll for an LKE node to be ready.",
 			},
 		},


### PR DESCRIPTION
This pull request adds a test to measure the volume of requests made to the API for parallel Linode creation. If the number of requests exceeds the `maxRequests` value, the test will fail.

This test also reports the frequency of the requests and the number of requests made:
```
[INFO] results from 12 linode parallel creation:
total requests: 186
frequency: ~1.823047 requests/second
```

Depends on https://github.com/linode/linodego/pull/250