### PR TITLE
fix: Allow creating a `linode_firewall` with no rules

### DIFF
--- a/linode/firewall/resource.go
+++ b/linode/firewall/resource.go
@@ -36,7 +36,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*helper.ProviderMeta).Client
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -75,7 +75,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*helper.ProviderMeta).Client
 
 	createOpts := linodego.FirewallCreateOptions{
@@ -84,14 +84,10 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	createOpts.Devices.Linodes = helper.ExpandIntSet(d.Get("linodes").(*schema.Set))
-	createOpts.Rules.Inbound = expandFirewallRules(d.Get("inbound").([]interface{}))
+	createOpts.Rules.Inbound = expandFirewallRules(d.Get("inbound").([]any))
 	createOpts.Rules.InboundPolicy = d.Get("inbound_policy").(string)
-	createOpts.Rules.Outbound = expandFirewallRules(d.Get("outbound").([]interface{}))
+	createOpts.Rules.Outbound = expandFirewallRules(d.Get("outbound").([]any))
 	createOpts.Rules.OutboundPolicy = d.Get("outbound_policy").(string)
-
-	if len(createOpts.Rules.Inbound)+len(createOpts.Rules.Outbound) == 0 {
-		return diag.Errorf("cannot create firewall without at least one inbound or outbound rule")
-	}
 
 	firewall, err := client.CreateFirewall(ctx, createOpts)
 	if err != nil {
@@ -110,7 +106,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	return readResource(ctx, d, meta)
 }
 
-func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*helper.ProviderMeta).Client
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -135,8 +131,8 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 		}
 	}
 
-	inboundRules := expandFirewallRules(d.Get("inbound").([]interface{}))
-	outboundRules := expandFirewallRules(d.Get("outbound").([]interface{}))
+	inboundRules := expandFirewallRules(d.Get("inbound").([]any))
+	outboundRules := expandFirewallRules(d.Get("outbound").([]any))
 	ruleSet := linodego.FirewallRuleSet{
 		Inbound:        inboundRules,
 		InboundPolicy:  d.Get("inbound_policy").(string),
@@ -189,7 +185,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*helper.ProviderMeta).Client
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {

--- a/linode/firewall/resource_test.go
+++ b/linode/firewall/resource_test.go
@@ -464,3 +464,34 @@ func TestAccLinodeFirewall_emptyIPv6(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLinodeFirewall_noRules(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.NoRules(t, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testFirewallResName, "label", name),
+					resource.TestCheckResourceAttr(testFirewallResName, "disabled", "false"),
+					resource.TestCheckResourceAttr(testFirewallResName, "inbound.#", "0"),
+					resource.TestCheckResourceAttr(testFirewallResName, "outbound.#", "0"),
+					resource.TestCheckResourceAttr(testFirewallResName, "devices.#", "0"),
+					resource.TestCheckResourceAttr(testFirewallResName, "linodes.#", "0"),
+					resource.TestCheckResourceAttr(testFirewallResName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(testFirewallResName, "tags.0", "test"),
+				),
+			},
+			{
+				ResourceName:      testFirewallResName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/linode/firewall/tmpl/no_rules.gotf
+++ b/linode/firewall/tmpl/no_rules.gotf
@@ -1,0 +1,11 @@
+{{ define "firewall_no_rules" }}
+
+resource "linode_firewall" "test" {
+    label = "{{.Label}}"
+    tags  = ["test"]
+
+    inbound_policy = "DROP"
+    outbound_policy = "DROP"
+}
+
+{{ end }}

--- a/linode/firewall/tmpl/template.go
+++ b/linode/firewall/tmpl/template.go
@@ -91,6 +91,13 @@ func NoIPv6(t *testing.T, label string) string {
 		})
 }
 
+func NoRules(t *testing.T, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"firewall_no_rules", TemplateData{
+			Label: label,
+		})
+}
+
 func DataBasic(t *testing.T, label, devicePrefix, region string) string {
 	return acceptance.ExecuteTemplate(t,
 		"firewall_data_basic", TemplateData{


### PR DESCRIPTION
## 📝 Description

This change drops the client-side check that ensures at least one inbound or outbound rule is specified when creating a Linode Firewall and adds a corresponding acceptance test case. This restriction is no longer enforced at an API level.

Resolves #881 

## ✔️ How to Test

```
make PKG_NAME=linode/firewall testacc
```
