### PR TITLE
Add object storage bucket data source

### DIFF
--- a/linode/objbucket/datasource.go
+++ b/linode/objbucket/datasource.go
@@ -1,0 +1,50 @@
+package objbucket
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: readDataSource,
+		Schema:      bucketDataSourceSchema,
+	}
+}
+
+func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*helper.ProviderMeta).Client
+
+	//	cluster, label, err := DecodeBucketID(d.Id())
+	cluster := d.Get("cluster").(string)
+	label := d.Get("label").(string)
+
+	// if err != nil {
+	// 	return diag.Errorf("failed to parse Linode ObjectStorageBucket id %s", d.Id())
+	// }
+
+	bucket, err := client.GetObjectStorageBucket(ctx, cluster, label)
+	if err != nil {
+		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
+			log.Printf("[WARN] removing Object Storage Bucket %q from state because it no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("failed to find the specified Linode ObjectStorageBucket: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", bucket.Cluster, bucket.Label))
+	d.Set("cluster", bucket.Cluster)
+	d.Set("created", bucket.Created.Format(time.RFC3339))
+	d.Set("hostname", bucket.Hostname)
+	d.Set("label", bucket.Label)
+
+	return nil
+}

--- a/linode/objbucket/datasource.go
+++ b/linode/objbucket/datasource.go
@@ -21,14 +21,8 @@ func DataSource() *schema.Resource {
 
 func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*helper.ProviderMeta).Client
-
-	//	cluster, label, err := DecodeBucketID(d.Id())
 	cluster := d.Get("cluster").(string)
 	label := d.Get("label").(string)
-
-	// if err != nil {
-	// 	return diag.Errorf("failed to parse Linode ObjectStorageBucket id %s", d.Id())
-	// }
 
 	bucket, err := client.GetObjectStorageBucket(ctx, cluster, label)
 	if err != nil {

--- a/linode/objbucket/datasource_test.go
+++ b/linode/objbucket/datasource_test.go
@@ -1,0 +1,35 @@
+package objbucket_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/objbucket/tmpl"
+)
+
+func TestAccDataSourceBucket_basic(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_object_storage_bucket.foobar"
+	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: checkBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, objectStorageBucketName, testCluster),
+				Check: resource.ComposeTestCheckFunc(
+					checkBucketExists,
+					resource.TestCheckResourceAttr(resourceName, "cluster", testCluster),
+					resource.TestCheckResourceAttr(resourceName, "label", objectStorageBucketName),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "created"),
+				),
+			},
+		},
+	})
+}

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -400,7 +400,7 @@ func TestAccResourceBucket_dataSource(t *testing.T) {
 		CheckDestroy: checkBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataBasic(t, objectStorageBucketName, testCluster),
+				Config: tmpl.ClusterDataBasic(t, objectStorageBucketName, testCluster),
 				Check: resource.ComposeTestCheckFunc(
 					checkBucketExists,
 					resource.TestCheckResourceAttr(resName, "label", objectStorageBucketName),

--- a/linode/objbucket/schema_datasource.go
+++ b/linode/objbucket/schema_datasource.go
@@ -14,9 +14,10 @@ var bucketDataSourceSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"hostname": {
-		Type:        schema.TypeString,
-		Description: "The hostname where this bucket can be accessed. This hostname can be accessed through a browser if the bucket is made public.",
-		Computed:    true,
+		Type: schema.TypeString,
+		Description: "The hostname where this bucket can be accessed." +
+			"This hostname can be accessed through a browser if the bucket is made public.",
+		Computed: true,
 	},
 	"id": {
 		Type:        schema.TypeString,

--- a/linode/objbucket/schema_datasource.go
+++ b/linode/objbucket/schema_datasource.go
@@ -18,14 +18,14 @@ var bucketDataSourceSchema = map[string]*schema.Schema{
 		Description: "The hostname where this bucket can be accessed. This hostname can be accessed through a browser if the bucket is made public.",
 		Computed:    true,
 	},
-	"label": {
-		Type:        schema.TypeString,
-		Description: "The name of this bucket.",
-		Required:    true,
-	},
 	"id": {
 		Type:        schema.TypeString,
 		Description: "The id of this bucket.",
 		Computed:    true,
+	},
+	"label": {
+		Type:        schema.TypeString,
+		Description: "The name of this bucket.",
+		Required:    true,
 	},
 }

--- a/linode/objbucket/schema_datasource.go
+++ b/linode/objbucket/schema_datasource.go
@@ -1,0 +1,31 @@
+package objbucket
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+var bucketDataSourceSchema = map[string]*schema.Schema{
+	"cluster": {
+		Type:        schema.TypeString,
+		Description: "The ID of the Object Storage Cluster this bucket is in.",
+		Required:    true,
+	},
+	"created": {
+		Type:        schema.TypeString,
+		Description: "When this bucket was created.",
+		Computed:    true,
+	},
+	"hostname": {
+		Type:        schema.TypeString,
+		Description: "The hostname where this bucket can be accessed. This hostname can be accessed through a browser if the bucket is made public.",
+		Computed:    true,
+	},
+	"label": {
+		Type:        schema.TypeString,
+		Description: "The name of this bucket.",
+		Required:    true,
+	},
+	"id": {
+		Type:        schema.TypeString,
+		Description: "The id of this bucket.",
+		Computed:    true,
+	},
+}

--- a/linode/objbucket/tmpl/cluster_data_basic.gotf
+++ b/linode/objbucket/tmpl/cluster_data_basic.gotf
@@ -1,0 +1,12 @@
+{{ define "object_bucket_cluster_data_basic" }}
+
+data "linode_object_storage_cluster" "baz" {
+    id = "{{ .Cluster }}"
+}
+
+resource "linode_object_storage_bucket" "foobar" {
+    cluster = data.linode_object_storage_cluster.baz.id
+    label = "{{.Label}}"
+}
+
+{{ end }}

--- a/linode/objbucket/tmpl/data_basic.gotf
+++ b/linode/objbucket/tmpl/data_basic.gotf
@@ -1,11 +1,14 @@
 {{ define "object_bucket_data_basic" }}
 
-data "linode_object_storage_cluster" "baz" {
-    id = "{{ .Cluster }}"
-}
+{{ template "object_key_basic" .Key }}
 
 resource "linode_object_storage_bucket" "foobar" {
-    cluster = data.linode_object_storage_cluster.baz.id
+    cluster = "{{ .Cluster }}"
+    label = "{{.Label}}"
+}
+
+data "linode_object_storage_bucket" "foobar" {
+    cluster = "{{ .Cluster }}"
     label = "{{.Label}}"
 }
 

--- a/linode/objbucket/tmpl/data_basic.gotf
+++ b/linode/objbucket/tmpl/data_basic.gotf
@@ -1,16 +1,13 @@
 {{ define "object_bucket_data_basic" }}
 
-{{ template "object_key_basic" .Key }}
-
 resource "linode_object_storage_bucket" "foobar" {
     cluster = "{{ .Cluster }}"
     label = "{{.Label}}"
 }
 
 data "linode_object_storage_bucket" "foobar" {
-    cluster = "{{ .Cluster }}"
-    label = "{{.Label}}"
-    id = linode_object_storage_bucket.foobar.id
+    cluster = linode_object_storage_bucket.foobar.cluster
+    label = linode_object_storage_bucket.foobar.label
 }
 
 {{ end }}

--- a/linode/objbucket/tmpl/data_basic.gotf
+++ b/linode/objbucket/tmpl/data_basic.gotf
@@ -10,6 +10,7 @@ resource "linode_object_storage_bucket" "foobar" {
 data "linode_object_storage_bucket" "foobar" {
     cluster = "{{ .Cluster }}"
     label = "{{.Label}}"
+    id = linode_object_storage_bucket.foobar.id
 }
 
 {{ end }}

--- a/linode/objbucket/tmpl/template.go
+++ b/linode/objbucket/tmpl/template.go
@@ -87,6 +87,14 @@ func LifeCycleUpdates(t *testing.T, label, cluster, keyName string) string {
 		})
 }
 
+func ClusterDataBasic(t *testing.T, label, cluster string) string {
+	return acceptance.ExecuteTemplate(t,
+		"object_bucket_cluster_data_basic", TemplateData{
+			Label:   label,
+			Cluster: cluster,
+		})
+}
+
 func DataBasic(t *testing.T, label, cluster string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_bucket_data_basic", TemplateData{

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -193,6 +193,7 @@ func Provider() *schema.Provider {
 			"linode_nodebalancer":           nb.DataSource(),
 			"linode_nodebalancer_node":      nbnode.DataSource(),
 			"linode_nodebalancer_config":    nbconfig.DataSource(),
+			"linode_object_storage_bucket":  objbucket.DataSource(),
 			"linode_object_storage_cluster": objcluster.DataSource(),
 			"linode_profile":                profile.DataSource(),
 			"linode_region":                 region.DataSource(),


### PR DESCRIPTION
## 📝 Description

Add the data source for object storage bucket. Users can get info of a bucket using the data source. 

Note: There was an existing `data_basic`, and a `DataBasic` func under this objbucket, which are not for getting the actual data source. To avoid misleading, rename and move them to be `cluster_data_basic` and `ClusterDataBasic` func.

## ✔️ How to Test

`make PKG_NAME="linode/objbucket" TESTARGS="-run TestAccDataSourceBucket_basic" testacc`
```
=== RUN   TestAccDataSourceBucket_basic
=== PAUSE TestAccDataSourceBucket_basic
=== CONT  TestAccDataSourceBucket_basic
--- PASS: TestAccDataSourceBucket_basic (12.42s)
PASS
ok  	github.com/linode/terraform-provider-linode/linode/objbucket	13.463s
```