### PR TITLE
fix: Add validation for null values in `authorized_keys`

### DIFF
--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -407,12 +407,22 @@ func createInstanceDisk(
 
 		if authorizedKeys, ok := disk["authorized_keys"]; ok {
 			for _, sshKey := range authorizedKeys.([]interface{}) {
+				if sshKey == nil {
+					return nil, fmt.Errorf(
+						"invalid input for disk authorized_keys: keys cannot be empty or null")
+				}
+
 				diskOpts.AuthorizedKeys = append(diskOpts.AuthorizedKeys, sshKey.(string))
 			}
 		}
 
 		if authorizedUsers, ok := disk["authorized_users"]; ok {
 			for _, user := range authorizedUsers.([]interface{}) {
+				if user == nil {
+					return nil, fmt.Errorf(
+						"invalid input for disk authorized_users: users cannot be empty or null")
+				}
+
 				diskOpts.AuthorizedUsers = append(diskOpts.AuthorizedUsers, user.(string))
 			}
 		}

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -187,10 +187,18 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	// If we don't have disks and we don't have configs, use the single API call approach
 	if !disksOk && !configsOk {
 		for _, key := range d.Get("authorized_keys").([]interface{}) {
+			if key == nil {
+				return diag.Errorf("invalid input for authorized_keys: keys cannot be empty or null")
+			}
+
 			createOpts.AuthorizedKeys = append(createOpts.AuthorizedKeys, key.(string))
 		}
-		for _, key := range d.Get("authorized_users").([]interface{}) {
-			createOpts.AuthorizedUsers = append(createOpts.AuthorizedUsers, key.(string))
+		for _, user := range d.Get("authorized_users").([]interface{}) {
+			if user == nil {
+				return diag.Errorf("invalid input for authorized_users: users cannot be empty or null")
+			}
+
+			createOpts.AuthorizedUsers = append(createOpts.AuthorizedUsers, user.(string))
 		}
 		createOpts.RootPass = d.Get("root_pass").(string)
 		if createOpts.RootPass == "" {

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -155,6 +155,30 @@ func TestAccResourceInstance_authorizedUsers(t *testing.T) {
 	})
 }
 
+func TestAccResourceInstance_validateAuthorizedKeys(t *testing.T) {
+	t.Parallel()
+
+	instanceName := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.AuthorizedKeysEmpty(t, instanceName, testRegion),
+				ExpectError: regexp.MustCompile(
+					"invalid input for authorized_keys"),
+			},
+			{
+				Config: tmpl.DiskAuthorizedKeysEmpty(t, instanceName, testRegion),
+				ExpectError: regexp.MustCompile(
+					"invalid input for disk authorized_keys"),
+			},
+		},
+	})
+}
+
 func TestAccResourceInstance_interfaces(t *testing.T) {
 	t.Parallel()
 

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -376,6 +376,24 @@ func AuthorizedUsers(t *testing.T, label, pubKey, region string) string {
 		})
 }
 
+func AuthorizedKeysEmpty(t *testing.T, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_authorized_keys_empty", TemplateData{
+			Label:  label,
+			Image:  acceptance.TestImageLatest,
+			Region: region,
+		})
+}
+
+func DiskAuthorizedKeysEmpty(t *testing.T, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_disk_authorized_keys_empty", TemplateData{
+			Label:  label,
+			Image:  acceptance.TestImageLatest,
+			Region: region,
+		})
+}
+
 func StackScript(t *testing.T, label, region string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_stackscript", TemplateData{

--- a/linode/instance/tmpl/templates/authorized_keys_empty.gotf
+++ b/linode/instance/tmpl/templates/authorized_keys_empty.gotf
@@ -1,0 +1,14 @@
+{{ define "instance_authorized_keys_empty" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "g6-nanode-1"
+    image = "{{.Image}}"
+    region = "{{ .Region }}"
+    authorized_keys = [
+        ""
+    ]
+}
+
+{{ end }}

--- a/linode/instance/tmpl/templates/disk_authorized_keys_empty.gotf
+++ b/linode/instance/tmpl/templates/disk_authorized_keys_empty.gotf
@@ -1,0 +1,17 @@
+{{ define "instance_disk_authorized_keys_empty" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+
+    disk {
+        label = "boot"
+        size = 4096
+        image = "{{.Image}}"
+        authorized_keys = [""]
+        root_pass = "myc00lp@ss!"
+    }
+}
+
+{{ end }}


### PR DESCRIPTION
This pull request adds graceful error handling for empty `authorized_keys` values in `linode_instance` as described in #714.

Ideally this validation would be done at plan-time using a `ValidateDiagFunc`, but there is currently a hard limitation on validating lists and sets using `terraform-plugin-sdk`: https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/schema.go#L1022

Resolves #714 