### PR TITLE
Support adding firewall to the linode during creation

### DIFF
--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -178,6 +178,10 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 		}
 	}
 
+	if firewallID, ok := d.GetOk("firewall_id"); ok {
+		createOpts.FirewallID = firewallID.(int)
+	}
+
 	if interfaces, interfacesOk := d.GetOk("interface"); interfacesOk {
 		interfaces := interfaces.([]interface{})
 

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -283,6 +283,13 @@ var resourceSchema = map[string]*schema.Schema{
 		Default:  nil,
 		Computed: true,
 	},
+	"firewall_id": {
+		Type: schema.TypeInt,
+		Description: "The ID of the firewall applied to the Linode " +
+			"instance during creation.",
+		Optional: true,
+		ForceNew: true,
+	},
 	"shared_ipv4": {
 		Type:        schema.TypeSet,
 		Description: "A set of IPv4 addresses to share with this Linode.",

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -591,3 +591,12 @@ func DataClientFilter(t *testing.T, label, tag, region string) string {
 			Region: region,
 		})
 }
+
+func FirewallOnCreation(t *testing.T, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_firewall_on_creation", TemplateData{
+			Label:  label,
+			Image:  acceptance.TestImageLatest,
+			Region: region,
+		})
+}

--- a/linode/instance/tmpl/templates/firewall_on_creation.gotf
+++ b/linode/instance/tmpl/templates/firewall_on_creation.gotf
@@ -1,0 +1,19 @@
+{{ define "instance_firewall_on_creation" }}
+
+resource "linode_firewall" "foobar" {
+  label = "{{.Label}}_fw"
+  inbound_policy = "DROP"
+  outbound_policy = "ACCEPT"
+}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "g6-nanode-1"
+    image = "{{.Image}}"
+    region = "{{ .Region }}"
+    root_pass = "myr00tp@ssw0rd!!!"
+    firewall_id = linode_firewall.foobar.id
+}
+
+{{ end }}


### PR DESCRIPTION
## 📝 Description

This PR is for supporting applying a cloud firewall to a linode instance during creation.

## ✔️ How to Test
1. Remove this line in `linode/helper/config.go`
```go
client.SetBaseURL(DefaultLinodeURL)
```

2. Setup alpha environmental variables.
3. Make `GetRandomRegionWithCaps` only return `"us-east"`
4. Remove unrelated test cases in the `resource_test.go` file and delete `datasource_test.go` in the `linode/instance` directory.
5. `make testacc PKG_NAME=linode/instanceconfig`