### PR TITLE
Replace GHA `action-regex-match` with  GitHub script

### DIFF
--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -22,14 +22,23 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: 'stable'
       - run: go version
-      - uses: actions-ecosystem/action-regex-match@v2
-        id: validate-pkg
-        with:
+
+      - uses: actions/github-script@v6
+        id: disallowed-character-check
+        env:
           text: ${{ inputs.module }}
-          regex: '[^a-z0-9.\/]'
-          flags: gi
+        with:
+          result-encoding: string
+          script: |
+            let regex = /[^a-z0-9./]/;
+            let result = regex.test(process.env.text);
+            if (result) {
+              return "not pass";
+            } else {
+              return "pass";
+            }
 
       # Check out merge commit
       - name: Checkout PR
@@ -38,7 +47,7 @@ jobs:
           ref: ${{ inputs.sha }}
 
       - run: make PKG_NAME="${{ inputs.module }}" testacc
-        if: ${{ steps.validate-pkg.outputs.match == '' }}
+        if: ${{ steps.disallowed-character-check.outputs.result == 'pass' }}
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
       


### PR DESCRIPTION
## 📝 Description

The maintainer of `action-regex-match` didn't response the call to update the deprecated action runtime. So we will have to replace it, with a custom GitHub script to do the regex check.
