### PR TITLE
fix: Markdown issue for users documentation

### DIFF
--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -3,9 +3,7 @@ layout: "linode"
 page_title: "Linode: linode_users"
 sidebar_current: "docs-linode-datasource-users"
 description: |-
-  Lists Users on your Account.
-
-Users may access all or part of your Account based on their restricted status and grants. An unrestricted User may access everything on the account, whereas restricted User may only access entities or perform actions they’ve been given specific grants to.
+  Lists Users on your Account. Users may access all or part of your Account based on their restricted status and grants. An unrestricted User may access everything on the account, whereas restricted User may only access entities or perform actions they’ve been given specific grants to.
 ---
 
 # linode\_users


### PR DESCRIPTION
## 📝 Description

A quick fix to the markdown issue existing in the users documentation: `Error in user YAML: (<unknown>): could not find expected ':' while scanning a simple key at line 7 column 1`