### PR TITLE
new: Add `skip_implicit_reboots` provider argument

### DIFF
--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -106,6 +106,10 @@ func (p *FrameworkProvider) Schema(
 				Optional:    true,
 				Description: "Skip waiting for a linode_instance resource to finish deleting.",
 			},
+			"skip_implicit_reboots": schema.BoolAttribute{
+				Optional:    true,
+				Description: "If true, Linode Instances will not be rebooted on config and interface changes.",
+			},
 			"disable_internal_cache": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Disable the internal caching system that backs certain Linode API requests.",

--- a/linode/framework_provider_config.go
+++ b/linode/framework_provider_config.go
@@ -164,6 +164,10 @@ func (fp *FrameworkProvider) HandleDefaults(
 		lpm.SkipInstanceDeletePoll = types.BoolValue(false)
 	}
 
+	if lpm.SkipImplicitReboots.IsNull() {
+		lpm.SkipImplicitReboots = types.BoolValue(false)
+	}
+
 	if lpm.DisableInternalCache.IsNull() {
 		lpm.DisableInternalCache = types.BoolValue(false)
 	}

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -38,6 +38,7 @@ type Config struct {
 
 	SkipInstanceReadyPoll        bool
 	SkipInstanceDeletePoll       bool
+	SkipImplicitReboots          bool
 	DisableInternalCache         bool
 	MinRetryDelayMilliseconds    int
 	MaxRetryDelayMilliseconds    int

--- a/linode/helper/framework_provider_model.go
+++ b/linode/helper/framework_provider_model.go
@@ -17,6 +17,8 @@ type FrameworkProviderModel struct {
 	SkipInstanceReadyPoll  types.Bool `tfsdk:"skip_instance_ready_poll"`
 	SkipInstanceDeletePoll types.Bool `tfsdk:"skip_instance_delete_poll"`
 
+	SkipImplicitReboots types.Bool `tfsdk:"skip_implicit_reboots"`
+
 	DisableInternalCache types.Bool `tfsdk:"disable_internal_cache"`
 
 	MinRetryDelayMilliseconds types.Int64 `tfsdk:"min_retry_delay_ms"`

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -644,7 +644,9 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	// Only reboot the instance if implicit reboots are not skipped
-	rebootInstance = rebootInstance && !meta.(*helper.ProviderMeta).Config.SkipImplicitReboots
+	if !meta.(*helper.ProviderMeta).Config.SkipImplicitReboots {
+		rebootInstance = false
+	}
 
 	if rebootInstance && len(diskIDLabelMap) > 0 && len(updatedConfigMap) > 0 && bootConfig > 0 {
 		p, err := client.NewEventPoller(ctx, id, linodego.EntityLinode, linodego.ActionLinodeReboot)

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -643,6 +643,9 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 		rebootInstance = false
 	}
 
+	// Only reboot the instance if implicit reboots are not skipped
+	rebootInstance = rebootInstance && !meta.(*helper.ProviderMeta).Config.SkipImplicitReboots
+
 	if rebootInstance && len(diskIDLabelMap) > 0 && len(updatedConfigMap) > 0 && bootConfig > 0 {
 		p, err := client.NewEventPoller(ctx, id, linodego.EntityLinode, linodego.ActionLinodeReboot)
 		if err != nil {

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -157,6 +157,15 @@ func ConfigInterfacesUpdate(t *testing.T, label, region string) string {
 		})
 }
 
+func ConfigInterfacesUpdateNoReboot(t *testing.T, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_config_interfaces_update_no_reboot", TemplateData{
+			Label:  label,
+			Image:  acceptance.TestImageLatest,
+			Region: region,
+		})
+}
+
 func ConfigInterfacesUpdateEmpty(t *testing.T, label, region string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_config_interfaces_update_empty", TemplateData{

--- a/linode/instance/tmpl/templates/config_interfaces_update_no_reboot.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces_update_no_reboot.gotf
@@ -1,0 +1,71 @@
+{{ define "instance_config_interfaces_update_no_reboot" }}
+
+provider "linode" {
+    skip_implicit_reboots = true
+}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+    alerts {
+        cpu = 60
+    }
+    config {
+        label = "config"
+        kernel = "linode/latest-64bit"
+        root_device = "/dev/sda"
+        helpers {
+            network = true
+        }
+
+        interface {
+            purpose = "public"
+        }
+
+        interface {
+            purpose = "vlan"
+            label = "tf-really-cool-vlan"
+        }
+        devices {
+            sda {
+                disk_label = "boot"
+            }
+        }
+    }
+
+    config {
+        label = "config2"
+        kernel = "linode/latest-64bit"
+        root_device = "/dev/sda"
+        helpers {
+            network = true
+        }
+
+        interface {
+            purpose = "public"
+        }
+
+        interface {
+            purpose = "vlan"
+            label = "tf-really-cool-vlan"
+        }
+        devices {
+            sda {
+                disk_label = "boot"
+            }
+        }
+    }
+
+    disk {
+        label = "boot"
+        size = 3000
+        image  = "{{.Image}}"
+        root_pass = "myr00tp@ssw0rd!!!"
+    }
+
+    boot_config_label = "config"
+}
+
+{{ end }}

--- a/linode/instanceip/schema_resource.go
+++ b/linode/instanceip/schema_resource.go
@@ -54,8 +54,9 @@ var resourceSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"apply_immediately": {
-		Type:        schema.TypeBool,
-		Description: "If true, the instance will be rebooted to update network interfaces.",
-		Optional:    true,
+		Type: schema.TypeBool,
+		Description: "If true, the instance will be rebooted to update network interfaces. " +
+			"This functionality is not affected by the `skip_implicit_reboots` provider argument.",
+		Optional: true,
 	},
 }

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -84,6 +84,12 @@ func Provider() *schema.Provider {
 				Description: "Skip waiting for a linode_instance resource to finish deleting.",
 			},
 
+			"skip_implicit_reboots": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "If true, Linode Instances will not be rebooted on config and interface changes.",
+			},
+
 			"disable_internal_cache": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -239,6 +245,7 @@ func providerConfigure(
 	config := &helper.Config{
 		SkipInstanceReadyPoll:  d.Get("skip_instance_ready_poll").(bool),
 		SkipInstanceDeletePoll: d.Get("skip_instance_delete_poll").(bool),
+		SkipImplicitReboots:    d.Get("skip_implicit_reboots").(bool),
 
 		DisableInternalCache: d.Get("disable_internal_cache").(bool),
 


### PR DESCRIPTION
## 📝 Description

This change adds a new `skip_implicit_reboots` provider argument that allows users to skip implicit Linode reboots when altering instance configs and interfaces.

## ✔️ How to Test

```
make PKG_NAME=linode/instance testacc
```