### PR TITLE
Downgrade slash command to v1.2.0 in terraform repo

### DIFF
--- a/.github/workflows/acctest_command.yml
+++ b/.github/workflows/acctest_command.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request


### PR DESCRIPTION
## 📝 Description

The v3 and v2 versions of the slash command action require the `read:org` permission to work. Our org contains sensitive private repos so we can't give it that permission. Thus downgrade to v1.2.0