### PR TITLE
fix: Correct broken documentation link

### DIFF
--- a/website/docs/r/object_storage_bucket.html.markdown
+++ b/website/docs/r/object_storage_bucket.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `label` - (Required) The label of the Linode Object Storage Bucket.
 
-* `acl` - (Optional) The Access Control Level of the bucket using a canned ACL string. See all ACL strings [in the Linode API v4 documentation](linode.com/docs/api/object-storage/#object-storage-bucket-access-update__request-body-schema).
+* `acl` - (Optional) The Access Control Level of the bucket using a canned ACL string. See all ACL strings [in the Linode API v4 documentation](https://linode.com/docs/api/object-storage/#object-storage-bucket-access-update__request-body-schema).
 
 * `access_key` - (Optional) The access key to authenticate with.
 


### PR DESCRIPTION
## 📝 Description

This change corrects a broken ACL documentation link in the `linode_object_storage_bucket` resource documentation

Resolves #747 