### PR TITLE
Always set state in the `Update` function of `nb` resource

### DIFF
--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -150,8 +151,11 @@ func (r *Resource) Update(
 		}
 
 		resp.Diagnostics.Append(plan.parseComputedAttrs(ctx, nodebalancer)...)
-		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	} else {
+		req.State.GetAttribute(ctx, path.Root("updated"), &plan.Updated)
+		req.State.GetAttribute(ctx, path.Root("transfer"), &plan.Transfer)
 	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *Resource) Delete(


### PR DESCRIPTION
[Last time I thought putting the set state in the if block was okay](https://github.com/linode/terraform-provider-linode/pull/911#discussion_r1258464203) but later I realized that this may be better because normally Terraform framework won't call the update function when the user configured values remain unchanged, but if there is a bug or intentional change to the behavior, we will still want to make sure the `Update` function is running correctly. And this can also serve as a pattern for the future resource implementation.

I apologize about going back and forth on this issue.