### PR TITLE
fix: Revert integer ID attributes to strings

### DIFF
--- a/linode/nb/framework_models.go
+++ b/linode/nb/framework_models.go
@@ -16,7 +16,7 @@ import (
 // NodeBalancerModel describes the Terraform resource data model to match the
 // resource schema.
 type NodeBalancerModel struct {
-	ID                 types.Int64       `tfsdk:"id"`
+	ID                 types.String      `tfsdk:"id"`
 	Label              types.String      `tfsdk:"label"`
 	Region             types.String      `tfsdk:"region"`
 	ClientConnThrottle types.Int64       `tfsdk:"client_conn_throttle"`
@@ -31,7 +31,7 @@ type NodeBalancerModel struct {
 }
 
 type nbModelV0 struct {
-	ID                 types.Int64  `tfsdk:"id"`
+	ID                 types.String `tfsdk:"id"`
 	Label              types.String `tfsdk:"label"`
 	Region             types.String `tfsdk:"region"`
 	ClientConnThrottle types.Int64  `tfsdk:"client_conn_throttle"`
@@ -48,7 +48,7 @@ func (data *NodeBalancerModel) ParseNonComputedAttrs(
 	ctx context.Context,
 	nodebalancer *linodego.NodeBalancer,
 ) diag.Diagnostics {
-	data.ID = types.Int64Value(int64(nodebalancer.ID))
+	data.ID = types.StringValue(strconv.Itoa(nodebalancer.ID))
 	data.Label = types.StringPointerValue(nodebalancer.Label)
 
 	tags, diags := types.SetValueFrom(ctx, types.StringType, helper.StringSliceToFramework(nodebalancer.Tags))
@@ -64,7 +64,7 @@ func (data *NodeBalancerModel) ParseComputedAttrs(
 	ctx context.Context,
 	nodebalancer *linodego.NodeBalancer,
 ) diag.Diagnostics {
-	data.ID = types.Int64Value(int64(nodebalancer.ID))
+	data.ID = types.StringValue(strconv.Itoa(nodebalancer.ID))
 	data.Region = types.StringValue(nodebalancer.Region)
 	data.ClientConnThrottle = types.Int64Value(int64(nodebalancer.ClientConnThrottle))
 	data.Hostname = types.StringPointerValue(nodebalancer.Hostname)

--- a/linode/nb/framework_models_unit_test.go
+++ b/linode/nb/framework_models_unit_test.go
@@ -66,7 +66,7 @@ func TestParseComputedAttrs(t *testing.T) {
 
 	assert.False(t, diags.HasError())
 
-	assert.Equal(t, types.Int64Value(123), nodeBalancerModel.ID)
+	assert.Equal(t, types.StringValue("123"), nodeBalancerModel.ID)
 	assert.Equal(t, types.StringValue("us-east"), nodeBalancerModel.Region)
 	assert.Equal(t, types.Int64Value(10), nodeBalancerModel.ClientConnThrottle)
 	assert.Equal(t, types.StringPointerValue(&hostname), nodeBalancerModel.Hostname)

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -20,7 +20,7 @@ func NewResource() resource.Resource {
 		BaseResource: helper.NewBaseResource(
 			helper.BaseResourceConfig{
 				Name:   "linode_nodebalancer",
-				IDType: types.Int64Type,
+				IDType: types.StringType,
 				Schema: &frameworkResourceSchema,
 			},
 		),
@@ -92,18 +92,23 @@ func (r *Resource) Read(
 		return
 	}
 
-	nodebalancer, err := client.GetNodeBalancer(ctx, int(data.ID.ValueInt64()))
+	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	nodebalancer, err := client.GetNodeBalancer(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			resp.Diagnostics.AddWarning(
 				"Nodebalancer",
-				fmt.Sprintf("removing Linode NodeBalancer ID %v from state because it no longer exists", data.ID.ValueInt64()),
+				fmt.Sprintf("removing Linode NodeBalancer ID %v from state because it no longer exists", id),
 			)
 			resp.State.RemoveResource(ctx)
 			return
 		}
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to get nodebalancer %v", data.ID.ValueInt64()),
+			fmt.Sprintf("Failed to get nodebalancer %v", id),
 			err.Error(),
 		)
 	}
@@ -131,6 +136,11 @@ func (r *Resource) Update(
 		return
 	}
 
+	id := helper.StringToInt(plan.ID.ValueString(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	isEqual := state.Label.Equal(plan.Label) &&
 		state.ClientConnThrottle.Equal(plan.ClientConnThrottle) &&
 		state.Tags.Equal(plan.Tags)
@@ -145,10 +155,10 @@ func (r *Resource) Update(
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		nodebalancer, err := client.UpdateNodeBalancer(ctx, int(plan.ID.ValueInt64()), updateOpts)
+		nodebalancer, err := client.UpdateNodeBalancer(ctx, id, updateOpts)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to update Nodebalancer %v", plan.ID.ValueInt64()),
+				fmt.Sprintf("Failed to update Nodebalancer %v", id),
 				err.Error(),
 			)
 			return
@@ -175,12 +185,17 @@ func (r *Resource) Delete(
 		return
 	}
 
-	err := client.DeleteNodeBalancer(ctx, int(data.ID.ValueInt64()))
+	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := client.DeleteNodeBalancer(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			resp.Diagnostics.AddWarning(
 				"Nodebalancer does not exist.",
-				fmt.Sprintf("Nodebalancer %v does not exist, removing from state.", data.ID.ValueInt64()),
+				fmt.Sprintf("Nodebalancer %v does not exist, removing from state.", id),
 			)
 			resp.State.RemoveResource(ctx)
 			return

--- a/linode/nb/framework_resource_schema.go
+++ b/linode/nb/framework_resource_schema.go
@@ -18,10 +18,10 @@ import (
 var frameworkResourceSchema = schema.Schema{
 	Version: 1,
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description:   "The unique ID of the Linode NodeBalancer.",
 			Computed:      true,
-			PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
+			PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 		},
 		"label": schema.StringAttribute{
 			Description: "The label of the Linode NodeBalancer.",
@@ -99,7 +99,7 @@ var frameworkResourceSchema = schema.Schema{
 
 var resourceNodebalancerV0 = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The unique ID of the Linode NodeBalancer.",
 			Computed:    true,
 		},

--- a/linode/objkey/framework_model.go
+++ b/linode/objkey/framework_model.go
@@ -1,6 +1,8 @@
 package objkey
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 )
@@ -14,7 +16,7 @@ type BucketAccessModelEntry struct {
 // ResourceModel describes the Terraform resource rm model to match the
 // resource schema.
 type ResourceModel struct {
-	ID           types.Int64              `tfsdk:"id"`
+	ID           types.String             `tfsdk:"id"`
 	Label        types.String             `tfsdk:"label"`
 	AccessKey    types.String             `tfsdk:"access_key"`
 	SecretKey    types.String             `tfsdk:"secret_key"`
@@ -44,7 +46,7 @@ func (rm *ResourceModel) parseConfiguredAttributes(key *linodego.ObjectStorageKe
 }
 
 func (rm *ResourceModel) parseComputedAttributes(key *linodego.ObjectStorageKey) {
-	rm.ID = types.Int64Value(int64(key.ID))
+	rm.ID = types.StringValue(strconv.Itoa(key.ID))
 	rm.AccessKey = types.StringValue(key.AccessKey)
 	rm.Limited = types.BoolValue(key.Limited)
 

--- a/linode/objkey/framework_resource_schema.go
+++ b/linode/objkey/framework_resource_schema.go
@@ -3,7 +3,6 @@ package objkey
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -16,11 +15,11 @@ var frameworkResourceSchema = schema.Schema{
 			Required:    true,
 		},
 
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The unique ID of this Object Storage key.",
 			Computed:    true,
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"access_key": schema.StringAttribute{

--- a/linode/sshkey/framework_resource_model.go
+++ b/linode/sshkey/framework_resource_model.go
@@ -1,6 +1,8 @@
 package sshkey
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -12,7 +14,7 @@ type ResourceModel struct {
 	Label   types.String      `tfsdk:"label"`
 	SSHKey  types.String      `tfsdk:"ssh_key"`
 	Created timetypes.RFC3339 `tfsdk:"created"`
-	ID      types.Int64       `tfsdk:"id"`
+	ID      types.String      `tfsdk:"id"`
 }
 
 func (rm *ResourceModel) parseConfiguredAttributes(key *linodego.SSHKey) {
@@ -21,6 +23,6 @@ func (rm *ResourceModel) parseConfiguredAttributes(key *linodego.SSHKey) {
 }
 
 func (rm *ResourceModel) parseComputedAttributes(key *linodego.SSHKey) {
-	rm.ID = types.Int64Value(int64(key.ID))
+	rm.ID = types.StringValue(strconv.Itoa(key.ID))
 	rm.Created = timetypes.NewRFC3339TimePointerValue(key.Created)
 }

--- a/linode/sshkey/framework_resource_models_unit_test.go
+++ b/linode/sshkey/framework_resource_models_unit_test.go
@@ -3,6 +3,7 @@
 package sshkey
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -34,6 +35,6 @@ func TestParseComputedAttributes(t *testing.T) {
 	rm := &ResourceModel{}
 	rm.parseComputedAttributes(&key)
 
-	assert.Equal(t, types.Int64Value(int64(key.ID)), rm.ID)
+	assert.Equal(t, types.StringValue(strconv.Itoa(key.ID)), rm.ID)
 	assert.Equal(t, types.StringValue(created.Format(time.RFC3339)), rm.Created.StringValue)
 }

--- a/linode/sshkey/framework_resource_schema.go
+++ b/linode/sshkey/framework_resource_schema.go
@@ -3,7 +3,6 @@ package sshkey
 import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
@@ -31,11 +30,11 @@ var frameworkResourceSchema = schema.Schema{
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The unique identifier for this SSH key.",
 			Computed:    true,
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 	},


### PR DESCRIPTION
## 📝 Description

This change reverts integer ID attributes to strings to unblock provider upgrades in the [Linode Crossplane Provider](https://github.com/linode/provider-linode), which relies on the Terraform provider under the hood. This change is needed because Crossplane pre-populates ID attributes in the state with empty strings, which causes Terraform to raise an error on integer IDs. 

NOTE: Since Terraform already implicitly stores IDs as strings, we should not need any form of state migrations to maintain backwards compatibility.

## ✔️ How to Test

**Integration Tests**

```
make unittest
make PKG_NAME=linode/objkey testacc
make PKG_NAME=linode/sshkey testacc
make PKG_NAME=linode/nb testacc
```

**Manual Testing**

In a dx-devenv sandbox environment:

1. Add the following configuration to `main.tf`

```terraform
resource "linode_sshkey" "foo" {
  label = "foo"
  ssh_key = "ssh-rsa foobar foobar"
}

resource "linode_object_storage_key" "foo" {
  label = "foobar"
}

resource "linode_nodebalancer" "foobar" {
  label = "foobar"
  region = "us-east"
}
```

2. Apply the configuration (`make apply`).
3. Observe the ID attributes being stored as strings in `terraform.tfstate`