### PR TITLE
Fix `instancetype`'s Integration test

### DIFF
--- a/linode/instancetype/datasource_test.go
+++ b/linode/instancetype/datasource_test.go
@@ -1,6 +1,8 @@
 package instancetype_test
 
 import (
+	"context"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,6 +16,16 @@ func TestAccDataSourceLinodeInstanceType_basic(t *testing.T) {
 	instanceTypeID := "g6-standard-2"
 	resourceName := "data.linode_instance_type.foobar"
 
+	client, err := acceptance.GetClientForSweepers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typeInfo, err := client.GetType(context.Background(), instanceTypeID)
+	if err != nil {
+		t.Fatalf("failed to get instance type %s: %s", instanceTypeID, err)
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acceptance.PreCheck(t) },
 		Providers: acceptance.TestAccProviders,
@@ -22,16 +34,51 @@ func TestAccDataSourceLinodeInstanceType_basic(t *testing.T) {
 				Config: tmpl.DataBasic(t, instanceTypeID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", instanceTypeID),
-					resource.TestCheckResourceAttr(resourceName, "label", "Linode 4GB"),
-					resource.TestCheckResourceAttr(resourceName, "disk", "81920"),
-					resource.TestCheckResourceAttr(resourceName, "class", "standard"),
-					resource.TestCheckResourceAttr(resourceName, "memory", "4096"),
-					resource.TestCheckResourceAttr(resourceName, "vcpus", "2"),
-					resource.TestCheckResourceAttr(resourceName, "network_out", "4000"),
-					resource.TestCheckResourceAttr(resourceName, "price.0.hourly", "0.035999998450279236"),
-					resource.TestCheckResourceAttr(resourceName, "price.0.monthly", "20"),
-					resource.TestCheckResourceAttr(resourceName, "addons.0.backups.0.price.0.hourly", "0.00800000037997961"),
-					resource.TestCheckResourceAttr(resourceName, "addons.0.backups.0.price.0.monthly", "5"),
+					resource.TestCheckResourceAttr(resourceName, "label", typeInfo.Label),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"disk",
+						strconv.FormatInt(int64(typeInfo.Disk), 10),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"class",
+						string(typeInfo.Class),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"memory",
+						strconv.FormatInt(int64(typeInfo.Memory), 10),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"vcpus",
+						strconv.FormatInt(int64(typeInfo.VCPUs), 10),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"network_out",
+						strconv.FormatInt(int64(typeInfo.NetworkOut), 10),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"price.0.hourly",
+						strconv.FormatFloat(float64(typeInfo.Price.Hourly), 'f', -1, 64)),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"price.0.monthly",
+						strconv.FormatFloat(float64(typeInfo.Price.Monthly), 'f', -1, 64),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"addons.0.backups.0.price.0.hourly",
+						strconv.FormatFloat(float64(typeInfo.Addons.Backups.Price.Hourly), 'f', -1, 64),
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"addons.0.backups.0.price.0.monthly",
+						strconv.FormatFloat(float64(typeInfo.Addons.Backups.Price.Monthly), 'f', -1, 64),
+					),
 				),
 			},
 		},

--- a/linode/instancetype/datasource_test.go
+++ b/linode/instancetype/datasource_test.go
@@ -28,7 +28,7 @@ func TestAccDataSourceLinodeInstanceType_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "memory", "4096"),
 					resource.TestCheckResourceAttr(resourceName, "vcpus", "2"),
 					resource.TestCheckResourceAttr(resourceName, "network_out", "4000"),
-					resource.TestCheckResourceAttr(resourceName, "price.0.hourly", "0.029999999329447746"),
+					resource.TestCheckResourceAttr(resourceName, "price.0.hourly", "0.035999998450279236"),
 					resource.TestCheckResourceAttr(resourceName, "price.0.monthly", "20"),
 					resource.TestCheckResourceAttr(resourceName, "addons.0.backups.0.price.0.hourly", "0.00800000037997961"),
 					resource.TestCheckResourceAttr(resourceName, "addons.0.backups.0.price.0.monthly", "5"),


### PR DESCRIPTION
## 📝 Description

We raised the price, so also need to update the test case accordingly.

## ✔️ How to Test

`make PKG_NAME="linode/instancetype" TESTARGS="-run TestAccDataSourceLinodeInstanceType_basic" testacc`