### PR TITLE
ref: Configure `gomoddirectives` to ignore linodego feature branches

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,10 @@ linters-settings:
     check-type-assertions: true
     check-blank: true
 
+  gomoddirectives:
+    replace-allow-list:
+      - github.com/linode/linodego
+
   govet:
     check-shadowing: true
 


### PR DESCRIPTION
## 📝 Description

This change configures the `gomoddirectives` linter to ignore replace statements pointing to linodego feature branches. Ideally we would want to raise these as warnings, but at the moment `golangci-lint` does not offer a way to set exit code depending on individual linter severity.
