### PR TITLE
fix: Fix broken check for `skip_implicit_reboots` in `linode_instance`; implement workaround for null IPAM issue

### DIFF
--- a/linode/instance/flatten.go
+++ b/linode/instance/flatten.go
@@ -158,6 +158,13 @@ func flattenInstanceConfigs(
 
 		interfaces := make([]interface{}, len(config.Interfaces))
 		for i, ni := range config.Interfaces {
+			// Workaround for "222" responses for null IPAM
+			// addresses from the API.
+			// TODO: Remove this when issue is resolved.
+			if ni.IPAMAddress == "222" {
+				ni.IPAMAddress = ""
+			}
+
 			interfaces[i] = flattenConfigInterface(ni)
 		}
 

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -136,6 +136,13 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 			flattenedInterfaces := make([]map[string]interface{}, len(defaultConfig.Interfaces))
 
 			for i, configInterface := range defaultConfig.Interfaces {
+				// Workaround for "222" responses for null IPAM
+				// addresses from the API.
+				// TODO: Remove this when issue is resolved.
+				if configInterface.IPAMAddress == "222" {
+					configInterface.IPAMAddress = ""
+				}
+
 				flattenedInterfaces[i] = flattenConfigInterface(configInterface)
 			}
 
@@ -655,7 +662,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	// Only reboot the instance if implicit reboots are not skipped
-	if !meta.(*helper.ProviderMeta).Config.SkipImplicitReboots {
+	if meta.(*helper.ProviderMeta).Config.SkipImplicitReboots {
 		rebootInstance = false
 	}
 

--- a/linode/instanceconfig/helper.go
+++ b/linode/instanceconfig/helper.go
@@ -50,6 +50,13 @@ func flattenInterfaces(interfaces []linodego.InstanceConfigInterface) []map[stri
 	result := make([]map[string]any, len(interfaces))
 
 	for i, iface := range interfaces {
+		// Workaround for "222" responses for null IPAM
+		// addresses from the API.
+		// TODO: Remove this when issue is resolved.
+		if iface.IPAMAddress == "222" {
+			iface.IPAMAddress = ""
+		}
+
 		result[i] = map[string]any{
 			"purpose":      iface.Purpose,
 			"ipam_address": iface.IPAMAddress,


### PR DESCRIPTION
## 📝 Description

This change fixes a broken check that would cause `skip_implicit_reboots` to not work as expected. Additionally, this change implements a temporary workaround for the `222` null IPAM address issue with config interfaces.

## ✔️ How to Test

```
make PKG_NAME=linode/instance testacc
make PKG_NAME=linode/instanceconfig testacc
```