### PR TITLE
fix: Handle resolving the previous K8s version only one version is available

### DIFF
--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -51,8 +51,18 @@ func init() {
 
 	sort.Strings(k8sVersions)
 
+	if len(k8sVersions) < 1 {
+		log.Fatal("no k8s versions found")
+	}
+
 	k8sVersionLatest = k8sVersions[len(k8sVersions)-1]
-	k8sVersionPrevious = k8sVersions[len(k8sVersions)-2]
+
+	k8sVersionPrevious = k8sVersionLatest
+
+	// If there are multiple images, use the second to last image
+	if len(k8sVersions) > 1 {
+		k8sVersionPrevious = k8sVersions[len(k8sVersions)-2]
+	}
 }
 
 func sweep(prefix string) error {


### PR DESCRIPTION
This pull request resolves an issue that would cause a nullptr dereference when trying to resolve the previous K8s version where only one version exists.