### PR TITLE
Fix `TestAccDataSourceVolume_basic`

### DIFF
--- a/linode/volumes/tmpl/basic.gotf
+++ b/linode/volumes/tmpl/basic.gotf
@@ -1,9 +1,0 @@
-{{ define "volume_basic" }}
-
-resource "linode_volume" "foobar" {
-    label = "{{.Label}}"
-    region = "{{ .Region }}"
-    tags = ["tf_test"]
-}
-
-{{ end }}

--- a/linode/volumes/tmpl/data_basic.gotf
+++ b/linode/volumes/tmpl/data_basic.gotf
@@ -1,4 +1,4 @@
-{{ define "volume_data_basic" }}
+{{ define "volumes_data_basic" }}
 
 {{ template "volume_basic" . }}
 

--- a/linode/volumes/tmpl/template.go
+++ b/linode/volumes/tmpl/template.go
@@ -13,5 +13,5 @@ type TemplateData struct {
 
 func DataBasic(t *testing.T, volume, region string) string {
 	return acceptance.ExecuteTemplate(t,
-		"volume_data_basic", TemplateData{Label: volume, Region: region})
+		"volumes_data_basic", TemplateData{Label: volume, Region: region})
 }


### PR DESCRIPTION
## 📝 Description

Fixed `TestAccDataSourceVolume_basic`.

It was caused by duplicated naming of test config templates for `volume` and `volumes` tests.