### PR TITLE
fix: Re-enable `has_user_data` test cases

### DIFF
--- a/linode/accountlogins/framework_models_unit_test.go
+++ b/linode/accountlogins/framework_models_unit_test.go
@@ -3,10 +3,11 @@
 package accountlogins
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/linode/linodego"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
 )
 
 func TestParseLogins(t *testing.T) {

--- a/linode/accountsettings/framework_model_unit_test.go
+++ b/linode/accountsettings/framework_model_unit_test.go
@@ -3,8 +3,9 @@
 package accountsettings
 
 import (
-	"github.com/linode/linodego"
 	"testing"
+
+	"github.com/linode/linodego"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )

--- a/linode/backup/framework_model_unit_test.go
+++ b/linode/backup/framework_model_unit_test.go
@@ -4,8 +4,9 @@ package backup
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"

--- a/linode/databasebackups/framework_models_unit_test.go
+++ b/linode/databasebackups/framework_models_unit_test.go
@@ -3,11 +3,12 @@
 package databasebackups
 
 import (
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestParseMySQLBackup(t *testing.T) {

--- a/linode/databaseengines/framework_models_unit_test.go
+++ b/linode/databaseengines/framework_models_unit_test.go
@@ -3,8 +3,9 @@
 package databaseengines
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"

--- a/linode/domain/framework_models_unit_test.go
+++ b/linode/domain/framework_models_unit_test.go
@@ -3,8 +3,9 @@
 package domain
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"

--- a/linode/firewall/firewall_helpers_unit_test.go
+++ b/linode/firewall/firewall_helpers_unit_test.go
@@ -3,10 +3,11 @@
 package firewall
 
 import (
-	"github.com/linode/linodego"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
 )
 
 // Assertion helpers

--- a/linode/instance/expand_unit_test.go
+++ b/linode/instance/expand_unit_test.go
@@ -3,8 +3,9 @@
 package instance
 
 import (
-	"github.com/linode/linodego"
 	"testing"
+
+	"github.com/linode/linodego"
 )
 
 func TestExpandInstanceConfigDeviceMap(t *testing.T) {

--- a/linode/instance/flatten_unit_test.go
+++ b/linode/instance/flatten_unit_test.go
@@ -3,10 +3,11 @@
 package instance
 
 import (
-	"github.com/linode/linodego"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/linode/linodego"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -324,7 +325,6 @@ func TestFlattenInstanceConfigs(t *testing.T) {
 	}
 
 	for i := 0; i < len(expectedConfigs); i++ {
-
 		if !areMapsEqual(actualConfigs[i], expectedConfigs[i]) {
 			t.Errorf("Config %d: Mismatch between expected and actual config", i)
 		}

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -2016,12 +2016,16 @@ func TestAccResourceInstance_ipv4Sharing(t *testing.T) {
 }
 
 func TestAccResourceInstance_userData(t *testing.T) {
-	t.Skip("Skipping this test due to: 'Error creating a Linode Instance: [400] [metadata] The Metadata service is not currently available in this datacenter.'")
 	t.Parallel()
 
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+
+	region, err := acceptance.GetRandomRegionWithCaps([]string{"Metadata"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2029,16 +2033,15 @@ func TestAccResourceInstance_userData(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.UserData(t, instanceName, "eu-west"),
+				Config: tmpl.UserData(t, instanceName, region),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
 					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
 					resource.TestCheckResourceAttr(resName, "image", acceptance.TestImageLatest),
-					resource.TestCheckResourceAttr(resName, "region", "eu-west"),
+					resource.TestCheckResourceAttr(resName, "region", region),
 
-					// TODO:: This attribute currently does not get set by the API. Need to uncomment this line when metadata api returns a valid response
-					// resource.TestCheckResourceAttr(resName, "has_user_data", "true"),
+					resource.TestCheckResourceAttr(resName, "has_user_data", "true"),
 				),
 			},
 			{

--- a/linode/objkey/framework_models_unit_test.go
+++ b/linode/objkey/framework_models_unit_test.go
@@ -28,11 +28,11 @@ func TestParseConfiguredAttributes(t *testing.T) {
 
 	data := ResourceModel{}
 	data.parseConfiguredAttributes(&key)
-	//assert.Equal(t, types.Int64Value(123), data.ID)
-	//assert.Equal(t, types.StringValue("my-key"), data.Label)
-	//assert.Equal(t, types.StringValue("KVAKUTGBA4WTR2NSJQ81"), data.AccessKey)
-	//assert.Equal(t, types.StringValue("OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw"), data.SecretKey)
-	//assert.Equal(t, types.BoolValue(true), data.Limited)
+	// assert.Equal(t, types.Int64Value(123), data.ID)
+	// assert.Equal(t, types.StringValue("my-key"), data.Label)
+	// assert.Equal(t, types.StringValue("KVAKUTGBA4WTR2NSJQ81"), data.AccessKey)
+	// assert.Equal(t, types.StringValue("OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw"), data.SecretKey)
+	// assert.Equal(t, types.BoolValue(true), data.Limited)
 
 	//assert.NotNil(t, data.BucketAccess)
 	//

--- a/linode/user/framework_models_unit_test.go
+++ b/linode/user/framework_models_unit_test.go
@@ -4,10 +4,11 @@ package user
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
@@ -150,5 +151,4 @@ func TestParseUserGrants(t *testing.T) {
 	assert.Contains(t, dataModel.GlobalGrants.String(), "\"add_volumes\":true")
 	assert.Contains(t, dataModel.GlobalGrants.String(), "\"cancel_account\":false")
 	assert.Contains(t, dataModel.GlobalGrants.String(), "\"longview_subscription\":true")
-
 }


### PR DESCRIPTION
## 📝 Description

This change re-enables the `TestAccResourceInstance_userData` test now that the `has_user_data` field is now accessible through the Linode API.

## ✔️ How to Test

```
make PKG_NAME=linode/instance TESTARGS="-run TestAccResourceInstance_userData" testacc
```
