### PR TITLE
fix: Use SetConnInfo in `linode_instance_config`

### DIFF
--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -239,6 +239,38 @@ func TestAccResourceInstanceConfig_bootedSwap(t *testing.T) {
 	})
 }
 
+func TestAccResourceInstanceConfig_provisioner(t *testing.T) {
+	t.Parallel()
+
+	var instance linodego.Instance
+
+	resName := "linode_instance_config.foobar"
+	instanceName := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Provisioner(t, instanceName, testRegion),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
+					checkExists(resName, nil),
+					resource.TestCheckResourceAttr(resName, "label", "my-config"),
+					resource.TestCheckResourceAttr(resName, "booted", "true"),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: resourceImportStateID,
+			},
+		},
+	})
+}
+
 func checkExists(name string, config *linodego.InstanceConfig) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.TestAccProvider.Meta().(*helper.ProviderMeta).Client

--- a/linode/instanceconfig/tmpl/provisioner.gotf
+++ b/linode/instanceconfig/tmpl/provisioner.gotf
@@ -1,0 +1,32 @@
+{{ define "instance_config_provisioner" }}
+
+{{ template "instance_config_empty_instance" . }}
+
+{{ template "instance_config_disk" . }}
+
+resource "linode_instance_config" "foobar" {
+  linode_id = linode_instance.foobar.id
+  label = "my-config"
+
+  devices {
+    sda {
+      disk_id = linode_instance_disk.foobar.id
+    }
+  }
+
+  booted = true
+
+  connection {
+    host        = linode_instance.foobar.ip_address
+    user        = "root"
+    password    = "myc00lpass!"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Hello World!'"
+    ]
+  }
+}
+
+{{ end }}

--- a/linode/instanceconfig/tmpl/template.go
+++ b/linode/instanceconfig/tmpl/template.go
@@ -54,3 +54,11 @@ func BootedSwap(t *testing.T, label, region string, swap bool) string {
 			Region: region,
 		})
 }
+
+func Provisioner(t *testing.T, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_config_provisioner", TemplateData{
+			Label:  label,
+			Region: region,
+		})
+}

--- a/website/docs/r/instance_config.html.markdown
+++ b/website/docs/r/instance_config.html.markdown
@@ -81,6 +81,19 @@ resource "linode_instance_config" "my-config" {
   }
   
   booted = true
+
+  // Run a remote-exec provisioner
+  connection {
+    host        = linode_instance.my-instance.ip_address
+    user        = "root"
+    password    = "myc00lpass!"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Hello World!'"
+    ]
+  }
 }
 
 # Create a boot disk


### PR DESCRIPTION
## 📝 Description

This change allows the `linode_instance_config` resource to implicitly set the connection info for use with `remote-exec` provisioners. Additionally, this change adds documentation for using provisioners with a multi-resource instance.

## ✔️ How to Test

```
make TESTARGS="-run TestAccResourceInstanceConfig_provisioner" PKG_NAME="linode/instanceconfig" testacc
```

## 💡 Related Issues

Resolves #727 