### PR TITLE
fix: Exclude non-updated fields from LKE update requests

### DIFF
--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -148,8 +148,14 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	updateOpts := linodego.LKEClusterUpdateOptions{}
-	updateOpts.Label = d.Get("label").(string)
-	updateOpts.K8sVersion = d.Get("k8s_version").(string)
+
+	if d.HasChange("label") {
+		updateOpts.Label = d.Get("label").(string)
+	}
+
+	if d.HasChange("k8s_version") {
+		updateOpts.K8sVersion = d.Get("k8s_version").(string)
+	}
 
 	controlPlane := d.Get("control_plane").([]interface{})
 	if len(controlPlane) > 0 {

--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -267,9 +267,8 @@ func TestAccResourceLKECluster_basicUpdates(t *testing.T) {
 	clusterName := acctest.RandomWithPrefix("tf_test")
 	newClusterName := acctest.RandomWithPrefix("tf_test")
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    providerMap,
-		CheckDestroy: acceptance.CheckLKEClusterDestroy,
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: providerMap,
 		Steps: []resource.TestStep{
 			{
 				Config: tmpl.Basic(t, clusterName, k8sVersionLatest, testRegion),


### PR DESCRIPTION
This change validates that `linode_lke_cluster` fields are only included in update requests when changed. This is useful for situations where a cluster has an attribute that is no longer valid (e.g. deprecated K8s version) but still needs to be managed through Terraform.