### PR TITLE
fix: Normalize values to underlying types in filter data sources

### DIFF
--- a/linode/helper/filter.go
+++ b/linode/helper/filter.go
@@ -464,6 +464,9 @@ func (f FilterConfig) validateFilter(
 		return recursiveValidate()
 	}
 
+	// Normalize item value types
+	itemValue = normalizeItemValue(itemValue)
+
 	cfg := f[name]
 
 	valuesNormalized := make([]interface{}, len(values))
@@ -533,6 +536,23 @@ func validateFilterRegex(name string, values []interface{}, result interface{}) 
 	}
 
 	return false, nil
+}
+
+// normalizeItemValue converts similar item values (i.e. enum types) into their underlying types.
+func normalizeItemValue(value any) any {
+	kind := reflect.TypeOf(value).Kind()
+	rValue := reflect.ValueOf(value)
+
+	switch kind {
+	case reflect.String:
+		return rValue.String()
+	case reflect.Int:
+		return int(rValue.Int())
+	case reflect.Bool:
+		return rValue.Bool()
+	}
+
+	return value
 }
 
 func FilterTypeString(value string) (interface{}, error) {

--- a/linode/helper/filter.go
+++ b/linode/helper/filter.go
@@ -19,6 +19,14 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// validFilterValueTypes is a list of valid underlying types for filterable fields.
+var validFilterValueTypes = []reflect.Kind{
+	reflect.String, reflect.Int,
+	reflect.Int32, reflect.Array,
+	reflect.Float64, reflect.Float32,
+	reflect.Slice, reflect.Bool,
+}
+
 // FilterConfig stores a map of FilterAttributes for a resource.
 type FilterConfig map[string]FilterAttribute
 
@@ -458,6 +466,11 @@ func (f FilterConfig) validateFilter(
 		return false, nil
 	}
 
+	// Ensure that the filter value has a valid type
+	if err := validateItemValueType(itemValue); err != nil {
+		return false, err
+	}
+
 	// Filter recursively on lists (tags, ids, etc.); calling a closure
 	// for code readability.
 	if reflect.TypeOf(itemValue).Kind() == reflect.Slice {
@@ -553,6 +566,22 @@ func normalizeItemValue(value any) any {
 	}
 
 	return value
+}
+
+// validateItemValueType ensures that all underlying filter values have a supported underlying type.
+func validateItemValueType(value any) error {
+	kind := reflect.TypeOf(value).Kind()
+
+	for _, v := range validFilterValueTypes {
+		if kind == v {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("The underlying type (%v) for this filterable field is not supported. "+
+		"This is always a provider bug. Please create an issue describing this bug on the terraform-provider-linode "+
+		"GitHub repository. (https://github.com/linode/terraform-provider-linode/issues)",
+		kind)
 }
 
 func FilterTypeString(value string) (interface{}, error) {

--- a/linode/images/schema_datasource.go
+++ b/linode/images/schema_datasource.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper"
 	"github.com/linode/terraform-provider-linode/linode/image"
 )
@@ -15,13 +14,9 @@ var filterConfig = helper.FilterConfig{
 	"type":       {APIFilterable: true, TypeFunc: helper.FilterTypeString},
 	"vendor":     {APIFilterable: true, TypeFunc: helper.FilterTypeString},
 
-	"created_by": {TypeFunc: helper.FilterTypeString},
-	"id":         {TypeFunc: helper.FilterTypeString},
-	"status": {
-		TypeFunc: func(value string) (interface{}, error) {
-			return linodego.ImageStatus(value), nil
-		},
-	},
+	"created_by":  {TypeFunc: helper.FilterTypeString},
+	"id":          {TypeFunc: helper.FilterTypeString},
+	"status":      {TypeFunc: helper.FilterTypeString},
 	"description": {TypeFunc: helper.FilterTypeString},
 }
 

--- a/linode/instance/datasource.go
+++ b/linode/instance/datasource.go
@@ -17,12 +17,8 @@ var filterConfig = helper.FilterConfig{
 	"region": {APIFilterable: true, TypeFunc: helper.FilterTypeString},
 
 	// Tags must be filtered on the client
-	"tags": {TypeFunc: helper.FilterTypeString},
-	"status": {
-		TypeFunc: func(value string) (interface{}, error) {
-			return linodego.InstanceStatus(value), nil
-		},
-	},
+	"tags":             {TypeFunc: helper.FilterTypeString},
+	"status":           {TypeFunc: helper.FilterTypeString},
 	"type":             {TypeFunc: helper.FilterTypeString},
 	"watchdog_enabled": {TypeFunc: helper.FilterTypeBool},
 }

--- a/linode/instancetypes/datasource.go
+++ b/linode/instancetypes/datasource.go
@@ -2,7 +2,6 @@ package instancetypes
 
 import (
 	"context"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"

--- a/linode/instancetypes/datasource.go
+++ b/linode/instancetypes/datasource.go
@@ -2,6 +2,7 @@ package instancetypes
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"

--- a/linode/instancetypes/datasource_test.go
+++ b/linode/instancetypes/datasource_test.go
@@ -78,3 +78,23 @@ func TestAccDataSourceInstanceTypes_regex(t *testing.T) {
 		},
 	})
 }
+
+func TestAccDataSourceInstanceTypes_byClass(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_instance_types.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataByClass(t),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckResourceAttrGreaterThan(resourceName, "types.#", 0),
+					acceptance.CheckResourceAttrContains(resourceName, "types.0.label", "Linode"),
+				),
+			},
+		},
+	})
+}

--- a/linode/instancetypes/tmpl/data_by_class.gotf
+++ b/linode/instancetypes/tmpl/data_by_class.gotf
@@ -1,0 +1,18 @@
+{{ define "instance_types_data_by_class" }}
+
+data "linode_instance_types" "foobar" {
+  filter {
+    name = "vcpus"
+    values = [ "4" ]
+  }
+  filter {
+    name = "memory"
+    values = [ "8192" ]
+  }
+  filter {
+    name = "class"
+    values = [ "standard" ]
+  }
+}
+
+{{ end }}

--- a/linode/instancetypes/tmpl/template.go
+++ b/linode/instancetypes/tmpl/template.go
@@ -20,3 +20,8 @@ func DataRegex(t *testing.T) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_types_data_regex", nil)
 }
+
+func DataByClass(t *testing.T) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_types_data_by_class", nil)
+}


### PR DESCRIPTION
This change resolves a bug that would cause equivalent enum values to be evaluated as unequal. In short, this is the result of `DeepEqual(...)` comparisons between enum and primitive types.

This change normalizes all enum types into their underlying type (string, int, etc.) for comparison. Additionally, this pull request adds validation to ensure that the underlying type of a value is supported.

Resolves #703 