### PR TITLE
new: Add `vpcs` data source

### DIFF
--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -54,6 +54,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/vlan"
 	"github.com/linode/terraform-provider-linode/linode/volume"
 	"github.com/linode/terraform-provider-linode/linode/vpc"
+	"github.com/linode/terraform-provider-linode/linode/vpcs"
 	"github.com/linode/terraform-provider-linode/linode/vpcsubnet"
 )
 
@@ -206,5 +207,6 @@ func (p *FrameworkProvider) DataSources(ctx context.Context) []func() datasource
 		kernels.NewDataSource,
 		vpcsubnet.NewDataSource,
 		vpc.NewDataSource,
+		vpcs.NewDataSource,
 	}
 }

--- a/linode/vpc/framework_datasource.go
+++ b/linode/vpc/framework_datasource.go
@@ -51,7 +51,7 @@ func (d *DataSource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseVPC(ctx, vpc)...)
+	resp.Diagnostics.Append(data.ParseVPC(ctx, vpc)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/vpc/framework_models.go
+++ b/linode/vpc/framework_models.go
@@ -35,7 +35,7 @@ func (d *VPCModel) parseComputedAttributes(
 	return nil
 }
 
-func (d *VPCModel) parseVPC(
+func (d *VPCModel) ParseVPC(
 	ctx context.Context,
 	vpc *linodego.VPC,
 ) diag.Diagnostics {

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -102,7 +102,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseVPC(ctx, vpc)...)
+	resp.Diagnostics.Append(data.ParseVPC(ctx, vpc)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/vpc/framework_schema_datasource.go
+++ b/linode/vpc/framework_schema_datasource.go
@@ -5,33 +5,35 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/helper/customtypes"
 )
 
-var frameworkDatasourceSchema = schema.Schema{
-	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
-			Description: "The id of the VPC.",
-			Required:    true,
-		},
-		"label": schema.StringAttribute{
-			Description: "The label of the VPC.",
-			Computed:    true,
-		},
-		"description": schema.StringAttribute{
-			Description: "The user-defined description of this VPC.",
-			Computed:    true,
-		},
-		"region": schema.StringAttribute{
-			Description: "The region of the VPC.",
-			Computed:    true,
-		},
-		"created": schema.StringAttribute{
-			Description: "The date and time when the VPC was created.",
-			Computed:    true,
-			CustomType:  customtypes.RFC3339TimeStringType{},
-		},
-		"updated": schema.StringAttribute{
-			Description: "The date and time when the VPC was updated.",
-			Computed:    true,
-			CustomType:  customtypes.RFC3339TimeStringType{},
-		},
+var VPCAttrs = map[string]schema.Attribute{
+	"id": schema.Int64Attribute{
+		Description: "The id of the VPC.",
+		Required:    true,
 	},
+	"label": schema.StringAttribute{
+		Description: "The label of the VPC.",
+		Computed:    true,
+	},
+	"description": schema.StringAttribute{
+		Description: "The user-defined description of this VPC.",
+		Computed:    true,
+	},
+	"region": schema.StringAttribute{
+		Description: "The region of the VPC.",
+		Computed:    true,
+	},
+	"created": schema.StringAttribute{
+		Description: "The date and time when the VPC was created.",
+		Computed:    true,
+		CustomType:  customtypes.RFC3339TimeStringType{},
+	},
+	"updated": schema.StringAttribute{
+		Description: "The date and time when the VPC was updated.",
+		Computed:    true,
+		CustomType:  customtypes.RFC3339TimeStringType{},
+	},
+}
+
+var frameworkDatasourceSchema = schema.Schema{
+	Attributes: VPCAttrs,
 }

--- a/linode/vpcs/datasource_test.go
+++ b/linode/vpcs/datasource_test.go
@@ -42,7 +42,7 @@ func TestAccDataSourceVPCs_filterByLabel(t *testing.T) {
 
 	resourceName := "data.linode_vpcs.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion, err = acceptance.GetRandomRegionWithCaps([]string{"VPCs"})
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{"VPCs"})
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}

--- a/linode/vpcs/datasource_test.go
+++ b/linode/vpcs/datasource_test.go
@@ -3,6 +3,8 @@
 package vpcs_test
 
 import (
+	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -40,7 +42,10 @@ func TestAccDataSourceVPCs_filterByLabel(t *testing.T) {
 
 	resourceName := "data.linode_vpcs.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion := "us-east"
+	testRegion, err = acceptance.GetRandomRegionWithCaps([]string{"VPCs"})
+	if err != nil {
+		log.Fatal(fmt.Errorf("Error getting region: %s", err))
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },

--- a/linode/vpcs/datasource_test.go
+++ b/linode/vpcs/datasource_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package vpcs_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/vpcs/tmpl"
+)
+
+func TestAccDataSourceVPCs_basic_smoke(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_vpcs.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckResourceAttrGreaterThan(resourceName, "vpcs.#", 0),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.label"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.description"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.region"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.created"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVPCs_filterByLabel(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_vpcs.foobar"
+	vpcLabel := acctest.RandomWithPrefix("tf-test")
+	testRegion := "us-east"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataFilterLabel(t, vpcLabel, testRegion),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckResourceAttrGreaterThan(resourceName, "vpcs.#", 0),
+					acceptance.CheckResourceAttrContains(resourceName, "vpcs.0.label", "tf-test"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.region"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.created"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpcs.0.updated"),
+				),
+			},
+		},
+	})
+}

--- a/linode/vpcs/framework_datasource.go
+++ b/linode/vpcs/framework_datasource.go
@@ -1,0 +1,70 @@
+package vpcs
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{
+		BaseDataSource: helper.NewBaseDataSource(
+			helper.BaseDataSourceConfig{
+				Name:   "linode_vpcs",
+				Schema: &frameworkDataSourceSchema,
+			},
+		),
+	}
+}
+
+type DataSource struct {
+	helper.BaseDataSource
+}
+
+func (r *DataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var data VPCFilterModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, d := filterConfig.GenerateID(data.Filters)
+	if d != nil {
+		resp.Diagnostics.Append(d)
+		return
+	}
+	data.ID = id
+
+	result, d := filterConfig.GetAndFilter(
+		ctx, r.Meta.Client, data.Filters, listVPCs,
+		// There are no API filterable fields so we don't need to provide
+		// order and order_by.
+		types.StringNull(), types.StringNull())
+	if d != nil {
+		resp.Diagnostics.Append(d)
+		return
+	}
+
+	data.parseVPCs(ctx, helper.AnySliceToTyped[linodego.VPC](result))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func listVPCs(ctx context.Context, client *linodego.Client, filter string) ([]any, error) {
+	vpcs, err := client.ListVPC(ctx, &linodego.ListOptions{
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return helper.TypedSliceToAny(vpcs), nil
+}

--- a/linode/vpcs/framework_datasource.go
+++ b/linode/vpcs/framework_datasource.go
@@ -2,10 +2,10 @@ package vpcs
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/linode/linodego"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 

--- a/linode/vpcs/framework_datasource.go
+++ b/linode/vpcs/framework_datasource.go
@@ -53,7 +53,10 @@ func (r *DataSource) Read(
 		return
 	}
 
-	data.parseVPCs(ctx, helper.AnySliceToTyped[linodego.VPC](result))
+	resp.Diagnostics.Append(data.parseVPCs(ctx, helper.AnySliceToTyped[linodego.VPC](result))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/linode/vpcs/framework_models.go
+++ b/linode/vpcs/framework_models.go
@@ -1,0 +1,37 @@
+package vpcs
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper/frameworkfilter"
+	"github.com/linode/terraform-provider-linode/linode/vpc"
+)
+
+// VPCFilterModel describes the Terraform resource data model to match the
+// resource schema.
+type VPCFilterModel struct {
+	ID      types.String                     `tfsdk:"id"`
+	Filters frameworkfilter.FiltersModelType `tfsdk:"filter"`
+	Order   types.String                     `tfsdk:"order"`
+	OrderBy types.String                     `tfsdk:"order_by"`
+	VPCs    []vpc.VPCModel                   `tfsdk:"vpcs"`
+}
+
+func (model *VPCFilterModel) parseVPCs(
+	ctx context.Context,
+	vpcs []linodego.VPC,
+) {
+	vpcModels := make([]vpc.VPCModel, len(vpcs))
+
+	for i, v := range vpcs {
+		var vpc vpc.VPCModel
+
+		vpc.ParseVPC(ctx, &v)
+
+		vpcModels[i] = vpc
+	}
+
+	model.VPCs = vpcModels
+}

--- a/linode/vpcs/framework_models.go
+++ b/linode/vpcs/framework_models.go
@@ -3,6 +3,7 @@ package vpcs
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/linode/helper/frameworkfilter"
@@ -22,16 +23,21 @@ type VPCFilterModel struct {
 func (model *VPCFilterModel) parseVPCs(
 	ctx context.Context,
 	vpcs []linodego.VPC,
-) {
+) diag.Diagnostics {
 	vpcModels := make([]vpc.VPCModel, len(vpcs))
 
 	for i := range vpcs {
 		var vpc vpc.VPCModel
 
-		vpc.ParseVPC(ctx, &vpcs[i])
+		diags := vpc.ParseVPC(ctx, &vpcs[i])
+		if diags.HasError() {
+			return diags
+		}
 
 		vpcModels[i] = vpc
 	}
 
 	model.VPCs = vpcModels
+
+	return nil
 }

--- a/linode/vpcs/framework_models.go
+++ b/linode/vpcs/framework_models.go
@@ -25,10 +25,10 @@ func (model *VPCFilterModel) parseVPCs(
 ) {
 	vpcModels := make([]vpc.VPCModel, len(vpcs))
 
-	for i, v := range vpcs {
+	for i, _ := range vpcs {
 		var vpc vpc.VPCModel
 
-		vpc.ParseVPC(ctx, &v)
+		vpc.ParseVPC(ctx, &vpcs[i])
 
 		vpcModels[i] = vpc
 	}

--- a/linode/vpcs/framework_models.go
+++ b/linode/vpcs/framework_models.go
@@ -25,7 +25,7 @@ func (model *VPCFilterModel) parseVPCs(
 ) {
 	vpcModels := make([]vpc.VPCModel, len(vpcs))
 
-	for i, _ := range vpcs {
+	for i := range vpcs {
 		var vpc vpc.VPCModel
 
 		vpc.ParseVPC(ctx, &vpcs[i])

--- a/linode/vpcs/framework_schema_datasource.go
+++ b/linode/vpcs/framework_schema_datasource.go
@@ -19,8 +19,6 @@ var frameworkDataSourceSchema = schema.Schema{
 			Description: "The data source's unique ID.",
 			Computed:    true,
 		},
-		"order":    filterConfig.OrderSchema(),
-		"order_by": filterConfig.OrderBySchema(),
 	},
 	Blocks: map[string]schema.Block{
 		"filter": filterConfig.Schema(),

--- a/linode/vpcs/framework_schema_datasource.go
+++ b/linode/vpcs/framework_schema_datasource.go
@@ -1,0 +1,34 @@
+package vpcs
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/linode/terraform-provider-linode/linode/helper/frameworkfilter"
+	"github.com/linode/terraform-provider-linode/linode/vpc"
+)
+
+var filterConfig = frameworkfilter.Config{
+	"id":          {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeInt},
+	"label":       {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+	"description": {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+	"region":      {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+}
+
+var frameworkDataSourceSchema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Description: "The data source's unique ID.",
+			Computed:    true,
+		},
+		"order":    filterConfig.OrderSchema(),
+		"order_by": filterConfig.OrderBySchema(),
+	},
+	Blocks: map[string]schema.Block{
+		"filter": filterConfig.Schema(),
+		"vpcs": schema.ListNestedBlock{
+			Description: "The returned list of VPCs.",
+			NestedObject: schema.NestedBlockObject{
+				Attributes: vpc.VPCAttrs,
+			},
+		},
+	},
+}

--- a/linode/vpcs/tmpl/data_basic.gotf
+++ b/linode/vpcs/tmpl/data_basic.gotf
@@ -1,0 +1,10 @@
+{{ define "vpcs_data_basic" }}
+
+provider "linode" {
+    url = "https://api.dev.linode.com"
+    api_version = "v4beta"
+}
+
+data "linode_vpcs" "foobar" {}
+
+{{ end }}

--- a/linode/vpcs/tmpl/data_basic.gotf
+++ b/linode/vpcs/tmpl/data_basic.gotf
@@ -1,10 +1,5 @@
 {{ define "vpcs_data_basic" }}
 
-provider "linode" {
-    url = "https://api.dev.linode.com"
-    api_version = "v4beta"
-}
-
 data "linode_vpcs" "foobar" {}
 
 {{ end }}

--- a/linode/vpcs/tmpl/data_filter_label.gotf
+++ b/linode/vpcs/tmpl/data_filter_label.gotf
@@ -1,10 +1,5 @@
 {{ define "vpcs_data_filter_label" }}
 
-provider "linode" {
-    url = "https://api.dev.linode.com"
-    api_version = "v4beta"
-}
-
 resource "linode_vpc" "foo" {
     label = "{{.Label}}"
     region = "{{.Region}}"

--- a/linode/vpcs/tmpl/data_filter_label.gotf
+++ b/linode/vpcs/tmpl/data_filter_label.gotf
@@ -1,0 +1,21 @@
+{{ define "vpcs_data_filter_label" }}
+
+provider "linode" {
+    url = "https://api.dev.linode.com"
+    api_version = "v4beta"
+}
+
+resource "linode_vpc" "foo" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+}
+
+data "linode_vpcs" "foobar" {
+    filter {
+        name = "label"
+        values = ["tf-test"]
+        match_by = "substring"
+    }
+}
+
+{{ end }}

--- a/linode/vpcs/tmpl/template.go
+++ b/linode/vpcs/tmpl/template.go
@@ -1,0 +1,25 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+type TemplateData struct {
+	Label  string
+	Region string
+}
+
+func DataBasic(t *testing.T) string {
+	return acceptance.ExecuteTemplate(t,
+		"vpcs_data_basic", nil)
+}
+
+func DataFilterLabel(t *testing.T, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"vpcs_data_filter_label", TemplateData{
+			Label:  label,
+			Region: region,
+		})
+}


### PR DESCRIPTION
## 📝 Description

Add `vpcs` data source to get a list of VPCs that the user has grants to view. 

## ✔️ How to Test

To test this change in alpha, you'll need to config linode provider to use alpha url and beta version. 

`make PKG_NAME="linode/vpcs" testacc`