### PR TITLE
fix: Correct duration for `EventPollMilliseconds` in SDKv2 client

### DIFF
--- a/linode/domainzonefile/framework_datasource.go
+++ b/linode/domainzonefile/framework_datasource.go
@@ -67,7 +67,7 @@ func (d *DataSource) Read(
 		return
 	}
 
-	retry := time.Duration(d.Meta.Config.EventPollMilliseconds.ValueInt64())
+	retry := time.Duration(d.Meta.Config.EventPollMilliseconds.ValueInt64()) * time.Millisecond
 
 	zf, diags := getZoneFileRetry(ctx, client, int(data.DomainID.ValueInt64()), retry)
 	if diags.HasError() {

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -89,7 +89,7 @@ func (c *Config) Client() (*linodego.Client, error) {
 	client.UseCache(!c.DisableInternalCache)
 
 	if c.EventPollMilliseconds != 0 {
-		client.SetPollDelay(time.Duration(c.EventPollMilliseconds))
+		client.SetPollDelay(time.Duration(c.EventPollMilliseconds) * time.Millisecond)
 	}
 	if c.MinRetryDelayMilliseconds != 0 {
 		client.SetRetryWaitTime(time.Duration(c.MinRetryDelayMilliseconds) * time.Millisecond)


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused clients created by the SDKv2 provider to use an inaccurate polling interval.