### PR TITLE
Adding `linode_kernels` data source

### DIFF
--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -29,6 +29,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/instancetypes"
 	"github.com/linode/terraform-provider-linode/linode/ipv6range"
 	"github.com/linode/terraform-provider-linode/linode/kernel"
+	"github.com/linode/terraform-provider-linode/linode/kernels"
 	"github.com/linode/terraform-provider-linode/linode/lkeversions"
 	"github.com/linode/terraform-provider-linode/linode/nb"
 	"github.com/linode/terraform-provider-linode/linode/nbconfig"
@@ -187,5 +188,6 @@ func (p *FrameworkProvider) DataSources(ctx context.Context) []func() datasource
 		users.NewDataSource,
 		nbnode.NewDataSource,
 		accountsettings.NewDataSource,
+		kernels.NewDataSource,
 	}
 }

--- a/linode/kernel/framework_datasource.go
+++ b/linode/kernel/framework_datasource.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
@@ -20,28 +18,6 @@ func NewDataSource() datasource.DataSource {
 
 type DataSource struct {
 	helper.BaseDataSource
-}
-
-func (data *DataSourceModel) parseKernel(kernel *linodego.LinodeKernel) {
-	data.ID = types.StringValue(kernel.ID)
-	data.Architecture = types.StringValue(kernel.Architecture)
-	data.Deprecated = types.BoolValue(kernel.Deprecated)
-	data.KVM = types.BoolValue(kernel.KVM)
-	data.Label = types.StringValue(kernel.Label)
-	data.PVOPS = types.BoolValue(kernel.PVOPS)
-	data.Version = types.StringValue(kernel.Version)
-	data.XEN = types.BoolValue(kernel.XEN)
-}
-
-type DataSourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	Architecture types.String `tfsdk:"architecture"`
-	Deprecated   types.Bool   `tfsdk:"deprecated"`
-	KVM          types.Bool   `tfsdk:"kvm"`
-	Label        types.String `tfsdk:"label"`
-	PVOPS        types.Bool   `tfsdk:"pvops"`
-	Version      types.String `tfsdk:"version"`
-	XEN          types.Bool   `tfsdk:"xen"`
 }
 
 func (d *DataSource) Read(
@@ -66,6 +42,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	data.parseKernel(kernel)
+	data.ParseKernel(ctx, kernel)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/linode/kernel/framework_datasource_schema.go
+++ b/linode/kernel/framework_datasource_schema.go
@@ -5,39 +5,39 @@ import (
 )
 
 var KernelAttributes = map[string]schema.Attribute{
-		"id": schema.StringAttribute{
-			Description: "The unique ID of this Kernel.",
-			Required:    true,
-		},
-		"architecture": schema.StringAttribute{
-			Description: "The architecture of this Kernel.",
-			Computed:    true,
-		},
-		"deprecated": schema.BoolAttribute{
-			Description: "Whether or not this Kernel is deprecated.",
-			Computed:    true,
-		},
-		"kvm": schema.BoolAttribute{
-			Description: "If this Kernel is suitable for KVM Linodes.",
-			Computed:    true,
-		},
-		"label": schema.StringAttribute{
-			Description: "The friendly name of this Kernel.",
-			Computed:    true,
-		},
-		"pvops": schema.BoolAttribute{
-			Description: "If this Kernel is suitable for paravirtualized operations.",
-			Computed:    true,
-		},
-		"version": schema.StringAttribute{
-			Description: "Linux Kernel version.",
-			Computed:    true,
-		},
-		"xen": schema.BoolAttribute{
-			Description: "If this Kernel is suitable for Xen Linodes.",
-			Computed:    true,
-		},
-	}
+	"id": schema.StringAttribute{
+		Description: "The unique ID of this Kernel.",
+		Required:    true,
+	},
+	"architecture": schema.StringAttribute{
+		Description: "The architecture of this Kernel.",
+		Computed:    true,
+	},
+	"deprecated": schema.BoolAttribute{
+		Description: "Whether or not this Kernel is deprecated.",
+		Computed:    true,
+	},
+	"kvm": schema.BoolAttribute{
+		Description: "If this Kernel is suitable for KVM Linodes.",
+		Computed:    true,
+	},
+	"label": schema.StringAttribute{
+		Description: "The friendly name of this Kernel.",
+		Computed:    true,
+	},
+	"pvops": schema.BoolAttribute{
+		Description: "If this Kernel is suitable for paravirtualized operations.",
+		Computed:    true,
+	},
+	"version": schema.StringAttribute{
+		Description: "Linux Kernel version.",
+		Computed:    true,
+	},
+	"xen": schema.BoolAttribute{
+		Description: "If this Kernel is suitable for Xen Linodes.",
+		Computed:    true,
+	},
+}
 
 var frameworkDatasourceSchema = schema.Schema{
 	Attributes: KernelAttributes,

--- a/linode/kernel/framework_datasource_schema.go
+++ b/linode/kernel/framework_datasource_schema.go
@@ -4,8 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 )
 
-var frameworkDatasourceSchema = schema.Schema{
-	Attributes: map[string]schema.Attribute{
+var KernelAttributes = map[string]schema.Attribute{
 		"id": schema.StringAttribute{
 			Description: "The unique ID of this Kernel.",
 			Required:    true,
@@ -38,5 +37,8 @@ var frameworkDatasourceSchema = schema.Schema{
 			Description: "If this Kernel is suitable for Xen Linodes.",
 			Computed:    true,
 		},
-	},
+	}
+
+var frameworkDatasourceSchema = schema.Schema{
+	Attributes: KernelAttributes,
 }

--- a/linode/kernel/framework_models.go
+++ b/linode/kernel/framework_models.go
@@ -2,7 +2,7 @@ package kernel
 
 import (
 	"context"
-	
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 )

--- a/linode/kernel/framework_models.go
+++ b/linode/kernel/framework_models.go
@@ -1,0 +1,30 @@
+package kernel
+
+import (
+	"context"
+	
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+)
+
+type DataSourceModel struct {
+	ID           types.String `tfsdk:"id"`
+	Architecture types.String `tfsdk:"architecture"`
+	Deprecated   types.Bool   `tfsdk:"deprecated"`
+	KVM          types.Bool   `tfsdk:"kvm"`
+	Label        types.String `tfsdk:"label"`
+	PVOPS        types.Bool   `tfsdk:"pvops"`
+	Version      types.String `tfsdk:"version"`
+	XEN          types.Bool   `tfsdk:"xen"`
+}
+
+func (data *DataSourceModel) ParseKernel(ctx context.Context, kernel *linodego.LinodeKernel) {
+	data.ID = types.StringValue(kernel.ID)
+	data.Architecture = types.StringValue(kernel.Architecture)
+	data.Deprecated = types.BoolValue(kernel.Deprecated)
+	data.KVM = types.BoolValue(kernel.KVM)
+	data.Label = types.StringValue(kernel.Label)
+	data.PVOPS = types.BoolValue(kernel.PVOPS)
+	data.Version = types.StringValue(kernel.Version)
+	data.XEN = types.BoolValue(kernel.XEN)
+}

--- a/linode/kernels/datasource_test.go
+++ b/linode/kernels/datasource_test.go
@@ -3,16 +3,18 @@ package kernels_test
 import (
 	"testing"
 
+	//	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/linode/terraform-provider-linode/linode/acceptance"
-	"github.com/linode/terraform-provider-linode/linode/kernel/tmpl"
+	"github.com/linode/terraform-provider-linode/linode/kernels/tmpl"
 )
 
-func TestAccDataSourceKernel_basic(t *testing.T) {
+func TestAccDataSourceKernels_basic(t *testing.T) {
 	t.Parallel()
 
+	resourceName := "data.linode_kernels.kernels"
+
 	kernelID := "linode/latest-64bit"
-	resourceName := "data.linode_kernel.foobar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -21,15 +23,26 @@ func TestAccDataSourceKernel_basic(t *testing.T) {
 			{
 				Config: tmpl.DataBasic(t, kernelID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "id", kernelID),
-					resource.TestCheckResourceAttrSet(resourceName, "label"),
-					resource.TestCheckResourceAttrSet(resourceName, "architecture"),
-					resource.TestCheckResourceAttrSet(resourceName, "deprecated"),
-					resource.TestCheckResourceAttrSet(resourceName, "kvm"),
-					resource.TestCheckResourceAttrSet(resourceName, "label"),
-					resource.TestCheckResourceAttrSet(resourceName, "pvops"),
-					resource.TestCheckResourceAttrSet(resourceName, "version"),
-					resource.TestCheckResourceAttrSet(resourceName, "xen"),
+					resource.TestCheckResourceAttr(resourceName, "kernels.0.id", kernelID+"-0"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernels.0.architecture"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernels.0.deprecated"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernels.0.kvm"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernels.0.label"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernels.0.pvops"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernels.0.version"),
+					resource.TestCheckResourceAttrSet(resourceName, "kernels.0.xen"),
+				),
+			},
+			{
+				Config: tmpl.DataFilter(t, kernelID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "kernels.#", "1"),
+				),
+			},
+			{
+				Config: tmpl.DataFilterEmpty(t, kernelID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "kernels.#", "0"),
 				),
 			},
 		},

--- a/linode/kernels/datasource_test.go
+++ b/linode/kernels/datasource_test.go
@@ -1,0 +1,37 @@
+package kernels_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/kernel/tmpl"
+)
+
+func TestAccDataSourceKernel_basic(t *testing.T) {
+	t.Parallel()
+
+	kernelID := "linode/latest-64bit"
+	resourceName := "data.linode_kernel.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, kernelID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", kernelID),
+					resource.TestCheckResourceAttrSet(resourceName, "label"),
+					resource.TestCheckResourceAttrSet(resourceName, "architecture"),
+					resource.TestCheckResourceAttrSet(resourceName, "deprecated"),
+					resource.TestCheckResourceAttrSet(resourceName, "kvm"),
+					resource.TestCheckResourceAttrSet(resourceName, "label"),
+					resource.TestCheckResourceAttrSet(resourceName, "pvops"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttrSet(resourceName, "xen"),
+				),
+			},
+		},
+	})
+}

--- a/linode/kernels/framework_datasource.go
+++ b/linode/kernels/framework_datasource.go
@@ -1,0 +1,68 @@
+package kernels
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+type DataSource struct {
+	helper.BaseDataSource
+}
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{
+		BaseDataSource: helper.NewBaseDataSource(
+			"linode_kernels",
+			frameworkDatasourceSchema,
+		),
+	}
+}
+
+func (d *DataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var data KernelFilterModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, diag := filterConfig.GenerateID(data.Filters)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+	data.ID = id
+
+	result, diag := filterConfig.GetAndFilter(
+		ctx, d.Meta.Client, data.Filters, listKernels,
+		data.Order, data.OrderBy)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+
+	data.parseKernels(ctx, helper.AnySliceToTyped[linodego.LinodeKernel](result))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func listKernels(
+	ctx context.Context,
+	client *linodego.Client,
+	filter string,
+) ([]any, error) {
+	kernels, err := client.ListKernels(ctx, &linodego.ListOptions{
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return helper.TypedSliceToAny(kernels), nil
+}

--- a/linode/kernels/framework_datasource_schema.go
+++ b/linode/kernels/framework_datasource_schema.go
@@ -7,6 +7,7 @@ import (
 )
 
 var filterConfig = frameworkfilter.Config{
+	"id":           {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
 	"architecture": {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
 	"deprecated":   {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
 	"kvm":          {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
@@ -27,7 +28,7 @@ var frameworkDatasourceSchema = schema.Schema{
 	},
 	Blocks: map[string]schema.Block{
 		"filter": filterConfig.Schema(),
-		"users": schema.ListNestedBlock{
+		"kernels": schema.ListNestedBlock{
 			Description: "The returned list of Kernels.",
 			NestedObject: schema.NestedBlockObject{
 				Attributes: kernel.KernelAttributes,

--- a/linode/kernels/framework_datasource_schema.go
+++ b/linode/kernels/framework_datasource_schema.go
@@ -1,0 +1,37 @@
+package kernels
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/linode/terraform-provider-linode/linode/helper/frameworkfilter"
+	"github.com/linode/terraform-provider-linode/linode/kernel"
+)
+
+var filterConfig = frameworkfilter.Config{
+	"architecture": {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"deprecated":   {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
+	"kvm":          {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
+	"label":        {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"pvops":        {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
+	"version":      {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"xen":          {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
+}
+
+var frameworkDatasourceSchema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Description: "The data source's unique ID.",
+			Computed:    true,
+		},
+		"order":    filterConfig.OrderSchema(),
+		"order_by": filterConfig.OrderBySchema(),
+	},
+	Blocks: map[string]schema.Block{
+		"filter": filterConfig.Schema(),
+		"users": schema.ListNestedBlock{
+			Description: "The returned list of Kernels.",
+			NestedObject: schema.NestedBlockObject{
+				Attributes: kernel.KernelAttributes,
+			},
+		},
+	},
+}

--- a/linode/kernels/framework_models.go
+++ b/linode/kernels/framework_models.go
@@ -1,0 +1,34 @@
+package kernels
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper/frameworkfilter"
+	"github.com/linode/terraform-provider-linode/linode/kernel"
+)
+
+// KernelFilterModel describes the Terraform resource data model to match the
+// resource schema.
+type KernelFilterModel struct {
+	ID      types.String                     `tfsdk:"id"`
+	Filters frameworkfilter.FiltersModelType `tfsdk:"filter"`
+	Order   types.String                     `tfsdk:"order"`
+	OrderBy types.String                     `tfsdk:"order_by"`
+	Kernels []kernel.DataSourceModel         `tfsdk:"kernels"`
+}
+
+func (data *KernelFilterModel) parseKernels(
+	ctx context.Context,
+	kernels []linodego.LinodeKernel,
+) {
+	result := make([]kernel.DataSourceModel, len(kernels))
+	for i := range kernels {
+		var kernelData kernel.DataSourceModel
+		kernelData.ParseKernel(ctx, &kernels[i])
+		result[i] = kernelData
+	}
+
+	data.Kernels = result
+}

--- a/linode/kernels/tmpl/data_base.gotf
+++ b/linode/kernels/tmpl/data_base.gotf
@@ -1,0 +1,8 @@
+{{ define "kernels_data_base" }}
+
+resource "linode_kernel" "kernel" {
+    count = 2
+    id = "{{.Id}}-${count.index}"
+}
+
+{{ end }}

--- a/linode/kernels/tmpl/data_basic.gotf
+++ b/linode/kernels/tmpl/data_basic.gotf
@@ -1,0 +1,12 @@
+{{ define "kernels_data_basic" }}
+
+{{ template "kernels_data_base" .}}
+
+data "linode_kernels" "kernels" {
+    filter {
+        name = "id"
+        values = [linode_kernel.kernel.0.id]
+    }
+}
+
+{{ end }}

--- a/linode/kernels/tmpl/data_filter.gotf
+++ b/linode/kernels/tmpl/data_filter.gotf
@@ -1,0 +1,12 @@
+{{ define "kernels_data_filter" }}
+
+{{ template "kernels_data_base" . }}
+
+data "linode_kernels" "kernels" {
+    filter {
+        name   = "id" 
+        values = ["{{.Id}}"]
+    }
+}
+
+{{ end }}

--- a/linode/kernels/tmpl/data_filter_empty.gotf
+++ b/linode/kernels/tmpl/data_filter_empty.gotf
@@ -1,0 +1,12 @@
+{{ define "kernels_data_filter_empty" }}
+
+{{ template "kernels_data_base" . }}
+
+data "linode_kernels" "kernels" {
+    filter {
+        name = "label"
+        values = ["not-real-label"]
+    }
+}
+
+{{ end }}

--- a/linode/kernels/tmpl/template.go
+++ b/linode/kernels/tmpl/template.go
@@ -1,0 +1,32 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+type TemplateData struct {
+	Id string
+}
+
+func DataBasic(t *testing.T, id string) string {
+	return acceptance.ExecuteTemplate(t,
+		"kernels_data_basic", TemplateData{
+			Id: id,
+		})
+}
+
+func DataFilter(t *testing.T, id string) string {
+	return acceptance.ExecuteTemplate(t,
+		"kernels_data_filter", TemplateData{
+			Id: id,
+		})
+}
+
+func DataFilterEmpty(t *testing.T, id string) string {
+	return acceptance.ExecuteTemplate(t,
+		"kernels_data_filter_empty", TemplateData{
+			Id: id,
+		})
+}


### PR DESCRIPTION
## 📝 Description

Adds a kernels data source that allows users to filter kernels.

Note: currently `linode_kernel` exists only as a data source, not a resource, this is not the case for `linode_nodebalancer` and `linode_user`.

## ✔️ How to Test

make PKG_NAME=linode/kernels TESTARGS="-run TestAccDataSourceKernels_basic" testacc
