### PR TITLE
test: Add test to ensure no IPv6 range race condition

### DIFF
--- a/linode/ipv6range/tmpl/race_condition.gotf
+++ b/linode/ipv6range/tmpl/race_condition.gotf
@@ -1,0 +1,20 @@
+{{ define "ipv6range_race_condition" }}
+
+resource "linode_instance" "foobar" {
+    count = 5
+
+    label = "{{.Label}}-${count.index}"
+    type = "g6-nanode-1"
+    region = "us-southeast"
+    booted = false
+}
+
+resource "linode_ipv6_range" "foobar" {
+    count = 5
+
+    linode_id = linode_instance.foobar[count.index].id
+
+    prefix_length = 64
+}
+
+{{ end }}

--- a/linode/ipv6range/tmpl/template.go
+++ b/linode/ipv6range/tmpl/template.go
@@ -43,6 +43,13 @@ func ReassignmentStep2(t *testing.T, label string) string {
 		})
 }
 
+func RaceCondition(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"ipv6range_race_condition", TemplateData{
+			Label: label,
+		})
+}
+
 func DataBasic(t *testing.T, label string) string {
 	return acceptance.ExecuteTemplate(t,
 		"ipv6range_data_basic", TemplateData{


### PR DESCRIPTION
This pull request adds a test to ensure that IPv6 ranges created in parallel will all be allocated separately.