### PR TITLE
fix: Raise minimum root password character count

### DIFF
--- a/linode/helper/instance.go
+++ b/linode/helper/instance.go
@@ -14,6 +14,11 @@ import (
 	"github.com/linode/linodego"
 )
 
+const (
+	RootPassMinimumCharacters = 7
+	RootPassMaximumCharacters = 128
+)
+
 var bootEvents = []linodego.EventAction{linodego.ActionLinodeBoot, linodego.ActionLinodeReboot}
 
 // set bootConfig = 0 if using existing boot config

--- a/linode/helper/instance.go
+++ b/linode/helper/instance.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	RootPassMinimumCharacters = 7
+	RootPassMinimumCharacters = 11
 	RootPassMaximumCharacters = 128
 )
 

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -219,12 +219,12 @@ var resourceSchema = map[string]*schema.Schema{
 		ConflictsWith: []string{"disk", "config"},
 	},
 	"root_pass": {
-		Type:          schema.TypeString,
-		Description:   "The password that will be initialially assigned to the 'root' user account.",
-		Sensitive:     true,
-		Optional:      true,
-		ForceNew:      true,
-		StateFunc:     rootPasswordState,
+		Type:        schema.TypeString,
+		Description: "The password that will be initialially assigned to the 'root' user account.",
+		Sensitive:   true,
+		Optional:    true,
+		ForceNew:    true,
+		StateFunc:   rootPasswordState,
 		ValidateFunc: validation.StringLenBetween(
 			helper.RootPassMinimumCharacters,
 			helper.RootPassMaximumCharacters),
@@ -738,7 +738,7 @@ var resourceSchema = map[string]*schema.Schema{
 					ValidateFunc: validation.StringLenBetween(
 						helper.RootPassMinimumCharacters,
 						helper.RootPassMaximumCharacters),
-					StateFunc:    rootPasswordState,
+					StateFunc: rootPasswordState,
 				},
 			},
 		},

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -1,13 +1,13 @@
 package instance
 
 import (
-	"github.com/linode/terraform-provider-linode/linode/helper"
 	"net"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
 const deviceDescription = "Device can be either a Disk or Volume identified by disk_id or " +

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"github.com/linode/terraform-provider-linode/linode/helper"
 	"net"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -224,6 +225,9 @@ var resourceSchema = map[string]*schema.Schema{
 		Optional:      true,
 		ForceNew:      true,
 		StateFunc:     rootPasswordState,
+		ValidateFunc: validation.StringLenBetween(
+			helper.RootPassMinimumCharacters,
+			helper.RootPassMaximumCharacters),
 		ConflictsWith: []string{"disk", "config"},
 	},
 	"swap_size": {
@@ -731,7 +735,9 @@ var resourceSchema = map[string]*schema.Schema{
 						// the API does not return this field for existing disks, so must be ignored for diffs/updates
 						return !d.HasChange("label")
 					},
-					ValidateFunc: validation.StringLenBetween(6, 128),
+					ValidateFunc: validation.StringLenBetween(
+						helper.RootPassMinimumCharacters,
+						helper.RootPassMaximumCharacters),
 					StateFunc:    rootPasswordState,
 				},
 			},

--- a/linode/instancedisk/schema_resource.go
+++ b/linode/instancedisk/schema_resource.go
@@ -3,6 +3,7 @@ package instancedisk
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
 var resourceSchema = map[string]*schema.Schema{
@@ -60,6 +61,9 @@ var resourceSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 		Sensitive:   true,
 		Description: "This sets the root user’s password on a newly-created Linode Disk when deploying from an Image.",
+		ValidateFunc: validation.StringLenBetween(
+			helper.RootPassMinimumCharacters,
+			helper.RootPassMaximumCharacters),
 	},
 	"stackscript_data": {
 		Type: schema.TypeMap,


### PR DESCRIPTION
## 📝 Description

This change raises the minimum length of `root_pass` values for client-side validation. 

**NOTE: This may be a breaking change for users using 6-character root passwords. We should include a graceful migration guide in the release notes and encourage users to use SSH keys.**
