### PR TITLE
fix: Raise unhandled error in createResourceFromUpload

### DIFF
--- a/linode/image/resource.go
+++ b/linode/image/resource.go
@@ -131,7 +131,7 @@ func createResourceFromUpload(
 
 	imageReader, err := imageFromResourceData(d)
 	if err != nil {
-		diag.Errorf("failed to get image source: %v", err)
+		return diag.Errorf("failed to get image source: %v", err)
 	}
 	defer imageReader.Close()
 


### PR DESCRIPTION
This change resolves an issue where errors opening the file at `file_path` would not be raised and would result in a segfault.