### PR TITLE
Fix: diskSlotReorder test in linode/instance 

### DIFF
--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -1537,7 +1537,7 @@ func TestAccResourceInstance_diskSlotReorder(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resName, "config.0.devices.0.sdb.0.disk_id", resName, "disk.0.id"),
 
 					resource.TestCheckResourceAttr(resName, "swap_size", "0"),
-					resource.TestCheckResourceAttr(resName, "status", "offline"),
+					resource.TestCheckResourceAttr(resName, "status", "running"),
 				),
 			},
 		},


### PR DESCRIPTION
## 📝 Description

The linode instance that is used in the test successfully reboots after adding a separate disk and reordering. Hence changing the status assertion to "running" instead of "offline"

## ✔️ How to Test

╰─➤  make PKG_NAME="linode/instance" TESTARGS="-run TestAccResourceInstance_diskSlotReorder" testacc                                                                                                   

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**