### PR TITLE
fix: `TestConstructFilterString` failed due to missing filter config `TypeFunc`

### DIFF
--- a/linode/helper/frameworkfilter/api_filter_test.go
+++ b/linode/helper/frameworkfilter/api_filter_test.go
@@ -38,6 +38,18 @@ func TestConstructFilterString(t *testing.T) {
 				types.StringValue("wow"),
 			},
 		},
+		{
+			Name: types.StringValue("api_foo_int"),
+			Values: []types.String{
+				types.StringValue("123"),
+			},
+		},
+		{
+			Name: types.StringValue("api_foo_bool"),
+			Values: []types.String{
+				types.StringValue("true"),
+			},
+		},
 	}
 
 	expectedJSONData := map[string]any{
@@ -56,6 +68,20 @@ func TestConstructFilterString(t *testing.T) {
 				"+or": []map[string]any{
 					{
 						"api_bar": "test",
+					},
+				},
+			},
+			{
+				"+or": []map[string]any{
+					{
+						"api_foo_int": 123,
+					},
+				},
+			},
+			{
+				"+or": []map[string]any{
+					{
+						"api_foo_bool": true,
 					},
 				},
 			},

--- a/linode/helper/frameworkfilter/filter.go
+++ b/linode/helper/frameworkfilter/filter.go
@@ -34,7 +34,7 @@ type FiltersModelType []FilterModel
 
 // FilterTypeFunc is a function that takes in a filter name and value,
 // and returns the value converted to the correct filter type.
-type FilterTypeFunc func(value string) (interface{}, error)
+type FilterTypeFunc func(value string) (any, error)
 
 // FilterAttribute is used to configure filtering for an individual
 // response field.

--- a/linode/helper/frameworkfilter/filter_test.go
+++ b/linode/helper/frameworkfilter/filter_test.go
@@ -1,8 +1,10 @@
 package frameworkfilter
 
 var testFilterConfig = Config{
-	"foo":     {APIFilterable: false},
-	"bar":     {APIFilterable: false},
-	"api_foo": {APIFilterable: true},
-	"api_bar": {APIFilterable: true},
+	"foo":          {APIFilterable: false, TypeFunc: FilterTypeString},
+	"bar":          {APIFilterable: false, TypeFunc: FilterTypeString},
+	"api_foo":      {APIFilterable: true, TypeFunc: FilterTypeString},
+	"api_bar":      {APIFilterable: true, TypeFunc: FilterTypeString},
+	"api_foo_int":  {APIFilterable: true, TypeFunc: FilterTypeInt},
+	"api_foo_bool": {APIFilterable: true, TypeFunc: FilterTypeBool},
 }

--- a/linode/helper/frameworkfilter/validators_test.go
+++ b/linode/helper/frameworkfilter/validators_test.go
@@ -35,7 +35,7 @@ func TestFilterableValidator_filter(t *testing.T) {
 		t.Fatal("summary mismatch")
 	}
 
-	expectedError := "Field \"fake\" is not filterable.\nFilterable Fields: api_bar, api_foo, bar, foo"
+	expectedError := "Field \"fake\" is not filterable.\nFilterable Fields: api_bar, api_foo, api_foo_bool, api_foo_int, bar, foo"
 	if response.Diagnostics[0].Detail() != expectedError {
 		t.Fatal(cmp.Diff(response.Diagnostics[0].Detail(), expectedError))
 	}
@@ -67,7 +67,7 @@ func TestFilterableValidator_order(t *testing.T) {
 	}
 
 	expectedError := "Field \"foo\" cannot be used in order_by as it is not API filterable.\n" +
-		"API Filterable Fields: api_bar, api_foo"
+		"API Filterable Fields: api_bar, api_foo, api_foo_bool, api_foo_int"
 	if response.Diagnostics[0].Detail() != expectedError {
 		t.Fatal(cmp.Diff(response.Diagnostics[0].Detail(), expectedError))
 	}


### PR DESCRIPTION
## 📝 Description

The test case `TestConstructFilterString` was failing because `TypeFunc` was missing in `testFilterConfig`. Added it to all existing fields in the filter config, and also added test cases to make sure `int` and `bool` type are correctly converted as well.

## ✔️ How to Test

`make PKG_NAME="linode/helper/frameworkfilter" testacc`