### PR TITLE
Fix filter type checking

### DIFF
--- a/linode/helper/frameworkfilter/latest.go
+++ b/linode/helper/frameworkfilter/latest.go
@@ -125,7 +125,7 @@ func getAndValidateFieldByName(elem any, attr string) (reflect.Value, diag.Diagn
 	}
 
 	// Deref any pointers
-	for val.Kind() == reflect.Ptr {
+	for val.Kind() == reflect.Pointer {
 		val = reflect.Indirect(val)
 	}
 

--- a/linode/helper/frameworkfilter/local_filter.go
+++ b/linode/helper/frameworkfilter/local_filter.go
@@ -119,7 +119,7 @@ func normalizeValue(field any) (string, diag.Diagnostic) {
 	rField := reflect.ValueOf(field)
 
 	// Dereference if the value is a pointer
-	for rField.Kind() == reflect.Ptr {
+	for rField.Kind() == reflect.Pointer {
 		// Null pointer; assume empty
 		if rField.IsNil() {
 			return "", nil

--- a/linode/helper/frameworkfilter/local_filter.go
+++ b/linode/helper/frameworkfilter/local_filter.go
@@ -127,15 +127,14 @@ func normalizeValue(field any) (string, diag.Diagnostic) {
 
 		rField = reflect.Indirect(rField)
 	}
-
-	switch rField.Interface().(type) {
-	case string:
+	switch rField.Kind() {
+	case reflect.String:
 		return rField.String(), nil
-	case int, int64:
+	case reflect.Int, reflect.Int64:
 		return strconv.FormatInt(rField.Int(), 10), nil
-	case bool:
+	case reflect.Bool:
 		return strconv.FormatBool(rField.Bool()), nil
-	case float32, float64:
+	case reflect.Float32, reflect.Float64:
 		return strconv.FormatFloat(rField.Float(), 'f', 0, 64), nil
 	default:
 		return "", diag.NewErrorDiagnostic(


### PR DESCRIPTION
## 📝 Description

This should fix the [failure below in another PR](https://github.com/linode/terraform-provider-linode/pull/864#issuecomment-1579525790).

```hcl
data "linode_instance_types" "specific-types" {
  filter {
    name = "class"
    values = ["gp"]
    match_by = "substring"
  }
}
```

```
│ Error: Invalid field type
│ 
│   with data.linode_instance_types.specific-types,
│   on main.tf line 15, in data "linode_instance_types" "specific-types":
│   15: data "linode_instance_types" "specific-types" {
│ 
│ Invalid type for field: linodego.LinodeTypeClass
```