### PR TITLE
new: Add validators for CIDR ranges in the `linode_firewall` resource

### DIFF
--- a/linode/firewall/schema_resource.go
+++ b/linode/firewall/schema_resource.go
@@ -3,8 +3,6 @@ package firewall
 import (
 	"strings"
 
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/linode/terraform-provider-linode/linode/helper"
@@ -38,23 +36,17 @@ var resourceRuleSchema = map[string]*schema.Schema{
 	"ipv4": {
 		Type: schema.TypeList,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:             schema.TypeString,
+			ValidateDiagFunc: helper.SDKv2ValidateIPv4Range,
 		},
-		Description: "A list of IP addresses, CIDR blocks, or 0.0.0.0/0 (to allow all) this rule applies to.",
+		Description: "A list of CIDR blocks or 0.0.0.0/0 (to allow all) this rule applies to.",
 		Optional:    true,
 	},
 	"ipv6": {
 		Type: schema.TypeList,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
-			ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-				err := helper.ValidateIPv6Range(i.(string))
-				if err != nil {
-					return diag.FromErr(err)
-				}
-
-				return nil
-			},
+			Type:             schema.TypeString,
+			ValidateDiagFunc: helper.SDKv2ValidateIPv6Range,
 			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 				// We handle validation separately
 				result, _ := helper.CompareIPv6Ranges(oldValue, newValue)

--- a/linode/helper/normalize.go
+++ b/linode/helper/normalize.go
@@ -17,8 +17,3 @@ func CompareIPv6Ranges(i, v string) (bool, error) {
 
 	return ipi.Equal(ipv) && ipneti.Mask.String() == ipnetv.Mask.String(), nil
 }
-
-func ValidateIPv6Range(i string) error {
-	_, _, err := net.ParseCIDR(i)
-	return err
-}

--- a/linode/helper/sdkv2_validators.go
+++ b/linode/helper/sdkv2_validators.go
@@ -1,0 +1,34 @@
+package helper
+
+import (
+	"net"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func SDKv2ValidateIPv4Range(i any, path cty.Path) diag.Diagnostics {
+	ip, _, err := net.ParseCIDR(i.(string))
+	if err != nil {
+		return diag.Errorf("Invalid IPv4 CIDR range: %s", i)
+	}
+
+	if ip.To4() == nil {
+		return diag.Errorf("Expected IPv4 address, got IPv6")
+	}
+
+	return nil
+}
+
+func SDKv2ValidateIPv6Range(i any, path cty.Path) diag.Diagnostics {
+	ip, _, err := net.ParseCIDR(i.(string))
+	if err != nil {
+		return diag.Errorf("Invalid IPv6 CIDR range: %s", i)
+	}
+
+	if ip.To4() != nil {
+		return diag.Errorf("Expected IPv6 address, got IPv4")
+	}
+
+	return nil
+}

--- a/linode/helper/sdkv2_validators_test.go
+++ b/linode/helper/sdkv2_validators_test.go
@@ -1,0 +1,60 @@
+//go:build unit
+
+package helper_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/linode/helper"
+)
+
+func TestSDKv2ValidateIPv4Range(t *testing.T) {
+	d := helper.SDKv2ValidateIPv4Range("192.168.0.1", nil)
+	if d == nil || !d.HasError() {
+		t.Fatal("Expected error, got none")
+	}
+
+	if !strings.Contains(d[0].Summary, "Invalid IPv4 CIDR range: 192.168.0.1") {
+		t.Fatalf("Error does not match expected error: %s", d[0].Summary)
+	}
+
+	d = helper.SDKv2ValidateIPv4Range("::0/0", nil)
+	if d == nil || !d.HasError() {
+		t.Fatal("Expected error, got none")
+	}
+
+	if !strings.Contains(d[0].Summary, "Expected IPv4 address, got IPv6") {
+		t.Fatal("Error does not match expected error")
+	}
+
+	d = helper.SDKv2ValidateIPv4Range("192.168.0.0/24", nil)
+	if d != nil && d.HasError() {
+		t.Fatal("Expected none, got error")
+	}
+}
+
+func TestSDKv2ValidateIPv6Range(t *testing.T) {
+	d := helper.SDKv2ValidateIPv6Range("::0", nil)
+	if d == nil || !d.HasError() {
+		t.Fatal("Expected error, got none")
+	}
+
+	if !strings.Contains(d[0].Summary, "Invalid IPv6 CIDR range: ::0") {
+		t.Fatalf("Error does not match expected error: %s", d[0].Summary)
+	}
+
+	d = helper.SDKv2ValidateIPv6Range("192.168.0.1/24", nil)
+	if d == nil || !d.HasError() {
+		t.Fatal("Expected error, got none")
+	}
+
+	if !strings.Contains(d[0].Summary, "Expected IPv6 address, got IPv4") {
+		t.Fatal("Error does not match expected error")
+	}
+
+	d = helper.SDKv2ValidateIPv6Range("::0/0", nil)
+	if d != nil && d.HasError() {
+		t.Fatal("Expected none, got error")
+	}
+}

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -107,9 +107,9 @@ The following arguments are supported in the inbound and outbound rule blocks:
 
 * `ports` - (Optional) A string representation of ports and/or port ranges (i.e. "443" or "80-90, 91").
   
-* `ipv4` - (Optional) A list of IPv4 addresses or networks. Must be in IP/mask format.
+* `ipv4` - (Optional) A list of IPv4 addresses or networks. Must be in IP/mask (CIDR) format.
 
-* `ipv6` - (Optional) A list of IPv6 addresses or networks. Must be in IP/mask format.
+* `ipv6` - (Optional) A list of IPv6 addresses or networks. Must be in IP/mask (CIDR) format.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## 📝 Description

This change adds plan-time validators for IPv4 and IPv6 ranges in the `linode_firewall` resource.

Relates to #1003 

## ✔️ How to Test

```
make unittest
```
