### PR TITLE
new: Generate random root password if not specified in `linode_instance_disk`

### DIFF
--- a/linode/helper/instance.go
+++ b/linode/helper/instance.go
@@ -2,8 +2,11 @@ package helper
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log"
+	"math/rand"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -114,4 +117,14 @@ func GetCurrentBootedConfig(ctx context.Context, client *linodego.Client, instID
 	}
 
 	return int(events[0].SecondaryEntity.ID.(float64)), nil
+}
+
+func CreateRandomRootPassword() (string, error) {
+	rawRootPass := make([]byte, 50)
+	_, err := rand.Read(rawRootPass)
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate random password")
+	}
+	rootPass := base64.StdEncoding.EncodeToString(rawRootPass)
+	return rootPass, nil
 }

--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -2,7 +2,6 @@ package instance
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"log"
@@ -400,7 +399,7 @@ func createInstanceDisk(
 			diskOpts.RootPass = rootPass.(string)
 		} else {
 			var err error
-			diskOpts.RootPass, err = createRandomRootPassword()
+			diskOpts.RootPass, err = helper.CreateRandomRootPassword()
 			if err != nil {
 				return nil, err
 			}
@@ -640,16 +639,6 @@ func rootPasswordState(val interface{}) string {
 func hashString(key string) string {
 	hash := sha3.Sum512([]byte(key))
 	return base64.StdEncoding.EncodeToString(hash[:])
-}
-
-func createRandomRootPassword() (string, error) {
-	rawRootPass := make([]byte, 50)
-	_, err := rand.Read(rawRootPass)
-	if err != nil {
-		return "", fmt.Errorf("Failed to generate random password")
-	}
-	rootPass := base64.StdEncoding.EncodeToString(rawRootPass)
-	return rootPass, nil
 }
 
 // ensureInstanceOffline ensures that a given instance is offline.

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -195,7 +195,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 		createOpts.RootPass = d.Get("root_pass").(string)
 		if createOpts.RootPass == "" {
 			var err error
-			createOpts.RootPass, err = createRandomRootPassword()
+			createOpts.RootPass, err = helper.CreateRandomRootPassword()
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/linode/instancedisk/resource.go
+++ b/linode/instancedisk/resource.go
@@ -107,6 +107,15 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		createOpts.StackscriptData = expandStackScriptData(stackscriptData)
 	}
 
+	createOpts.RootPass = d.Get("root_pass").(string)
+	if createOpts.RootPass == "" {
+		var err error
+		createOpts.RootPass, err = helper.CreateRandomRootPassword()
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	p, err := client.NewEventPoller(ctx, linodeID, linodego.EntityLinode, linodego.ActionDiskCreate)
 	if err != nil {
 		return diag.Errorf("failed to poll for events: %s", err)


### PR DESCRIPTION
This change causes an unspecified `root_pass` in the `linode_instance_disk` resource to generate a random root password. This mirrors the functionality in `linode_instance`.