### PR TITLE
Fix Token Resource

### DIFF
--- a/linode/helper/compare.go
+++ b/linode/helper/compare.go
@@ -28,7 +28,8 @@ func CompareTimeWithTimeString(t1 *time.Time, t2 string, timeFormat string) bool
 	return t1.Equal(parsedT2)
 }
 
-func StringListEqual(a, b []string) bool {
+// Check if two string lists contain the same elements regardless of order
+func StringListElementsEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -57,5 +58,5 @@ func CompareScopes(s1, s2 string) bool {
 
 	s1List := strings.Split(s1, " ")
 	s2List := strings.Split(s2, " ")
-	return StringListEqual(s1List, s2List)
+	return StringListElementsEqual(s1List, s2List)
 }

--- a/linode/helper/compare.go
+++ b/linode/helper/compare.go
@@ -1,0 +1,61 @@
+package helper
+
+import (
+	"strings"
+	"time"
+)
+
+func CompareTimeStrings(t1, t2, timeFormat string) bool {
+	parsedT1, err := time.Parse(timeFormat, t1)
+	if err != nil {
+		return false
+	}
+
+	parsedT2, err := time.Parse(timeFormat, t2)
+	if err != nil {
+		return false
+	}
+
+	return parsedT1.Equal(parsedT2)
+}
+
+func CompareTimeWithTimeString(t1 *time.Time, t2 string, timeFormat string) bool {
+	parsedT2, err := time.Parse(timeFormat, t2)
+	if err != nil {
+		return false
+	}
+
+	return t1.Equal(parsedT2)
+}
+
+func StringListEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	freq := make(map[string]int)
+	for _, v := range a {
+		freq[v]++
+	}
+	for _, v := range b {
+		freq[v]--
+		if freq[v] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func CompareScopes(s1, s2 string) bool {
+	s1AccountScope := s1 == "*"
+	s2AccountScope := s2 == "*"
+	if s1AccountScope != s2AccountScope {
+		return false
+	}
+	if s1AccountScope && s2AccountScope {
+		return true
+	}
+
+	s1List := strings.Split(s1, " ")
+	s2List := strings.Split(s2, " ")
+	return StringListEqual(s1List, s2List)
+}

--- a/linode/helper/constant.go
+++ b/linode/helper/constant.go
@@ -1,0 +1,3 @@
+package helper
+
+const TIME_FORMAT = "2006-01-02T15:04:05Z"

--- a/linode/helper/framework_validators.go
+++ b/linode/helper/framework_validators.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
@@ -17,7 +18,10 @@ func (dtv DateTimeStringValidator) Description(ctx context.Context) string {
 }
 
 func (dtv DateTimeStringValidator) MarkdownDescription(ctx context.Context) string {
-	return "value must meet RFC3339 standard and in format of '2023-01-02T03:04:05Z'."
+	return fmt.Sprintf(
+		"value must meet RFC3339 standard and in format of '%s'.",
+		TIME_FORMAT,
+	)
 }
 
 func (dtv DateTimeStringValidator) ValidateString(

--- a/linode/helper/framework_validators.go
+++ b/linode/helper/framework_validators.go
@@ -29,10 +29,10 @@ func (dtv DateTimeStringValidator) ValidateString(
 		return
 	}
 	if dtv.Format == "" {
-		dtv.Format = TIME_FORMAT
+		dtv.Format = time.RFC3339
 	}
 	v := request.ConfigValue.ValueString()
-	if _, err := time.Parse(TIME_FORMAT, v); err != nil {
+	if _, err := time.Parse(time.RFC3339, v); err != nil {
 		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.Path,
 			dtv.Description(ctx),

--- a/linode/helper/framework_validators.go
+++ b/linode/helper/framework_validators.go
@@ -29,10 +29,10 @@ func (dtv DateTimeStringValidator) ValidateString(
 		return
 	}
 	if dtv.Format == "" {
-		dtv.Format = time.RFC3339
+		dtv.Format = TIME_FORMAT
 	}
 	v := request.ConfigValue.ValueString()
-	if _, err := time.Parse(time.RFC3339, v); err != nil {
+	if _, err := time.Parse(TIME_FORMAT, v); err != nil {
 		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.Path,
 			dtv.Description(ctx),

--- a/linode/helper/framework_validators.go
+++ b/linode/helper/framework_validators.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
@@ -18,7 +17,7 @@ func (dtv DateTimeStringValidator) Description(ctx context.Context) string {
 }
 
 func (dtv DateTimeStringValidator) MarkdownDescription(ctx context.Context) string {
-	return fmt.Sprintf("value must meet ISO 8601 standard format, e.g., '%s'.", time.RFC3339)
+	return "value must meet RFC3339 standard and in format of '2023-01-02T03:04:05Z'."
 }
 
 func (dtv DateTimeStringValidator) ValidateString(

--- a/linode/token/framework_model.go
+++ b/linode/token/framework_model.go
@@ -1,0 +1,51 @@
+package token
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+// ResourceModel describes the Terraform resource rm model to match the
+// resource schema.
+type ResourceModel struct {
+	Label   types.String `tfsdk:"label"`
+	Scopes  types.String `tfsdk:"scopes"`
+	Expiry  types.String `tfsdk:"expiry"`
+	Created types.String `tfsdk:"created"`
+	Token   types.String `tfsdk:"token"`
+	ID      types.String `tfsdk:"id"`
+}
+
+func (rm *ResourceModel) parseComputedAttributes(token *linodego.Token, refresh bool) {
+	rm.Created = types.StringValue(token.Created.Format(time.RFC3339))
+
+	// token is too sensitive and won't appear in a GET
+	// method response during a refresh of this resource.
+	if !refresh {
+		rm.Token = types.StringValue(token.Token)
+	}
+	rm.ID = types.StringValue(strconv.Itoa(token.ID))
+}
+
+func (rm *ResourceModel) parseNonComputedAttributes(token *linodego.Token) {
+	// only update non-computed state values if not semantically equivalent
+	rm.Label = types.StringValue(token.Label)
+	if !helper.CompareTimeWithTimeString(
+		token.Expiry,
+		rm.Expiry.ValueString(),
+		time.RFC3339,
+	) {
+		rm.Expiry = types.StringValue(token.Expiry.Format(time.RFC3339))
+	}
+
+	if !helper.CompareScopes(
+		token.Scopes,
+		rm.Scopes.ValueString(),
+	) {
+		rm.Scopes = types.StringValue(token.Scopes)
+	}
+}

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -254,7 +254,7 @@ func (r *Resource) Delete(
 	client := r.client
 	err := client.DeleteToken(ctx, tokenID)
 	if err != nil {
-		if lErr, ok := err.(*linodego.Error); (ok && lErr.Code != 404) || !ok  {
+		if lErr, ok := err.(*linodego.Error); (ok && lErr.Code != 404) || !ok {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to delete the token with id %v", tokenID),
 				err.Error(),

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -182,14 +182,14 @@ func (r *Resource) Read(
 		data.Expiry.ValueString(),
 		time.RFC3339,
 	) {
-		data.Expiry = types.StringValue(token.Label)
+		data.Expiry = types.StringValue(token.Expiry.Format(time.RFC3339))
 	}
 
 	if !helper.CompareScopes(
 		token.Scopes,
 		data.Scopes.ValueString(),
 	) {
-		data.Scopes = types.StringValue(token.Label)
+		data.Scopes = types.StringValue(token.Scopes)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -24,8 +24,8 @@ type Resource struct {
 func (data *ResourceModel) getTokenComputedAttrs(token *linodego.Token, refresh bool) {
 	data.Created = types.StringValue(token.Created.Format(time.RFC3339))
 
-	// token is too sensitive and won't appear in the
-	// get method during a refresh of this resource.
+	// token is too sensitive and won't appear in a GET
+	// method response during a refresh of this resource.
 	if !refresh {
 		data.Token = types.StringValue(token.Token)
 	}

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -202,7 +202,7 @@ func (r *Resource) Update(
 		updateOpts := token.GetUpdateOptions()
 		updateOpts.Label = plan.Label.ValueString()
 
-		token, err = client.UpdateToken(ctx, token.ID, updateOpts)
+		_, err = client.UpdateToken(ctx, token.ID, updateOpts)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to update the token with id %v", tokenID),
@@ -211,8 +211,7 @@ func (r *Resource) Update(
 			return
 		}
 
-		state.parseToken(token)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	}
 }
 
@@ -236,10 +235,12 @@ func (r *Resource) Delete(
 	client := r.client
 	err := client.DeleteToken(ctx, tokenID)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to delete the token with id %v", tokenID),
-			err.Error(),
-		)
+		if err.(linodego.Error).Code != 404 {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Failed to delete the token with id %v", tokenID),
+				err.Error(),
+			)
+		}
 		return
 	}
 

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -254,7 +254,7 @@ func (r *Resource) Delete(
 	client := r.client
 	err := client.DeleteToken(ctx, tokenID)
 	if err != nil {
-		if err.(linodego.Error).Code != 404 {
+		if lErr, ok := err.(*linodego.Error); (ok && lErr.Code != 404) || !ok  {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to delete the token with id %v", tokenID),
 				err.Error(),

--- a/linode/token/framework_resource_schema.go
+++ b/linode/token/framework_resource_schema.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -8,6 +9,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+const (
+	RequireReplacementWhenExpiryChangedDescription = "Requiring token recreation if the " +
+		"Expiry time semantically changed."
+	RequireReplacementWhenScopesChangedDescription = "Requiring token recreation if the " +
+		"OAuth 2.0 scopes changed semantically. For example, from 'linodes:read_only lke:read_only' " +
+		"to 'linodes:read_write lke:read_only' is a semantically change, but from " +
+		"'linodes:read_only lke:read_only' to 'lke:read_only linodes:read_only' isn't."
 )
 
 var frameworkResourceSchema = schema.Schema{
@@ -24,7 +34,20 @@ var frameworkResourceSchema = schema.Schema{
 				"list of available scopes on Linode API docs site, https://www.linode.com/docs/api#oauth-reference",
 			Required: true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.RequiresReplaceIf(
+					func(
+						ctx context.Context,
+						sr planmodifier.StringRequest,
+						rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse,
+					) {
+						rrifr.RequiresReplace = !helper.CompareScopes(
+							sr.PlanValue.ValueString(),
+							sr.StateValue.ValueString(),
+						)
+					},
+					RequireReplacementWhenExpiryChangedDescription,
+					RequireReplacementWhenExpiryChangedDescription,
+				),
 			},
 		},
 		"expiry": schema.StringAttribute{
@@ -34,7 +57,21 @@ var frameworkResourceSchema = schema.Schema{
 				helper.TIME_FORMAT,
 			Optional: true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.RequiresReplaceIf(
+					func(
+						ctx context.Context,
+						sr planmodifier.StringRequest,
+						rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse,
+					) {
+						rrifr.RequiresReplace = !helper.CompareTimeStrings(
+							sr.PlanValue.ValueString(),
+							sr.StateValue.ValueString(),
+							time.RFC3339,
+						)
+					},
+					RequireReplacementWhenScopesChangedDescription,
+					RequireReplacementWhenScopesChangedDescription,
+				),
 			},
 			Validators: []validator.String{
 				helper.NewDateTimeStringValidator(time.RFC3339),
@@ -43,15 +80,24 @@ var frameworkResourceSchema = schema.Schema{
 		"created": schema.StringAttribute{
 			Description: "The date and time this token was created.",
 			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"token": schema.StringAttribute{
 			Sensitive:   true,
 			Description: "The token used to access the API.",
 			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"id": schema.StringAttribute{
 			Description: "The ID of the token.",
 			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 	},
 }

--- a/linode/token/framework_resource_schema.go
+++ b/linode/token/framework_resource_schema.go
@@ -31,7 +31,7 @@ var frameworkResourceSchema = schema.Schema{
 			Description: "When this token will expire. Personal Access Tokens cannot be renewed, so after " +
 				"this time the token will be completely unusable and a new token will need to be generated. Tokens " +
 				"may be created with 'null' as their expiry and will never expire unless revoked. Format: " +
-				time.RFC3339,
+				helper.TIME_FORMAT,
 			Optional: true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
## 📝 Description

1. Fix the date time object format description.

2. Ignore 404 error in `Delete` method as recommended by [the Terraform Framework docs](https://developer.hashicorp.com/terraform/plugin/framework/resources/delete#recommendations).
3. Apply plan to the state instead of the API return values to the state. Align with [the docs](https://developer.hashicorp.com/terraform/plugin/framework/resources/update#define-update-method) and prevent unexpected values from the API response, such as an expiry time with a same value but in different format, which can cause data inconsistent errors.
4. Check whether `expiry` and `scopes` were changed semantically, and only to recreated the token or update state values when it's changed semantically. For example, the scope changed from `linodes:read_only lke:read_only` to `linodes:read_write lke:read_only` is a semantically change, but from `linodes:read_only lke:read_only` to `lke:read_only linodes:read_only` isn't.
5. Apply `stringplanmodifier.UseStateForUnknown()` to attributes known not to change during an update (non-recreation) operation.