### PR TITLE
fix: Wait for linode_instance_disk ready status

### DIFF
--- a/linode/instancedisk/resource.go
+++ b/linode/instancedisk/resource.go
@@ -123,6 +123,11 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.Errorf("failed to wait for instance shutdown: %s", err)
 	}
 
+	if _, err := client.WaitForInstanceDiskStatus(
+		ctx, linodeID, disk.ID, linodego.DiskReady, helper.GetDeadlineSeconds(ctx, d)); err != nil {
+		return diag.Errorf("failed ot wait for disk ready: %s", err)
+	}
+
 	return readResource(ctx, d, meta)
 }
 


### PR DESCRIPTION
This pull request causes the `linode_instance_disk` create routine to wait for a disk to be in a `ready` status. This is necessary because the `disk_create` event does not reliably ensure the disk is ready. 