### PR TITLE
new: Reimplement `wait_for_available` in migrated linode_rdns resource

### DIFF
--- a/linode/rdns/framework_helper.go
+++ b/linode/rdns/framework_helper.go
@@ -1,0 +1,57 @@
+package rdns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/linode/linodego"
+)
+
+// updateIPAddress wraps the client.UpdateIPAddress(...) retry logic depending on the 'wait_for_available' field.
+func updateIPAddress(
+	ctx context.Context,
+	client *linodego.Client,
+	address string,
+	desiredRDNS *string,
+	waitForAvailable bool,
+) (*linodego.InstanceIP, error) {
+	updateOpts := linodego.IPAddressUpdateOptions{
+		RDNS: desiredRDNS,
+	}
+
+	if waitForAvailable {
+		return updateIPAddressWithRetries(ctx, client, address, updateOpts, time.Second*5)
+	}
+
+	return client.UpdateIPAddress(ctx, address, updateOpts)
+}
+
+func updateIPAddressWithRetries(ctx context.Context, client *linodego.Client, address string,
+	updateOpts linodego.IPAddressUpdateOptions, retryDuration time.Duration,
+) (*linodego.InstanceIP, error) {
+	ticker := time.NewTicker(retryDuration)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			result, err := client.UpdateIPAddress(ctx, address, updateOpts)
+			if err != nil {
+				if lerr, ok := err.(*linodego.Error); ok && lerr.Code != 400 &&
+					!strings.Contains(lerr.Error(), "unable to perform a lookup") {
+					return nil, fmt.Errorf("failed to update ip address: %s", err)
+				}
+
+				continue
+			}
+
+			return result, nil
+
+		case <-ctx.Done():
+			// The timeout for this context will implicitly be handled by Terraform
+			return nil, fmt.Errorf("failed to update ip address: %s", ctx.Err())
+		}
+	}
+}

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -63,11 +63,13 @@ func (r *Resource) Create(
 		)
 	}
 
-	updateOpts := linodego.IPAddressUpdateOptions{
-		RDNS: plan.RDNS.ValueStringPointer(),
-	}
-
-	ip, err = client.UpdateIPAddress(ctx, plan.Address.ValueString(), updateOpts)
+	ip, err = updateIPAddress(
+		ctx,
+		client,
+		plan.Address.ValueString(),
+		plan.RDNS.ValueStringPointer(),
+		plan.WaitForAvailable.ValueBool(),
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create Linode RDNS",
@@ -143,7 +145,13 @@ func (r *Resource) Update(
 	}
 
 	if resourceUpdated {
-		ip, err := client.UpdateIPAddress(ctx, plan.Address.ValueString(), updateOpts)
+		ip, err := updateIPAddress(
+			ctx,
+			client,
+			plan.Address.ValueString(),
+			plan.RDNS.ValueStringPointer(),
+			plan.WaitForAvailable.ValueBool(),
+		)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Failed to update the Linode RDNS",


### PR DESCRIPTION
## 📝 Description

This change reimplements the `wait_for_available` logic in the `linode_rdns` resource.

## ✔️ How to Test

```
make PKG_NAME=linode/rdns testacc
```
