### PR TITLE
Added documentation on volumes to handle the case where you attach vi…

### DIFF
--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -62,7 +62,7 @@ resource "linode_volume" "foobar" {
 }
 ```
 
-If you use a `linode_instance_config` you should not include the `linode_id` in the `linode_volume`. The volume will be attached to the linode via the instance config. The folowing is a complete example which demonstrates the usage: 
+If you use a `linode_instance_config` you should not include the `linode_id` in the `linode_volume`. The volume will be attached to the linode via the instance config. The folowing is a complete example which demonstrates the usage:
 
 ```hcl
 terraform {
@@ -161,7 +161,6 @@ resource "linode_instance" "my-instance" {
   region = "us-southeast"
 }
 ```
-
 
 ## Argument Reference
 


### PR DESCRIPTION
## 📝 Description

This PR updates documentation for `linode_volume`. The existing documentation implies that you should use the `linode_id` in the `linode_volume`. This is correct when you are not using a `linode_instance_config` however if you use a `linode_instance_config` the volume is associated with the linode through the config. If you use the `linode_id` in the `linode_volume` with a `linode_instance_config` then Terraform will attempt to associate the volume with the linode before the config has been created. The API does not allow this and fails. Terraform is unable to complete the request. 

I have included a complete working example based on the documentation for the `linode_instance_config`. 


## ✔️ How to Test

You can use the example in this PR to verify the documentation works. To verify the failure case you can add the `linode_id` to the `linode_volume` with 

```hcl
  linode_id = linode_instance.my-instance.id
```

With this addition you will receive the following error from the API. 

```
Error: failed to create volume: failed to create linode volume: [400] Couldn't choose a configuration profile to add this volume to. Please add this volume to the configuration profile you want.
```

