### PR TITLE
Fix NodeBalancer related data sources

### DIFF
--- a/linode/nb/framework_datasource.go
+++ b/linode/nb/framework_datasource.go
@@ -28,7 +28,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	var data NodebalancerModel
+	var data NodeBalancerDataSourceModel
 	client := d.Meta.Client
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -44,8 +44,7 @@ func (d *DataSource) Read(
 		)
 	}
 
-	resp.Diagnostics.Append(data.ParseComputedAttrs(ctx, nodebalancer)...)
-	resp.Diagnostics.Append(data.ParseNonComputedAttrs(ctx, nodebalancer)...)
+	resp.Diagnostics.Append(data.FlattenNodeBalancer(ctx, nodebalancer)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/nb/framework_models.go
+++ b/linode/nb/framework_models.go
@@ -14,9 +14,9 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/helper/customtypes"
 )
 
-// NodebalancerModel describes the Terraform resource data model to match the
+// NodeBalancerModel describes the Terraform resource data model to match the
 // resource schema.
-type NodebalancerModel struct {
+type NodeBalancerModel struct {
 	ID                 types.Int64                        `tfsdk:"id"`
 	Label              types.String                       `tfsdk:"label"`
 	Region             types.String                       `tfsdk:"region"`
@@ -45,7 +45,7 @@ type nbModelV0 struct {
 	Transfer           types.Map    `tfsdk:"transfer"`
 }
 
-func (data *NodebalancerModel) ParseNonComputedAttrs(
+func (data *NodeBalancerModel) ParseNonComputedAttrs(
 	ctx context.Context,
 	nodebalancer *linodego.NodeBalancer,
 ) diag.Diagnostics {
@@ -61,7 +61,7 @@ func (data *NodebalancerModel) ParseNonComputedAttrs(
 	return nil
 }
 
-func (data *NodebalancerModel) ParseComputedAttrs(
+func (data *NodeBalancerModel) ParseComputedAttrs(
 	ctx context.Context,
 	nodebalancer *linodego.NodeBalancer,
 ) diag.Diagnostics {
@@ -124,4 +124,57 @@ func UpgradeResourceStateValue(val string) (basetypes.Float64Value, diag.Diagnos
 		)
 	}
 	return types.Float64Value(result), nil
+}
+
+type NodeBalancerDataSourceModel struct {
+	ID                 types.Int64                        `tfsdk:"id"`
+	Label              types.String                       `tfsdk:"label"`
+	Region             types.String                       `tfsdk:"region"`
+	ClientConnThrottle types.Int64                        `tfsdk:"client_conn_throttle"`
+	Hostname           types.String                       `tfsdk:"hostname"`
+	Ipv4               types.String                       `tfsdk:"ipv4"`
+	Ipv6               types.String                       `tfsdk:"ipv6"`
+	Created            customtypes.RFC3339TimeStringValue `tfsdk:"created"`
+	Updated            customtypes.RFC3339TimeStringValue `tfsdk:"updated"`
+	Transfer           types.List                         `tfsdk:"transfer"`
+	Tags               types.Set                          `tfsdk:"tags"`
+}
+
+func (data *NodeBalancerDataSourceModel) FlattenNodeBalancer(
+	ctx context.Context,
+	nodebalancer *linodego.NodeBalancer,
+) diag.Diagnostics {
+	data.ID = types.Int64Value(int64(nodebalancer.ID))
+	data.Label = types.StringPointerValue(nodebalancer.Label)
+	data.ID = types.Int64Value(int64(nodebalancer.ID))
+	data.Region = types.StringValue(nodebalancer.Region)
+	data.ClientConnThrottle = types.Int64Value(int64(nodebalancer.ClientConnThrottle))
+	data.Hostname = types.StringPointerValue(nodebalancer.Hostname)
+	data.Ipv4 = types.StringPointerValue(nodebalancer.IPv4)
+	data.Ipv6 = types.StringPointerValue(nodebalancer.IPv6)
+
+	data.Created = customtypes.RFC3339TimeStringValue{
+		StringValue: helper.NullableTimeToFramework(nodebalancer.Created),
+	}
+	data.Updated = customtypes.RFC3339TimeStringValue{
+		StringValue: helper.NullableTimeToFramework(nodebalancer.Updated),
+	}
+
+	transfer, diags := parseTransfer(ctx, nodebalancer.Transfer)
+	if diags.HasError() {
+		return diags
+	}
+	data.Transfer = *transfer
+
+	tags, diags := types.SetValueFrom(
+		ctx,
+		types.StringType,
+		helper.StringSliceToFramework(nodebalancer.Tags),
+	)
+	if diags.HasError() {
+		return diags
+	}
+	data.Tags = tags
+
+	return nil
 }

--- a/linode/nb/framework_models_unit_test.go
+++ b/linode/nb/framework_models_unit_test.go
@@ -22,7 +22,7 @@ func TestParseNonComputedAttrs(t *testing.T) {
 		Tags:  []string{"tag1", "tag2"},
 	}
 
-	nodeBalancerModel := &NodebalancerModel{}
+	nodeBalancerModel := &NodeBalancerModel{}
 
 	diags := nodeBalancerModel.ParseNonComputedAttrs(context.Background(), nodeBalancer)
 
@@ -60,7 +60,7 @@ func TestParseComputedAttrs(t *testing.T) {
 		},
 	}
 
-	nodeBalancerModel := &NodebalancerModel{}
+	nodeBalancerModel := &NodeBalancerModel{}
 
 	diags := nodeBalancerModel.ParseComputedAttrs(context.Background(), nodeBalancer)
 

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -36,7 +36,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	var data NodebalancerModel
+	var data NodeBalancerModel
 	client := r.Meta.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -84,7 +84,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	var data NodebalancerModel
+	var data NodeBalancerModel
 	client := r.Meta.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -122,7 +122,7 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	var plan, state NodebalancerModel
+	var plan, state NodeBalancerModel
 	client := r.Meta.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -167,7 +167,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	var data NodebalancerModel
+	var data NodeBalancerModel
 	client := r.Meta.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -214,7 +214,7 @@ func upgradeNodebalancerResourceStateV0toV1(
 		return
 	}
 
-	nbDataV1 := NodebalancerModel{
+	nbDataV1 := NodeBalancerModel{
 		ID:                 nbDataV0.ID,
 		Label:              nbDataV0.Label,
 		Region:             nbDataV0.Region,

--- a/linode/nbs/framework_models.go
+++ b/linode/nbs/framework_models.go
@@ -16,16 +16,16 @@ type NodeBalancerFilterModel struct {
 	Filters       frameworkfilter.FiltersModelType `tfsdk:"filter"`
 	Order         types.String                     `tfsdk:"order"`
 	OrderBy       types.String                     `tfsdk:"order_by"`
-	NodeBalancers []nb.NodebalancerModel           `tfsdk:"nodebalancers"`
+	NodeBalancers []nb.NodeBalancerModel           `tfsdk:"nodebalancers"`
 }
 
 func (data *NodeBalancerFilterModel) parseNodeBalancers(
 	ctx context.Context,
 	nodebalancers []linodego.NodeBalancer,
 ) {
-	result := make([]nb.NodebalancerModel, len(nodebalancers))
+	result := make([]nb.NodeBalancerModel, len(nodebalancers))
 	for i := range nodebalancers {
-		var nbData nb.NodebalancerModel
+		var nbData nb.NodeBalancerModel
 		nbData.ParseComputedAttrs(ctx, &nodebalancers[i])
 		nbData.ParseNonComputedAttrs(ctx, &nodebalancers[i])
 		result[i] = nbData

--- a/linode/nbs/framework_models.go
+++ b/linode/nbs/framework_models.go
@@ -16,18 +16,17 @@ type NodeBalancerFilterModel struct {
 	Filters       frameworkfilter.FiltersModelType `tfsdk:"filter"`
 	Order         types.String                     `tfsdk:"order"`
 	OrderBy       types.String                     `tfsdk:"order_by"`
-	NodeBalancers []nb.NodeBalancerModel           `tfsdk:"nodebalancers"`
+	NodeBalancers []nb.NodeBalancerDataSourceModel `tfsdk:"nodebalancers"`
 }
 
 func (data *NodeBalancerFilterModel) parseNodeBalancers(
 	ctx context.Context,
 	nodebalancers []linodego.NodeBalancer,
 ) {
-	result := make([]nb.NodeBalancerModel, len(nodebalancers))
+	result := make([]nb.NodeBalancerDataSourceModel, len(nodebalancers))
 	for i := range nodebalancers {
-		var nbData nb.NodeBalancerModel
-		nbData.ParseComputedAttrs(ctx, &nodebalancers[i])
-		nbData.ParseNonComputedAttrs(ctx, &nodebalancers[i])
+		var nbData nb.NodeBalancerDataSourceModel
+		nbData.FlattenNodeBalancer(ctx, &nodebalancers[i])
 		result[i] = nbData
 	}
 


### PR DESCRIPTION
## 📝 Description

This is to fix a failing test of NodeBalancer data source. It was broken because the data source schema doesn't have `firewall_id`, thus an type conversion error can happens.


```
    datasource_test.go:20: Step 1/1 error: Error running apply: exit status 1
        
        Error: Value Conversion Error
        
          with data.linode_nodebalancer.foobar,
          on terraform_plugin_test.tf line 14, in data "linode_nodebalancer" "foobar":
          14: data "linode_nodebalancer" "foobar" {
        
        An unexpected error was encountered trying to convert tftypes.Value into
        nb.NodebalancerModel. This is always an error in the provider. Please report
        the following to the provider developer:
        
        mismatch between struct and object: Struct defines fields not found in
        object: firewall_id.
```

## ✔️ How to Test

`make testacc PKG_NAME=linode/nb`

GHA test run:
https://github.com/linode/terraform-provider-linode/actions/runs/6464480762