### PR TITLE
doc: Improve documentation for early access resources; display warning on API version mismatch

### DIFF
--- a/linode/helper/earlyaccess.go
+++ b/linode/helper/earlyaccess.go
@@ -1,0 +1,41 @@
+package helper
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// AttemptWarnEarlyAccessSDKv2 will raise a warning if an SDKv2
+// early access resource is being used without the v4beta API version.
+func AttemptWarnEarlyAccessSDKv2(providerMeta *ProviderMeta) {
+	if providerMeta.Config.APIVersion == "v4beta" {
+		return
+	}
+
+	log.Printf(
+		"[WARN] This resource is in early access but the provider "+
+			"API version is set to \"%s\" (expected \"v4beta\").",
+		providerMeta.Config.APIVersion,
+	)
+}
+
+// AttemptWarnEarlyAccessFramework will raise a warning if a Framework
+// early access resource is being used without the v4beta API version.
+func AttemptWarnEarlyAccessFramework(config *FrameworkProviderModel) diag.Diagnostics {
+	var d diag.Diagnostics
+
+	if config.APIVersion.ValueString() != "v4beta" {
+		d.AddWarning(
+			"Non-Beta Target API Version",
+			fmt.Sprintf(
+				"This resource is in early access but the provider "+
+					"API version is set to \"%s\" (expected \"v4beta\").",
+				config.APIVersion.ValueString(),
+			),
+		)
+	}
+
+	return d
+}

--- a/linode/helper/earlyaccess_test.go
+++ b/linode/helper/earlyaccess_test.go
@@ -1,0 +1,70 @@
+//go:build unit
+
+package helper_test
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func TestAttemptWarnEarlyAccessSDKv2(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	helper.AttemptWarnEarlyAccessSDKv2(&helper.ProviderMeta{
+		Config: &helper.Config{
+			APIVersion: "v4",
+		},
+	})
+
+	if !strings.Contains(buf.String(), "[WARN] This resource is in early access but the provider "+
+		"API version is set to \"v4\" (expected \"v4beta\").") {
+		t.Fatalf("expected warning")
+	}
+
+	buf.Reset()
+
+	helper.AttemptWarnEarlyAccessSDKv2(&helper.ProviderMeta{
+		Config: &helper.Config{
+			APIVersion: "v4beta",
+		},
+	})
+
+	if buf.Len() != 0 {
+		t.Fatal("expected none, got warning")
+	}
+}
+
+func TestAttemptWarnEarlyAccessFramework(t *testing.T) {
+	d := helper.AttemptWarnEarlyAccessFramework(&helper.FrameworkProviderModel{
+		APIVersion: types.StringValue("v4"),
+	})
+
+	if d.WarningsCount() < 1 {
+		t.Fatal("expected warning, got none")
+	}
+
+	warnings := d.Warnings()
+
+	if warnings[0].Summary() != "Non-Beta Target API Version" {
+		t.Fatal("Invalid warning summary")
+	}
+
+	if warnings[0].Detail() != "This resource is in early access but the provider "+
+		"API version is set to \"v4\" (expected \"v4beta\")." {
+		t.Fatal("Invalid warning detail")
+	}
+
+	d = helper.AttemptWarnEarlyAccessFramework(&helper.FrameworkProviderModel{
+		APIVersion: types.StringValue("v4beta"),
+	})
+
+	if d.WarningsCount() > 0 {
+		t.Fatalf("expected no warnings, got %d", d.WarningsCount())
+	}
+}

--- a/linode/helper/framework_datasource_base.go
+++ b/linode/helper/framework_datasource_base.go
@@ -20,7 +20,8 @@ type BaseDataSourceConfig struct {
 	Name string
 
 	// Optional
-	Schema *schema.Schema
+	Schema        *schema.Schema
+	IsEarlyAccess bool
 }
 
 // BaseDataSource contains various re-usable fields and methods
@@ -43,6 +44,12 @@ func (r *BaseDataSource) Configure(
 	r.Meta = GetDataSourceMeta(req, resp)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if r.Config.IsEarlyAccess {
+		resp.Diagnostics.Append(
+			AttemptWarnEarlyAccessFramework(r.Meta.Config)...,
+		)
 	}
 }
 

--- a/linode/helper/framework_resource_base.go
+++ b/linode/helper/framework_resource_base.go
@@ -27,7 +27,8 @@ type BaseResourceConfig struct {
 	IDType attr.Type
 
 	// Optional
-	Schema *schema.Schema
+	Schema        *schema.Schema
+	IsEarlyAccess bool
 }
 
 // BaseResource contains various re-usable fields and methods
@@ -50,6 +51,12 @@ func (r *BaseResource) Configure(
 	r.Meta = GetResourceMeta(req, resp)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if r.Config.IsEarlyAccess {
+		resp.Diagnostics.Append(
+			AttemptWarnEarlyAccessFramework(r.Meta.Config)...,
+		)
 	}
 }
 

--- a/linode/instancesharedips/resource.go
+++ b/linode/instancesharedips/resource.go
@@ -22,6 +22,8 @@ func Resource() *schema.Resource {
 }
 
 func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	helper.AttemptWarnEarlyAccessSDKv2(meta.(*helper.ProviderMeta))
+
 	client := meta.(*helper.ProviderMeta).Client
 
 	linodeID := d.Get("linode_id").(int)

--- a/linode/vlan/framework_datasource.go
+++ b/linode/vlan/framework_datasource.go
@@ -16,8 +16,9 @@ func NewDataSource() datasource.DataSource {
 	return &DataSource{
 		BaseDataSource: helper.NewBaseDataSource(
 			helper.BaseDataSourceConfig{
-				Name:   "linode_vlans",
-				Schema: &frameworkDatasourceSchema,
+				Name:          "linode_vlans",
+				Schema:        &frameworkDatasourceSchema,
+				IsEarlyAccess: true,
 			},
 		),
 	}

--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ lint: fmtcheck
 	golangci-lint run --timeout 15m0s
 	tfproviderlint \
 		-AT001=false \
+		-AT004=false \
 		-S006=false \
 		-R018=false \
 		-R019=false \

--- a/website/docs/d/vlans.html.markdown
+++ b/website/docs/d/vlans.html.markdown
@@ -8,6 +8,10 @@ description: |-
 
 # Data Source: linode\_vlans
 
+~> **Beta Notice** IPv6 sharing is currently available through early access.
+To use early access resources, the `api_version` provider argument must be set to `v4beta`.
+To learn more, see the [early access documentation](../..#early-access).
+
 Provides details about Linode VLANs.
 
 ## Example Usage

--- a/website/docs/d/vlans.html.markdown
+++ b/website/docs/d/vlans.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: linode\_vlans
 
-~> **Beta Notice** IPv6 sharing is currently available through early access.
+~> **Beta Notice** VLANs are currently available through early access.
 To use early access resources, the `api_version` provider argument must be set to `v4beta`.
 To learn more, see the [early access documentation](../..#early-access).
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -86,6 +86,22 @@ The following keys can be used to configure the provider.
 
 * `max_retry_delay_ms` - (Optional) Maximum delay in milliseconds before retrying a request.
 
+## Early Access
+
+Some resources are made available before the feature reaches general availability. These resources are subject to change, and may not be available to all customers in all regions. Early access features can be accessed by configuring the provider to use a different version of the API.
+
+### Configuring the Target API Version
+
+The `api_version` can be set on the provider block like so:
+
+```terraform
+provider "linode" {
+  api_version = "v4beta"
+}
+```
+
+Additionally, the version can be set with the `LINODE_API_VERSION` environment variable.
+
 ## Linode Guides
 
 Several [Linode Guides & Tutorials](https://www.linode.com/docs/) are available that explore Terraform usage with Linode resources:

--- a/website/docs/r/instance_shared_ips.html.markdown
+++ b/website/docs/r/instance_shared_ips.html.markdown
@@ -8,9 +8,11 @@ description: |-
 
 # linode\_instance\_shared\_ips
 
-~> **NOTICE:** This resource should only be defined once per-instance and should not be used alongside the `shared_ipv4` field in `linode_instance`.
+~> **Beta Notice** IPv6 sharing is currently available through early access. 
+To use early access resources, the `api_version` provider argument must be set to `v4beta`.
+To learn more, see the [early access documentation](../..#early-access).
 
-~> **NOTICE:** IPv6 sharing is currently available through early access. To learn more, see the [early access documentation](https://github.com/linode/terraform-provider-linode/tree/main/EARLY_ACCESS.md).
+~> **Notice** This resource should only be defined once per-instance and should not be used alongside the `shared_ipv4` field in `linode_instance`.
 
 Manages IPs shared to a Linode instance.
 

--- a/website/docs/r/instance_shared_ips.html.markdown
+++ b/website/docs/r/instance_shared_ips.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # linode\_instance\_shared\_ips
 
-~> **Beta Notice** IPv6 sharing is currently available through early access. 
+~> **Beta Notice** IPv6 sharing is currently available through early access.
 To use early access resources, the `api_version` provider argument must be set to `v4beta`.
 To learn more, see the [early access documentation](../..#early-access).
 


### PR DESCRIPTION
## 📝 Description

This change improves the documentation for early access resources endpoints. Additionally, this PR adds warnings that will show when the API version is not `v4beta` for an early access resource.

## ✔️ How to Test

```
make unittest
```
