### PR TITLE
Fix shebang typo in resource/stackscript docs

### DIFF
--- a/website/docs/r/stackscript.html.md
+++ b/website/docs/r/stackscript.html.md
@@ -16,7 +16,7 @@ The Linode Guide, [Deploy a WordPress Site Using Terraform and Linode StackScrip
 
 ## Example Usage
 
-The following example shows how one might use this resource to configure a StackScript attached to a Linode Instance.  As shown below, StackScripts must begin with a shebang (`#!/`).  The `<UDF ...>` element provided in the Bash comment block defines a variable whose value is provided when creating the Instance (or disk) using the `stackscript_data` field.
+The following example shows how one might use this resource to configure a StackScript attached to a Linode Instance.  As shown below, StackScripts must begin with a shebang (`#!`).  The `<UDF ...>` element provided in the Bash comment block defines a variable whose value is provided when creating the Instance (or disk) using the `stackscript_data` field.
 
 ```hcl
 resource "linode_stackscript" "foo" {


### PR DESCRIPTION
Hi. This is a tiny fix for a typo. A shebang is just `#!`.