### PR TITLE
fix: Resolve common acctest failure cases

### DIFF
--- a/linode/domainrecord/datasource_test.go
+++ b/linode/domainrecord/datasource_test.go
@@ -92,7 +92,7 @@ func TestAccDataSourceDomainRecord_caa(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceName, "name", "caa_test"),
 					resource.TestCheckResourceAttr(datasourceName, "type", "CAA"),
 					resource.TestCheckResourceAttr(datasourceName, "tag", "issue"),
-					resource.TestCheckResourceAttr(datasourceName, "target", "test"),
+					resource.TestCheckResourceAttr(datasourceName, "target", "example.com"),
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "domain_id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "type"),

--- a/linode/domainrecord/tmpl/data_caa.gotf
+++ b/linode/domainrecord/tmpl/data_caa.gotf
@@ -11,7 +11,7 @@ resource "linode_domain_record" "record" {
     domain_id = linode_domain.domain.id
     record_type = "CAA"
     tag = "issue"
-    target = "test"
+    target = "example.com"
 }
 
 data "linode_domain_record" "record" {

--- a/linode/instanceconfig/tmpl/booted_swap.gotf
+++ b/linode/instanceconfig/tmpl/booted_swap.gotf
@@ -18,6 +18,8 @@ resource "linode_instance_config" "foobar1" {
 }
 
 resource "linode_instance_config" "foobar2" {
+  depends_on = [linode_instance_config.foobar1]
+
   linode_id = linode_instance.foobar.id
   label = "my-config-2"
 


### PR DESCRIPTION
This change resolves some of the most common test failures in the acceptance test suite.

This includes:
- Resolving an issue that causes an invalid target to be used when creating a CAA record
- Resolving a race condition when swapping the booted field between `linode_instance_config`