### PR TITLE
ref: Retry on `TestAccResourceInstance_configUpdate` failures

### DIFF
--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -763,38 +763,41 @@ func TestAccResourceInstance_configUpdate(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.TestAccProviders,
-		CheckDestroy: acceptance.CheckInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: tmpl.WithConfig(t, instanceName, testRegion),
-				Check: resource.ComposeTestCheckFunc(
-					acceptance.CheckInstanceExists(resName, &instance),
-					resource.TestCheckResourceAttr(resName, "label", instanceName),
-					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
-					resource.TestCheckResourceAttr(resName, "config.0.kernel", "linode/latest-64bit"),
-					resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/sda"),
-					resource.TestCheckResourceAttr(resName, "config.0.helpers.0.network", "true"),
-					resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "60"),
-				),
+	// This test can occasionally fail while running the entire test suite in parallel
+	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
+		resource.Test(retryT, resource.TestCase{
+			PreCheck:     func() { acceptance.PreCheck(t) },
+			Providers:    acceptance.TestAccProviders,
+			CheckDestroy: acceptance.CheckInstanceDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: tmpl.WithConfig(t, instanceName, testRegion),
+					Check: resource.ComposeTestCheckFunc(
+						acceptance.CheckInstanceExists(resName, &instance),
+						resource.TestCheckResourceAttr(resName, "label", instanceName),
+						resource.TestCheckResourceAttr(resName, "group", "tf_test"),
+						resource.TestCheckResourceAttr(resName, "config.0.kernel", "linode/latest-64bit"),
+						resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/sda"),
+						resource.TestCheckResourceAttr(resName, "config.0.helpers.0.network", "true"),
+						resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "60"),
+					),
+				},
+				{
+					Config: tmpl.ConfigUpdates(t, instanceName, testRegion),
+					Check: resource.ComposeTestCheckFunc(
+						acceptance.CheckInstanceExists(resName, &instance),
+						resource.TestCheckResourceAttr(resName, "label", fmt.Sprintf("%s_r", instanceName)),
+						resource.TestCheckResourceAttr(resName, "group", "tf_test_r"),
+						// changed kerel, not label
+						resource.TestCheckResourceAttr(resName, "config.0.label", "config"),
+						resource.TestCheckResourceAttr(resName, "config.0.kernel", "linode/latest-32bit"),
+						resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/sda"),
+						resource.TestCheckResourceAttr(resName, "config.0.helpers.0.network", "false"),
+						resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "80"),
+					),
+				},
 			},
-			{
-				Config: tmpl.ConfigUpdates(t, instanceName, testRegion),
-				Check: resource.ComposeTestCheckFunc(
-					acceptance.CheckInstanceExists(resName, &instance),
-					resource.TestCheckResourceAttr(resName, "label", fmt.Sprintf("%s_r", instanceName)),
-					resource.TestCheckResourceAttr(resName, "group", "tf_test_r"),
-					// changed kerel, not label
-					resource.TestCheckResourceAttr(resName, "config.0.label", "config"),
-					resource.TestCheckResourceAttr(resName, "config.0.kernel", "linode/latest-32bit"),
-					resource.TestCheckResourceAttr(resName, "config.0.root_device", "/dev/sda"),
-					resource.TestCheckResourceAttr(resName, "config.0.helpers.0.network", "false"),
-					resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "80"),
-				),
-			},
-		},
+		})
 	})
 }
 


### PR DESCRIPTION
## 📝 Description

This change adds retries to the `TestAccResourceInstance_configUpdate` test. This test has occasional failures when being run alongside the entire test suite in parallel, and consistently passes when run alone.

## ✔️ How to Test

`make PKG_NAME=linode/instance TESTARGS="-run TestAccResourceInstance_configUpdate" testacc`
