### PR TITLE
fix: Resolve issue that prevents interface updates from being registered

### DIFF
--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -229,6 +229,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if d.HasChange("interface") {
 		putRequest.Interfaces = expandInterfaces(d.Get("interface").([]any))
+		shouldUpdate = true
 	}
 
 	if shouldUpdate {

--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -105,7 +105,7 @@ func TestAccResourceInstanceConfig_complex(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "helpers.0.updatedb_disabled", "false"),
 
 					resource.TestCheckResourceAttr(resName, "interface.0.purpose", "vlan"),
-					resource.TestCheckResourceAttr(resName, "interface.0.label", "cool"),
+					resource.TestCheckResourceAttr(resName, "interface.0.label", "cooler"),
 					resource.TestCheckResourceAttr(resName, "interface.0.ipam_address", "10.0.0.3/24"),
 
 					resource.TestCheckResourceAttr(resName, "kernel", "linode/latest-32bit"),

--- a/linode/instanceconfig/tmpl/complex_updates.gotf
+++ b/linode/instanceconfig/tmpl/complex_updates.gotf
@@ -25,7 +25,7 @@ resource "linode_instance_config" "foobar" {
 
   interface {
     purpose = "vlan"
-    label = "cool"
+    label = "cooler"
     ipam_address = "10.0.0.3/24"
   }
 


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that prevents changes to the `interfaces` field in `linode_instance_config` from being applied to the API.

Resolves #917 

## ✔️ How to Test

```
make PKG_NAME=linode/instanceconfig testacc
```
