### PR TITLE
Technically correct the CURD of ssh key and object storage key 

### DIFF
--- a/linode/objkey/framework_model.go
+++ b/linode/objkey/framework_model.go
@@ -22,18 +22,8 @@ type ResourceModel struct {
 	BucketAccess []BucketAccessModelEntry `tfsdk:"bucket_access"`
 }
 
-func (rm *ResourceModel) parseKey(key *linodego.ObjectStorageKey) {
-	rm.ID = types.Int64Value(int64(key.ID))
+func (rm *ResourceModel) parseConfiguredAttributes(key *linodego.ObjectStorageKey) {
 	rm.Label = types.StringValue(key.Label)
-	rm.AccessKey = types.StringValue(key.AccessKey)
-	rm.Limited = types.BoolValue(key.Limited)
-
-	// We only want to populate this field if a key is returned,
-	// else we should preserve the old value.
-	if key.SecretKey != "[REDACTED]" {
-		rm.SecretKey = types.StringValue(key.SecretKey)
-	}
-
 	// No access is configured; we can return here
 	if key.BucketAccess == nil {
 		rm.BucketAccess = nil
@@ -50,6 +40,18 @@ func (rm *ResourceModel) parseKey(key *linodego.ObjectStorageKey) {
 		entry.parseBucketAccess(&keyBucketAccess[i])
 
 		bucketAccess[i] = entry
+	}
+}
+
+func (rm *ResourceModel) parseComputedAttributes(key *linodego.ObjectStorageKey) {
+	rm.ID = types.Int64Value(int64(key.ID))
+	rm.AccessKey = types.StringValue(key.AccessKey)
+	rm.Limited = types.BoolValue(key.Limited)
+
+	// We only want to populate this field if a key is returned,
+	// else we should preserve the old value.
+	if key.SecretKey != "[REDACTED]" {
+		rm.SecretKey = types.StringValue(key.SecretKey)
 	}
 }
 

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -62,7 +62,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	data.parseKey(key)
+	data.parseComputedAttributes(key)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -100,7 +100,8 @@ func (r *Resource) Read(
 		return
 	}
 
-	data.parseKey(key)
+	data.parseComputedAttributes(key)
+	data.parseConfiguredAttributes(key)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -126,20 +127,20 @@ func (r *Resource) Update(
 	if shouldUpdate {
 		key, err := r.Meta.Client.UpdateObjectStorageKey(
 			ctx,
-			int(state.ID.ValueInt64()),
+			int(plan.ID.ValueInt64()),
 			updateOpts,
 		)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to update Object Storage Key (%d)", state.ID.ValueInt64()),
+				fmt.Sprintf("Failed to update Object Storage Key (%d)", plan.ID.ValueInt64()),
 				err.Error())
 			return
 		}
 
-		state.parseKey(key)
+		plan.parseComputedAttributes(key)
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *Resource) Delete(

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -49,7 +49,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	data.parseSSHKey(key)
+	data.parseComputedAttributes(key)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -87,7 +87,8 @@ func (r *Resource) Read(
 		return
 	}
 
-	data.parseSSHKey(key)
+	data.parseComputedAttributes(key)
+	data.parseConfiguredAttributes(key)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -113,20 +114,19 @@ func (r *Resource) Update(
 	if shouldUpdate {
 		key, err := r.Meta.Client.UpdateSSHKey(
 			ctx,
-			int(state.ID.ValueInt64()),
+			int(plan.ID.ValueInt64()),
 			updateOpts,
 		)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to update SSH Key (%d)", state.ID.ValueInt64()),
+				fmt.Sprintf("Failed to update SSH Key (%d)", plan.ID.ValueInt64()),
 				err.Error())
 			return
 		}
-
-		state.parseSSHKey(key)
+		plan.parseComputedAttributes(key)
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *Resource) Delete(

--- a/linode/sshkey/framework_resource_model.go
+++ b/linode/sshkey/framework_resource_model.go
@@ -17,11 +17,13 @@ type ResourceModel struct {
 	ID      types.Int64                        `tfsdk:"id"`
 }
 
-func (rm *ResourceModel) parseSSHKey(key *linodego.SSHKey) {
+func (rm *ResourceModel) parseConfiguredAttributes(key *linodego.SSHKey) {
 	rm.Label = types.StringValue(key.Label)
 	rm.SSHKey = types.StringValue(key.SSHKey)
-	rm.ID = types.Int64Value(int64(key.ID))
+}
 
+func (rm *ResourceModel) parseComputedAttributes(key *linodego.SSHKey) {
+	rm.ID = types.Int64Value(int64(key.ID))
 	rm.Created = customtypes.RFC3339TimeStringValue{
 		StringValue: types.StringValue(key.Created.Format(time.RFC3339)),
 	}


### PR DESCRIPTION
Although this made no difference in the real use case, this is to align with Terraform Framework's recommendations and requirements, and is a redundancy to prevent errors. It can also serve as an example of how to sort things out correctly with the framework.

> An error is returned unless every null or known value in the request plan is saved exactly as-is into the response state. Only unknown plan values can be modified.

https://developer.hashicorp.com/terraform/plugin/framework/resources/update#caveats

> Any attribute that does not have Computed set to true cannot be influenced by the provider; it can only be changed via the config or via state refreshing.

https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas#computed