### PR TITLE
Update go version requirenment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This provider plugin is maintained by Linode.
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.0+
-- [Go](https://golang.org/doc/install) 1.11.0 or higher (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.20.0 or higher (to build the provider plugin)
 
 ## Using the provider
 


### PR DESCRIPTION
We are now requiring go v1.20+ to build the provider