### PR TITLE
Update outdated MySQL engine references

### DIFF
--- a/linode/databasemysql/framework_datasource_schema.go
+++ b/linode/databasemysql/framework_datasource_schema.go
@@ -18,7 +18,7 @@ var frameworkDatasourceSchema = schema.Schema{
 			Optional:    true,
 		},
 		"engine_id": schema.StringAttribute{
-			Description: "The Managed Database engine in engine/version format. (e.g. mysql/8.0.26)",
+			Description: "The Managed Database engine in engine/version format. (e.g. mysql/8.0.30)",
 			Computed:    true,
 		},
 		"label": schema.StringAttribute{

--- a/linode/databasemysql/schema_resource.go
+++ b/linode/databasemysql/schema_resource.go
@@ -12,7 +12,7 @@ var resourceSchema = map[string]*schema.Schema{
 	// Required fields
 	"engine_id": {
 		Type:        schema.TypeString,
-		Description: "The Managed Database engine in engine/version format. (e.g. mysql/8.0.26)",
+		Description: "The Managed Database engine in engine/version format. (e.g. mysql/8.0.30)",
 		Required:    true,
 		ForceNew:    true,
 	},

--- a/website/docs/d/database_mysql.html.markdown
+++ b/website/docs/d/database_mysql.html.markdown
@@ -44,7 +44,7 @@ The `linode_database_mysql` data source exports the following attributes:
 
 * `engine` - The Managed Database engine. (e.g. `mysql`)
 
-* `engine_id` - The Managed Database engine in engine/version format. (e.g. `mysql/8.0.26`)
+* `engine_id` - The Managed Database engine in engine/version format. (e.g. `mysql/8.0.30`)
 
 * `host_primary` - The primary host for the Managed Database.
 

--- a/website/docs/r/database_access_controls.markdown
+++ b/website/docs/r/database_access_controls.markdown
@@ -31,7 +31,7 @@ resource "linode_instance" "my-instance" {
 
 resource "linode_database_mysql" "my-db" {
   label = "mydatabase"
-  engine_id = "mysql/8.0.26"
+  engine_id = "mysql/8.0.30"
   region = "us-southeast"
   type = "g6-nanode-1"
 }

--- a/website/docs/r/database_mysql.html.markdown
+++ b/website/docs/r/database_mysql.html.markdown
@@ -20,7 +20,7 @@ Creating a simple MySQL database instance:
 ```hcl
 resource "linode_database_mysql" "foobar" {
   label = "mydatabase"
-  engine_id = "mysql/8.0.26"
+  engine_id = "mysql/8.0.30"
   region = "us-southeast"
   type = "g6-nanode-1"
 }
@@ -31,7 +31,7 @@ Creating a complex MySQL database instance:
 ```hcl
 resource "linode_database_mysql" "foobar" {
   label = "mydatabase"
-  engine_id = "mysql/8.0.26"
+  engine_id = "mysql/8.0.30"
   region = "us-southeast"
   type = "g6-nanode-1"
 
@@ -55,7 +55,7 @@ resource "linode_database_mysql" "foobar" {
 
 The following arguments are supported:
 
-* `engine_id` - (Required) The Managed Database engine in engine/version format. (e.g. `mysql/8.0.26`)
+* `engine_id` - (Required) The Managed Database engine in engine/version format. (e.g. `mysql/8.0.30`)
 
 * `label` - (Required) A unique, user-defined string referring to the Managed Database.
 


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

This addresses https://github.com/linode/terraform-provider-linode/issues/943.

MySQL v8.0.26 is no longer offered; updated the documentation.