### PR TITLE
fix: Drop DiffSuppressFunc from `linode_instance` disk and config fields

### DIFF
--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -464,10 +464,6 @@ var resourceSchema = map[string]*schema.Schema{
 			"image", "root_pass", "authorized_keys", "authorized_users", "swap_size",
 			"backup_id", "stackscript_id", "interface",
 		},
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			_, hasImage := d.GetOk("image")
-			return hasImage
-		},
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"label": {
@@ -647,10 +643,6 @@ var resourceSchema = map[string]*schema.Schema{
 			"backup_id", "stackscript_id", "interface",
 		},
 		Type: schema.TypeList,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			_, hasImage := d.GetOk("image")
-			return hasImage
-		},
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"label": {

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -20,6 +20,8 @@ Creating an image from an existing Linode Instance and deploying another instanc
 resource "linode_instance" "foo" {
     type = "g6-nanode-1"
     region = "us-central"
+    image = "linode/ubuntu22.04"
+    root_pass = "insecure-p4ssw0rd!!"
 }
 
 resource "linode_image" "bar" {


### PR DESCRIPTION
## 📝 Description

This change drops the `DiffSuppressFunc` from the `linode_instance` config and disk fields, which caused these fields to be unusable from other resources when implicitly created.

Additionally, this change corrects an error in the example for the `linode_image` resource.

This PR is in draft while I investigate the scope of this change.

## ✔️ How to Test

```
make PKG_NAME=linode/instance testacc
```
