### PR TITLE
new: Add hostname field to linode_object_storage_bucket resource

### DIFF
--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -97,6 +97,7 @@ func readResource(
 	d.SetId(fmt.Sprintf("%s:%s", bucket.Cluster, bucket.Label))
 	d.Set("cluster", bucket.Cluster)
 	d.Set("label", bucket.Label)
+	d.Set("hostname", bucket.Hostname)
 	d.Set("acl", access.ACL)
 	d.Set("cors_enabled", access.CorsEnabled)
 

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -161,6 +161,7 @@ func TestAccResourceBucket_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkBucketExists,
 					resource.TestCheckResourceAttr(resName, "label", objectStorageBucketName),
+					resource.TestCheckResourceAttrSet(resName, "hostname"),
 				),
 			},
 			{

--- a/linode/objbucket/schema_resource.go
+++ b/linode/objbucket/schema_resource.go
@@ -44,6 +44,12 @@ var resourceSchema = map[string]*schema.Schema{
 		RequiredWith: []string{"access_key", "secret_key"},
 		Elem:         resourceLifeCycle(),
 	},
+	"hostname": {
+		Type: schema.TypeString,
+		Description: "The hostname where this bucket can be accessed. " +
+			"This hostname can be accessed through a browser if the bucket is made public.",
+		Computed: true,
+	},
 	"versioning": {
 		Type:         schema.TypeBool,
 		Description:  "Whether to enable versioning.",


### PR DESCRIPTION
This pull request adds a `hostname` field to the `linode_object_storage_bucket` resource to allow users to reliably resolve the hostname of their bucket.