### PR TITLE
fix: Bump Alpine 3.12 -> 3.16 in test suite

### DIFF
--- a/linode/networkingip/tmpl/data_basic.gotf
+++ b/linode/networkingip/tmpl/data_basic.gotf
@@ -3,7 +3,7 @@
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.12"
+    image = "linode/alpine3.16"
     type = "g6-standard-1"
     region = "{{ .Region }}"
 }

--- a/linode/rdns/tmpl/basic.gotf
+++ b/linode/rdns/tmpl/basic.gotf
@@ -3,7 +3,7 @@
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.12"
+    image = "linode/alpine3.16"
     type = "g6-standard-1"
     region = "{{ .Region }}"
 }

--- a/website/docs/r/instance_ip.html.markdown
+++ b/website/docs/r/instance_ip.html.markdown
@@ -18,7 +18,7 @@ Manages a Linode instance IP.
 
 ```terraform
 resource "linode_instance" "foo" {
-    image = "linode/alpine3.12"
+    image = "linode/alpine3.16"
     label = "foobar-test"
     type = "g6-nanode-1"
     region = "us-east"


### PR DESCRIPTION
This change bumps the Alpine image version in tests that use recently deprecated versions. In the future, we may want to dynamically resolve these images.