### PR TITLE
Add `gofumpt` to `make fmt`

### DIFF
--- a/makefile
+++ b/makefile
@@ -59,6 +59,7 @@ vet:
 
 fmt:
 	gofmt -w $(GOFMT_FILES)
+	gofumpt -w $(GOFMT_FILES)
 
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"


### PR DESCRIPTION
## 📝 Description

`gofumpt` is a stricter gofmt, and required by the lint check.
