### PR TITLE
fix: Move `GetTestClient()` and support API URL & version overrides

### DIFF
--- a/linode/acceptance/sweepers.go
+++ b/linode/acceptance/sweepers.go
@@ -3,32 +3,15 @@ package acceptance
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/linode/linodego"
-	"github.com/linode/terraform-provider-linode/linode/helper"
 )
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
-}
-
-func GetTestClient() (*linodego.Client, error) {
-	token := os.Getenv("LINODE_TOKEN")
-	if token == "" {
-		return nil, fmt.Errorf("LINODE_TOKEN must be set for acceptance tests")
-	}
-
-	config := &helper.Config{AccessToken: token, APIVersion: "v4beta"}
-	client, err := config.Client()
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
 }
 
 func SweeperListOptions(prefix, field string) *linodego.ListOptions {

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -626,3 +626,28 @@ func GetRandomOBJCluster() (string, error) {
 	// #nosec G404 -- Test data, doesn't need to be cryptography
 	return clusters[rand.Intn(len(clusters))].ID, nil
 }
+
+func GetTestClient() (*linodego.Client, error) {
+	token := os.Getenv("LINODE_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("LINODE_TOKEN must be set for acceptance tests")
+	}
+
+	apiVersion := os.Getenv("LINODE_API_VERSION")
+	if apiVersion == "" {
+		apiVersion = "v4beta"
+	}
+
+	config := &helper.Config{
+		AccessToken: token,
+		APIVersion:  apiVersion,
+		APIURL:      os.Getenv("LINODE_URL"),
+	}
+
+	client, err := config.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/linode/acceptance/util_test.go
+++ b/linode/acceptance/util_test.go
@@ -11,6 +11,7 @@ func TestGetTestClient_noURLOverride(t *testing.T) {
 	expectedURL := "api.linode.com"
 	expectedVersion := "v4beta"
 
+	t.Setenv("LINODE_TOKEN", "foobar")
 	t.Setenv("LINODE_URL", "")
 	t.Setenv("LINODE_API_VERSION", "")
 
@@ -38,6 +39,7 @@ func TestGetTestClient_URLOverride(t *testing.T) {
 	expectedURL := "foo.linode.com"
 	expectedVersion := "v4"
 
+	t.Setenv("LINODE_TOKEN", "foobar")
 	t.Setenv("LINODE_URL", expectedURL)
 	t.Setenv("LINODE_API_VERSION", expectedVersion)
 

--- a/linode/acceptance/util_test.go
+++ b/linode/acceptance/util_test.go
@@ -1,4 +1,7 @@
-//go:build unit
+//go:build integration
+
+// NOTE: This test file needs to be tagged as integration because the
+// package accesses the Linode API during init.
 
 package acceptance
 
@@ -11,7 +14,6 @@ func TestGetTestClient_noURLOverride(t *testing.T) {
 	expectedURL := "api.linode.com"
 	expectedVersion := "v4beta"
 
-	t.Setenv("LINODE_TOKEN", "foobar")
 	t.Setenv("LINODE_URL", "")
 	t.Setenv("LINODE_API_VERSION", "")
 
@@ -39,7 +41,6 @@ func TestGetTestClient_URLOverride(t *testing.T) {
 	expectedURL := "foo.linode.com"
 	expectedVersion := "v4"
 
-	t.Setenv("LINODE_TOKEN", "foobar")
 	t.Setenv("LINODE_URL", expectedURL)
 	t.Setenv("LINODE_API_VERSION", expectedVersion)
 

--- a/linode/acceptance/util_test.go
+++ b/linode/acceptance/util_test.go
@@ -1,0 +1,62 @@
+//go:build unit
+
+package acceptance
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetTestClient_noURLOverride(t *testing.T) {
+	expectedURL := "api.linode.com"
+	expectedVersion := "v4beta"
+
+	t.Setenv("LINODE_URL", "")
+	t.Setenv("LINODE_API_VERSION", "")
+
+	client, err := GetTestClient()
+	if err != nil {
+		t.Fatalf("failed to get test client: %s", err)
+	}
+
+	// baseURL and apiVersion are a private fields of
+	// linodego.Client, so we need to access them using reflection
+	rClient := reflect.ValueOf(*client)
+	baseURL := rClient.FieldByName("baseURL").String()
+	apiVersion := rClient.FieldByName("apiVersion").String()
+
+	if baseURL != expectedURL {
+		t.Fatalf("expected base url to be %s, got %s", expectedURL, baseURL)
+	}
+
+	if apiVersion != expectedVersion {
+		t.Fatalf("expected api version to be %s, got %s", expectedVersion, apiVersion)
+	}
+}
+
+func TestGetTestClient_URLOverride(t *testing.T) {
+	expectedURL := "foo.linode.com"
+	expectedVersion := "v4"
+
+	t.Setenv("LINODE_URL", expectedURL)
+	t.Setenv("LINODE_API_VERSION", expectedVersion)
+
+	client, err := GetTestClient()
+	if err != nil {
+		t.Fatalf("failed to get test client: %s", err)
+	}
+
+	// baseURL and apiVersion are a private fields of
+	// linodego.Client, so we need to access them using reflection
+	rClient := reflect.ValueOf(*client)
+	baseURL := rClient.FieldByName("baseURL").String()
+	apiVersion := rClient.FieldByName("apiVersion").String()
+
+	if baseURL != expectedURL {
+		t.Fatalf("expected base url to be %s, got %s", expectedURL, baseURL)
+	}
+
+	if apiVersion != expectedVersion {
+		t.Fatalf("expected api version to be %s, got %s", expectedVersion, apiVersion)
+	}
+}

--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ smoketest: fmtcheck
 	go test -v -run smoke ./linode/... -count $(ACCTEST_COUNT) -timeout $(ACCTEST_TIMEOUT) -parallel=$(ACCTEST_PARALLELISM) -ldflags="-X=github.com/linode/terraform-provider-linode/version.ProviderVersion=acc"
 
 unittest:
-	go test -v --tags=unit ./linode/...
+	go test -v --tags=unit ./linode/acceptance
 
 vet:
 	@echo "go vet ."

--- a/makefile
+++ b/makefile
@@ -58,7 +58,7 @@ smoketest: fmtcheck
 	go test -v -run smoke ./linode/... -count $(ACCTEST_COUNT) -timeout $(ACCTEST_TIMEOUT) -parallel=$(ACCTEST_PARALLELISM) -ldflags="-X=github.com/linode/terraform-provider-linode/version.ProviderVersion=acc"
 
 unittest:
-	go test -v --tags=unit ./linode/acceptance
+	go test -v --tags=unit ./linode/...
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
## 📝 Description

This change moves `GetTestClient()` to the `acceptance/util.go` file and adds support for overriding the API URL and version through the environment.

## ✔️ How to Test

```
make PKG_NAME=linode/acceptance testacc
```
