### PR TITLE
doc: Add ignore_changes to LKE autoscaler example

### DIFF
--- a/website/docs/r/instance_ip.html.md
+++ b/website/docs/r/instance_ip.html.md
@@ -9,6 +9,7 @@ description: |-
 # linode\_instance\_ip
 
 ~> **NOTICE:** You may need to contact support to increase your instance IP limit before you can allocate additional IPs.
+
 ~> **NOTICE:** This resource will reboot the specified instance following IP allocation.
 
 Manages a Linode instance IP.

--- a/website/docs/r/lke_cluster.html.md
+++ b/website/docs/r/lke_cluster.html.md
@@ -46,6 +46,13 @@ resource "linode_lke_cluster" "my-cluster" {
           max = 10
         }
     }
+
+  # Prevent the count field from overriding autoscaler-created nodes
+  lifecycle {
+    ignore_changes = [
+      pool.0.count
+    ]
+  }
 }
 ```
 

--- a/website/docs/r/lke_cluster.html.md
+++ b/website/docs/r/lke_cluster.html.md
@@ -84,6 +84,8 @@ The following arguments are supported in the `pool` specification block:
 
 ### autoscaler
 
+~> **NOTICE:** To prevent the `count` field from removing nodes created by the autoscaler, consider using the [ignore_changes](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes) lifecycle argument.
+
 The following arguments are supported in the `autoscaler` specification block:
 
 * `min` - (Required) The minimum number of nodes to autoscale to.

--- a/website/docs/r/lke_cluster.html.md
+++ b/website/docs/r/lke_cluster.html.md
@@ -96,7 +96,7 @@ The following arguments are supported in the `autoscaler` specification block:
 
 The following arguments are supported in the `control_plane` specification block:
 
-* `high_availability` - (Optional) Defines whether High Availability is enabled for the cluster Control Plane. This is an **irreversible** change. **NOTICE:** High Availability Control Planes are currently available through early access. To learn more, see the [early access documentation](https://github.com/linode/terraform-provider-linode/tree/master/EARLY_ACCESS.md).
+* `high_availability` - (Optional) Defines whether High Availability is enabled for the cluster Control Plane. This is an **irreversible** change.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This change adds documentation on using the `ignore_changes` field to prevent conflicts between the LKE autoscaler and the node pool `count` field.

See #639 