### PR TITLE
new: Add `vpcsubnets` data source

### DIFF
--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -55,6 +55,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/volume"
 	"github.com/linode/terraform-provider-linode/linode/vpc"
 	"github.com/linode/terraform-provider-linode/linode/vpcsubnet"
+	"github.com/linode/terraform-provider-linode/linode/vpcsubnets"
 )
 
 type FrameworkProvider struct {
@@ -206,5 +207,6 @@ func (p *FrameworkProvider) DataSources(ctx context.Context) []func() datasource
 		kernels.NewDataSource,
 		vpcsubnet.NewDataSource,
 		vpc.NewDataSource,
+		vpcsubnets.NewDataSource,
 	}
 }

--- a/linode/vpcs/framework_models.go
+++ b/linode/vpcs/framework_models.go
@@ -15,8 +15,6 @@ import (
 type VPCFilterModel struct {
 	ID      types.String                     `tfsdk:"id"`
 	Filters frameworkfilter.FiltersModelType `tfsdk:"filter"`
-	Order   types.String                     `tfsdk:"order"`
-	OrderBy types.String                     `tfsdk:"order_by"`
 	VPCs    []vpc.VPCModel                   `tfsdk:"vpcs"`
 }
 

--- a/linode/vpcsubnets/datasource_test.go
+++ b/linode/vpcsubnets/datasource_test.go
@@ -3,6 +3,8 @@
 package vpcsubnets_test
 
 import (
+	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -16,7 +18,10 @@ func TestAccDataSourceVPCSubnets_basic_smoke(t *testing.T) {
 
 	resourceName := "data.linode_vpc_subnets.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion := "us-east"
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{"VPCs"})
+	if err != nil {
+		log.Fatal(fmt.Errorf("Error getting region: %s", err))
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -42,7 +47,10 @@ func TestAccDataSourceVPCSubnets_filterByLabel(t *testing.T) {
 
 	resourceName := "data.linode_vpc_subnets.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion := "us-east"
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{"VPCs"})
+	if err != nil {
+		log.Fatal(fmt.Errorf("Error getting region: %s", err))
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },

--- a/linode/vpcsubnets/datasource_test.go
+++ b/linode/vpcsubnets/datasource_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package vpcsubnets_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/linode/vpcsubnets/tmpl"
+)
+
+func TestAccDataSourceVPCSubnets_basic_smoke(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_vpc_subnets.foobar"
+	vpcLabel := acctest.RandomWithPrefix("tf-test")
+	testRegion := "us-east"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, vpcLabel, testRegion, "10.0.0.0/24"),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckResourceAttrGreaterThan(resourceName, "vpc_subnets.#", 0),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.label"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.created"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVPCSubnets_filterByLabel(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_vpc_subnets.foobar"
+	vpcLabel := acctest.RandomWithPrefix("tf-test")
+	testRegion := "us-east"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataFilterLabel(t, vpcLabel, testRegion, "10.0.0.0/24"),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckResourceAttrGreaterThan(resourceName, "vpc_subnets.#", 0),
+					acceptance.CheckResourceAttrContains(resourceName, "vpc_subnets.0.label", "tf-test"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.created"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_subnets.0.updated"),
+				),
+			},
+		},
+	})
+}

--- a/linode/vpcsubnets/framework_datasource.go
+++ b/linode/vpcsubnets/framework_datasource.go
@@ -63,7 +63,11 @@ func (r *DataSource) Read(
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (data *VPCSubnetFilterModel) listVPCSubnets(ctx context.Context, client *linodego.Client, filter string) ([]any, error) {
+func (data *VPCSubnetFilterModel) listVPCSubnets(
+	ctx context.Context,
+	client *linodego.Client,
+	filter string,
+) ([]any, error) {
 	var diags diag.Diagnostics
 	vpcId := helper.SafeInt64ToInt(data.VPCId.ValueInt64(), &diags)
 	if diags.HasError() {

--- a/linode/vpcsubnets/framework_datasource.go
+++ b/linode/vpcsubnets/framework_datasource.go
@@ -1,0 +1,83 @@
+package vpcsubnets
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{
+		BaseDataSource: helper.NewBaseDataSource(
+			helper.BaseDataSourceConfig{
+				Name:   "linode_vpc_subnets",
+				Schema: &frameworkDataSourceSchema,
+			},
+		),
+	}
+}
+
+type DataSource struct {
+	helper.BaseDataSource
+}
+
+func (r *DataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var data VPCSubnetFilterModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, d := filterConfig.GenerateID(data.Filters)
+	if d != nil {
+		resp.Diagnostics.Append(d)
+		return
+	}
+	data.ID = id
+
+	result, d := filterConfig.GetAndFilter(
+		ctx, r.Meta.Client, data.Filters, data.listVPCSubnets,
+		// There are no API filterable fields so we don't need to provide
+		// order and order_by.
+		types.StringNull(), types.StringNull())
+	if d != nil {
+		resp.Diagnostics.Append(d)
+		return
+	}
+
+	resp.Diagnostics.Append(data.parseVPCSubnets(ctx, helper.AnySliceToTyped[linodego.VPCSubnet](result))...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (data *VPCSubnetFilterModel) listVPCSubnets(ctx context.Context, client *linodego.Client, filter string) ([]any, error) {
+	var diags diag.Diagnostics
+	vpcId := helper.SafeInt64ToInt(data.VPCId.ValueInt64(), &diags)
+	if diags.HasError() {
+		for _, err := range diags.Errors() {
+			return nil, errors.New(err.Detail())
+		}
+	}
+
+	vpcs, err := client.ListVPCSubnet(ctx, vpcId, &linodego.ListOptions{
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return helper.TypedSliceToAny(vpcs), nil
+}

--- a/linode/vpcsubnets/framework_models.go
+++ b/linode/vpcsubnets/framework_models.go
@@ -17,8 +17,6 @@ type VPCSubnetFilterModel struct {
 	ID         types.String                     `tfsdk:"id"`
 	VPCId      types.Int64                      `tfsdk:"vpc_id"`
 	Filters    frameworkfilter.FiltersModelType `tfsdk:"filter"`
-	Order      types.String                     `tfsdk:"order"`
-	OrderBy    types.String                     `tfsdk:"order_by"`
 	VPCSubnets []VPCSubnetModel                 `tfsdk:"vpc_subnets"`
 }
 

--- a/linode/vpcsubnets/framework_models.go
+++ b/linode/vpcsubnets/framework_models.go
@@ -1,0 +1,73 @@
+package vpcsubnets
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+	"github.com/linode/terraform-provider-linode/linode/helper/customtypes"
+	"github.com/linode/terraform-provider-linode/linode/helper/frameworkfilter"
+)
+
+// VPCSubnetFilterModel describes the Terraform resource data model to match the
+// resource schema.
+type VPCSubnetFilterModel struct {
+	ID         types.String                     `tfsdk:"id"`
+	VPCId      types.Int64                      `tfsdk:"vpc_id"`
+	Filters    frameworkfilter.FiltersModelType `tfsdk:"filter"`
+	Order      types.String                     `tfsdk:"order"`
+	OrderBy    types.String                     `tfsdk:"order_by"`
+	VPCSubnets []VPCSubnetModel                 `tfsdk:"vpc_subnets"`
+}
+
+type VPCSubnetModel struct {
+	ID      types.Int64                        `tfsdk:"id"`
+	Label   types.String                       `tfsdk:"label"`
+	IPv4    types.String                       `tfsdk:"ipv4"`
+	Linodes types.List                         `tfsdk:"linodes"`
+	Created customtypes.RFC3339TimeStringValue `tfsdk:"created"`
+	Updated customtypes.RFC3339TimeStringValue `tfsdk:"updated"`
+}
+
+func (model *VPCSubnetFilterModel) parseVPCSubnets(
+	ctx context.Context,
+	subnets []linodego.VPCSubnet,
+) diag.Diagnostics {
+	parseSubnet := func(subnet linodego.VPCSubnet) (VPCSubnetModel, diag.Diagnostics) {
+		var s VPCSubnetModel
+		s.ID = types.Int64Value(int64(subnet.ID))
+		s.Label = types.StringValue(subnet.Label)
+		s.IPv4 = types.StringValue(subnet.IPv4)
+
+		linodes, diags := types.ListValueFrom(ctx, types.Int64Type, subnet.Linodes)
+		if diags.HasError() {
+			return s, diags
+		}
+		s.Linodes = linodes
+
+		s.Created = customtypes.RFC3339TimeStringValue{
+			StringValue: helper.NullableTimeToFramework(subnet.Created),
+		}
+		s.Updated = customtypes.RFC3339TimeStringValue{
+			StringValue: helper.NullableTimeToFramework(subnet.Updated),
+		}
+
+		return s, nil
+	}
+
+	result := make([]VPCSubnetModel, len(subnets))
+
+	for i, s := range subnets {
+		subnet, diags := parseSubnet(s)
+		if diags.HasError() {
+			return diags
+		}
+		result[i] = subnet
+	}
+
+	model.VPCSubnets = result
+
+	return nil
+}

--- a/linode/vpcsubnets/framework_schema_datasource.go
+++ b/linode/vpcsubnets/framework_schema_datasource.go
@@ -23,8 +23,6 @@ var frameworkDataSourceSchema = schema.Schema{
 			Description: "The data source's unique ID.",
 			Computed:    true,
 		},
-		"order":    filterConfig.OrderSchema(),
-		"order_by": filterConfig.OrderBySchema(),
 	},
 	Blocks: map[string]schema.Block{
 		"filter": filterConfig.Schema(),

--- a/linode/vpcsubnets/framework_schema_datasource.go
+++ b/linode/vpcsubnets/framework_schema_datasource.go
@@ -15,13 +15,13 @@ var filterConfig = frameworkfilter.Config{
 
 var frameworkDataSourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
+		"vpc_id": schema.Int64Attribute{
+			Description: "The id of the parent VPC for the list of VPC subnets",
+			Required:    true,
+		},
 		"id": schema.StringAttribute{
 			Description: "The data source's unique ID.",
 			Computed:    true,
-		},
-		"vpc_id": schema.Int64Attribute{
-			Description: "The id of the parent VPC for this VPC Subnet",
-			Required:    true,
 		},
 		"order":    filterConfig.OrderSchema(),
 		"order_by": filterConfig.OrderBySchema(),

--- a/linode/vpcsubnets/framework_schema_datasource.go
+++ b/linode/vpcsubnets/framework_schema_datasource.go
@@ -1,0 +1,66 @@
+package vpcsubnets
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/terraform-provider-linode/linode/helper/customtypes"
+	"github.com/linode/terraform-provider-linode/linode/helper/frameworkfilter"
+)
+
+var filterConfig = frameworkfilter.Config{
+	"id":    {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeInt},
+	"label": {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+	"ipv4":  {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+}
+
+var frameworkDataSourceSchema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Description: "The data source's unique ID.",
+			Computed:    true,
+		},
+		"vpc_id": schema.Int64Attribute{
+			Description: "The id of the parent VPC for this VPC Subnet",
+			Required:    true,
+		},
+		"order":    filterConfig.OrderSchema(),
+		"order_by": filterConfig.OrderBySchema(),
+	},
+	Blocks: map[string]schema.Block{
+		"filter": filterConfig.Schema(),
+		"vpc_subnets": schema.ListNestedBlock{
+			Description: "The returned list of subnets under a VPC.",
+			NestedObject: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.Int64Attribute{
+						Description: "The id of the VPC Subnet.",
+						Computed:    true,
+					},
+					"label": schema.StringAttribute{
+						Description: "The label of the VPC Subnet.",
+						Computed:    true,
+					},
+					"ipv4": schema.StringAttribute{
+						Description: "The IPv4 range of this subnet in CIDR format.",
+						Computed:    true,
+					},
+					"linodes": schema.ListAttribute{
+						ElementType: types.Int64Type,
+						Description: "A list of Linode IDs that added to this subnet.",
+						Computed:    true,
+					},
+					"created": schema.StringAttribute{
+						Description: "The date and time when the VPC Subnet was created.",
+						Computed:    true,
+						CustomType:  customtypes.RFC3339TimeStringType{},
+					},
+					"updated": schema.StringAttribute{
+						Description: "The date and time when the VPC Subnet was updated.",
+						Computed:    true,
+						CustomType:  customtypes.RFC3339TimeStringType{},
+					},
+				},
+			},
+		},
+	},
+}

--- a/linode/vpcsubnets/tmpl/data_basic.gotf
+++ b/linode/vpcsubnets/tmpl/data_basic.gotf
@@ -1,0 +1,19 @@
+{{ define "vpc_subnets_data_basic" }}
+
+resource "linode_vpc" "foobar" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+    description = "some description"
+}
+
+resource "linode_vpc_subnet" "foobar" {
+    vpc_id = linode_vpc.foobar.id
+    label = "{{.Label}}-subnet-label"
+    ipv4 = "{{.IPv4}}"
+}
+
+data "linode_vpc_subnets" "foobar" {
+    vpc_id = linode_vpc_subnet.foobar.vpc_id
+}
+
+{{ end}}

--- a/linode/vpcsubnets/tmpl/data_filter_label.gotf
+++ b/linode/vpcsubnets/tmpl/data_filter_label.gotf
@@ -1,0 +1,24 @@
+{{ define "vpc_subnets_data_filter_label" }}
+
+resource "linode_vpc" "foobar" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+    description = "some description"
+}
+
+resource "linode_vpc_subnet" "foobar" {
+    vpc_id = linode_vpc.foobar.id
+    label = "{{.Label}}-subnet-label"
+    ipv4 = "{{.IPv4}}"
+}
+
+data "linode_vpc_subnets" "foobar" {
+    vpc_id = linode_vpc_subnet.foobar.vpc_id
+    filter {
+        name = "label"
+        values = ["tf-test"]
+        match_by = "substring"
+    }
+}
+
+{{ end }}

--- a/linode/vpcsubnets/tmpl/template.go
+++ b/linode/vpcsubnets/tmpl/template.go
@@ -1,0 +1,31 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/acceptance"
+)
+
+type TemplateData struct {
+	Label  string
+	Region string
+	IPv4   string
+}
+
+func DataBasic(t *testing.T, label, region, ipv4 string) string {
+	return acceptance.ExecuteTemplate(t,
+		"vpc_subnets_data_basic", TemplateData{
+			Label:  label,
+			Region: region,
+			IPv4:   ipv4,
+		})
+}
+
+func DataFilterLabel(t *testing.T, label, region, ipv4 string) string {
+	return acceptance.ExecuteTemplate(t,
+		"vpc_subnets_data_filter_label", TemplateData{
+			Label:  label,
+			Region: region,
+			IPv4:   ipv4,
+		})
+}


### PR DESCRIPTION
## 📝 Description

Add `vpcsubnets` data source to list subnets under a VPC.

## ✔️ How to Test

To test again Alpha, you'll need to set linode url to dev and use alpha available region in the test case.

`make PKG_NAME="linode/vpcsubnets" testacc 
`