### PR TITLE
fix: Expect 404s for missing Linode StackScripts

### DIFF
--- a/linode/stackscript/resource.go
+++ b/linode/stackscript/resource.go
@@ -34,7 +34,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	stackscript, err := client.GetStackscript(ctx, int(id))
 	if err != nil {
-		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 401 {
+		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			log.Printf("[WARN] removing StackScript ID %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil

--- a/linode/stackscript/resource_test.go
+++ b/linode/stackscript/resource_test.go
@@ -207,8 +207,8 @@ func checkStackscriptDestroy(s *terraform.State) error {
 			return fmt.Errorf("Linode Stackscript with id %d still exists", id)
 		}
 
-		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code != 401 {
-			return fmt.Errorf("Error requesting Linode Stackscript with id %d", id)
+		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code != 404 {
+			return fmt.Errorf("error requesting Linode Stackscript with id %d: %s", id, apiErr)
 		}
 	}
 


### PR DESCRIPTION
## 📝 Description

This pull request adjusts the missing StackScript resource logic to expect `404`s rather than `401`s. This is in response to a recent API change.

## ✔️ How to Test

`make PKG_NAME=linode/stackscript testacc`
