### PR TITLE
Allow `hour_of_day` to be 0 to align with Linode API

### DIFF
--- a/linode/databasemongodb/schema_resource.go
+++ b/linode/databasemongodb/schema_resource.go
@@ -120,7 +120,7 @@ var resourceSchema = map[string]*schema.Schema{
 					Type:             schema.TypeInt,
 					Description:      "The hour to begin maintenance based in UTC time.",
 					Required:         true,
-					ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 23)),
+					ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(0, 23)),
 				},
 				"week_of_month": {
 					Type: schema.TypeInt,

--- a/linode/databasemysql/schema_resource.go
+++ b/linode/databasemysql/schema_resource.go
@@ -114,7 +114,7 @@ var resourceSchema = map[string]*schema.Schema{
 					Type:             schema.TypeInt,
 					Description:      "The hour to begin maintenance based in UTC time.",
 					Required:         true,
-					ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 23)),
+					ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(0, 23)),
 				},
 				"week_of_month": {
 					Type: schema.TypeInt,

--- a/linode/databasepostgresql/schema_resource.go
+++ b/linode/databasepostgresql/schema_resource.go
@@ -128,7 +128,7 @@ var resourceSchema = map[string]*schema.Schema{
 					Type:             schema.TypeInt,
 					Description:      "The hour to begin maintenance based in UTC time.",
 					Required:         true,
-					ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 23)),
+					ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(0, 23)),
 				},
 				"week_of_month": {
 					Type: schema.TypeInt,


### PR DESCRIPTION
In [Linode API document](https://www.linode.com/docs/api/databases/#managed-databases-list-all__responses), the `hour_of_day` attribute of `updates` object is allowed to be from 0 to 23.

This PR is for updating Linode Terraform provider's parameter validator to align with the API and allow value of 0.

closes #734