### PR TITLE
Apply `FrameworkSafeInt64ToInt`

### DIFF
--- a/linode/databasemysql/framework_datasource.go
+++ b/linode/databasemysql/framework_datasource.go
@@ -39,9 +39,18 @@ func (d *DataSource) Read(
 	id := 0
 
 	if data.ID.IsNull() || data.ID.IsUnknown() {
-		id = int(data.DatabaseID.ValueInt64())
+		id = helper.FrameworkSafeInt64ToInt(
+			data.DatabaseID.ValueInt64(),
+			&resp.Diagnostics,
+		)
 	} else if data.DatabaseID.IsNull() || data.DatabaseID.IsUnknown() {
-		id = int(data.ID.ValueInt64())
+		id = helper.FrameworkSafeInt64ToInt(
+			data.ID.ValueInt64(),
+			&resp.Diagnostics,
+		)
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	if id == 0 {

--- a/linode/databasepostgresql/framework_datasource.go
+++ b/linode/databasepostgresql/framework_datasource.go
@@ -40,9 +40,15 @@ func (d *DataSource) Read(
 	var id int
 
 	if !data.ID.IsNull() && !data.ID.IsUnknown() {
-		id = int(data.ID.ValueInt64())
+		id = helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
 	} else {
-		id = int(data.DatabaseID.ValueInt64())
+		id = helper.FrameworkSafeInt64ToInt(
+			data.DatabaseID.ValueInt64(),
+			&resp.Diagnostics,
+		)
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	if id == 0 {

--- a/linode/domain/framework_datasource.go
+++ b/linode/domain/framework_datasource.go
@@ -43,7 +43,11 @@ func (d *DataSource) Read(
 
 	// Resolve the domain from the corresponding field
 	if !data.ID.IsNull() {
-		domain, err = d.getDomainByID(ctx, int(data.ID.ValueInt64()))
+		id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		domain, err = d.getDomainByID(ctx, id)
 	} else {
 		domain, err = d.getDomainByDomain(ctx, data.Domain.ValueString())
 	}

--- a/linode/domainrecord/framework_datasource.go
+++ b/linode/domainrecord/framework_datasource.go
@@ -77,7 +77,19 @@ func (d *DataSource) Read(
 	var record *linodego.DomainRecord
 
 	if !(data.ID.IsNull() || data.ID.IsUnknown()) {
-		rec, err := client.GetDomainRecord(ctx, int(data.DomainID.ValueInt64()), int(data.ID.ValueInt64()))
+		domainID := helper.FrameworkSafeInt64ToInt(
+			data.DomainID.ValueInt64(),
+			&resp.Diagnostics,
+		)
+		recordID := helper.FrameworkSafeInt64ToInt(
+			data.ID.ValueInt64(),
+			&resp.Diagnostics,
+		)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		rec, err := client.GetDomainRecord(ctx, domainID, recordID)
 		if err != nil {
 			resp.Diagnostics.AddError("Error fetching domain record: %v", err.Error())
 			return
@@ -85,7 +97,14 @@ func (d *DataSource) Read(
 		record = rec
 	} else if data.Name.ValueString() != "" {
 		filter, _ := json.Marshal(map[string]interface{}{"name": data.Name.ValueString()})
-		records, err := client.ListDomainRecords(ctx, int(data.DomainID.ValueInt64()),
+		domainID := helper.FrameworkSafeInt64ToInt(
+			data.DomainID.ValueInt64(),
+			&resp.Diagnostics,
+		)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		records, err := client.ListDomainRecords(ctx, domainID,
 			linodego.NewListOptions(0, string(filter)))
 		if err != nil {
 			resp.Diagnostics.AddError("Error listing domain records: %v", err.Error())

--- a/linode/domainzonefile/framework_datasource.go
+++ b/linode/domainzonefile/framework_datasource.go
@@ -69,7 +69,15 @@ func (d *DataSource) Read(
 
 	retry := time.Duration(d.Meta.Config.EventPollMilliseconds.ValueInt64()) * time.Millisecond
 
-	zf, diags := getZoneFileRetry(ctx, client, int(data.DomainID.ValueInt64()), retry)
+	domainID := helper.FrameworkSafeInt64ToInt(
+		data.DomainID.ValueInt64(),
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	zf, diags := getZoneFileRetry(ctx, client, domainID, retry)
 	if diags.HasError() {
 		return
 	}

--- a/linode/firewall/framework_datasource.go
+++ b/linode/firewall/framework_datasource.go
@@ -35,8 +35,12 @@ func (d *DataSource) Read(
 		return
 	}
 
-	firewallId := int(data.ID.ValueInt64())
-	firewall, err := client.GetFirewall(ctx, firewallId)
+	firewallID := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	firewall, err := client.GetFirewall(ctx, firewallID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to get firewall",
@@ -44,7 +48,7 @@ func (d *DataSource) Read(
 		)
 		return
 	}
-	rules, err := client.GetFirewallRules(ctx, firewallId)
+	rules, err := client.GetFirewallRules(ctx, firewallID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to get firewall rules",
@@ -52,7 +56,7 @@ func (d *DataSource) Read(
 		)
 		return
 	}
-	devices, err := client.ListFirewallDevices(ctx, firewallId, nil)
+	devices, err := client.ListFirewallDevices(ctx, firewallID, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to get firewall devices",

--- a/linode/instancenetworking/framework_datasource.go
+++ b/linode/instancenetworking/framework_datasource.go
@@ -39,7 +39,15 @@ func (d *DataSource) Read(
 		return
 	}
 
-	netInfo, err := client.GetInstanceIPAddresses(ctx, int(data.LinodeID.ValueInt64()))
+	linodeID := helper.FrameworkSafeInt64ToInt(
+		data.LinodeID.ValueInt64(),
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	netInfo, err := client.GetInstanceIPAddresses(ctx, linodeID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to get Instance Networking Information: ", err.Error(),

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -41,13 +41,28 @@ func (r *Resource) Create(
 		return
 	}
 
+	prefixLength := helper.FrameworkSafeInt64ToInt(
+		data.PrefixLength.ValueInt64(),
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	createOpts := linodego.IPv6RangeCreateOptions{
-		PrefixLength: int(data.PrefixLength.ValueInt64()),
+		PrefixLength: prefixLength,
 	}
 
 	linodeIdConfigured := false
+	linodeID := helper.FrameworkSafeInt64ToInt(
+		data.LinodeId.ValueInt64(),
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if !data.LinodeId.IsNull() && !data.LinodeId.IsUnknown() {
-		createOpts.LinodeID = int(data.LinodeId.ValueInt64())
+		createOpts.LinodeID = linodeID
 		linodeIdConfigured = true
 	} else if !data.RouteTarget.IsNull() && !data.RouteTarget.IsUnknown() {
 		createOpts.RouteTarget = strings.Split(data.RouteTarget.ValueString(), "/")[0]
@@ -161,11 +176,18 @@ func (r *Resource) Update(
 	}
 
 	if !state.LinodeId.Equal(plan.LinodeId) {
+		linodeID := helper.FrameworkSafeInt64ToInt(
+			plan.LinodeId.ValueInt64(),
+			&resp.Diagnostics,
+		)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		err := client.InstancesAssignIPs(ctx, linodego.LinodesAssignIPsOptions{
 			Region: ipv6range.Region,
 			Assignments: []linodego.LinodeIPAssignment{
 				{
-					LinodeID: int(plan.LinodeId.ValueInt64()),
+					LinodeID: linodeID,
 					Address:  fmt.Sprintf("%s/%d", ipv6range.Range, ipv6range.Prefix),
 				},
 			},

--- a/linode/nb/framework_datasource.go
+++ b/linode/nb/framework_datasource.go
@@ -36,15 +36,23 @@ func (d *DataSource) Read(
 		return
 	}
 
-	nodebalancer, err := client.GetNodeBalancer(ctx, int(data.ID.ValueInt64()))
+	nodeBalancerID := helper.FrameworkSafeInt64ToInt(
+		data.ID.ValueInt64(),
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	nodeBalancer, err := client.GetNodeBalancer(ctx, nodeBalancerID)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to get nodebalancer %d", int(data.ID.ValueInt64())),
+			fmt.Sprintf("Failed to get nodebalancer %d", nodeBalancerID),
 			err.Error(),
 		)
 	}
 
-	resp.Diagnostics.Append(data.FlattenNodeBalancer(ctx, nodebalancer)...)
+	resp.Diagnostics.Append(data.FlattenNodeBalancer(ctx, nodeBalancer)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -110,7 +110,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	nodebalancer, err := client.GetNodeBalancer(ctx, id)
+	nodeBalancer, err := client.GetNodeBalancer(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			resp.Diagnostics.AddWarning(
@@ -175,7 +175,7 @@ func (r *Resource) Update(
 			return
 		}
 
-		nodebalancer, err := client.UpdateNodeBalancer(ctx, id, updateOpts)
+		nodeBalancer, err := client.UpdateNodeBalancer(ctx, id, updateOpts)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to update Nodebalancer %v", id),
@@ -204,7 +204,6 @@ func (r *Resource) Delete(
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 
 	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/linode/nbconfig/framework_datasource.go
+++ b/linode/nbconfig/framework_datasource.go
@@ -62,7 +62,13 @@ func (d *DataSource) Read(
 		return
 	}
 
-	config, err := client.GetNodeBalancerConfig(ctx, int(data.NodebalancerId.ValueInt64()), int(data.ID.ValueInt64()))
+	nodeBalancerID := helper.FrameworkSafeInt64ToInt(data.NodebalancerId.ValueInt64(), &resp.Diagnostics)
+	configID := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	config, err := client.GetNodeBalancerConfig(ctx, nodeBalancerID, configID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("failed to get nodebalancer config %d", data.ID.ValueInt64()),

--- a/linode/nbnode/framework_datasource.go
+++ b/linode/nbnode/framework_datasource.go
@@ -37,11 +37,17 @@ func (d *DataSource) Read(
 		return
 	}
 
-	id := int(data.ID.ValueInt64())
-	nodebalancerID := int(data.NodeBalancerID.ValueInt64())
-	configID := int(data.ConfigID.ValueInt64())
+	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	nodeBalancerID := helper.FrameworkSafeInt64ToInt(
+		data.NodeBalancerID.ValueInt64(),
+		&resp.Diagnostics,
+	)
+	configID := helper.FrameworkSafeInt64ToInt(data.ConfigID.ValueInt64(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	node, err := client.GetNodeBalancerNode(ctx, nodebalancerID, configID, id)
+	node, err := client.GetNodeBalancerNode(ctx, nodeBalancerID, configID, id)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to get nodebalancer node with id %d:", id), err.Error(),

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -142,10 +142,6 @@ func (r *Resource) Update(
 	}
 
 	if shouldUpdate {
-		keyID := helper.FrameworkSafeInt64ToInt(plan.ID.ValueInt64(), &resp.Diagnostics)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 		key, err := r.Meta.Client.UpdateObjectStorageKey(
 			ctx,
 			id,

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -70,10 +70,6 @@ func (r *Resource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	keyID := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -130,10 +126,6 @@ func (r *Resource) Update(
 	}
 
 	if shouldUpdate {
-		keyID := helper.FrameworkSafeInt64ToInt(plan.ID.ValueInt64(), &resp.Diagnostics)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 		key, err := r.Meta.Client.UpdateSSHKey(
 			ctx,
 			id,

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -70,8 +70,12 @@ func (r *Resource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	keyID := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	key, err := client.GetSSHKey(ctx, int(data.ID.ValueInt64()))
+	key, err := client.GetSSHKey(ctx, keyID)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			resp.Diagnostics.AddWarning(
@@ -116,9 +120,13 @@ func (r *Resource) Update(
 	}
 
 	if shouldUpdate {
+		keyID := helper.FrameworkSafeInt64ToInt(plan.ID.ValueInt64(), &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		key, err := r.Meta.Client.UpdateSSHKey(
 			ctx,
-			int(plan.ID.ValueInt64()),
+			keyID,
 			updateOpts,
 		)
 		if err != nil {
@@ -146,7 +154,11 @@ func (r *Resource) Delete(
 	}
 
 	client := r.Meta.Client
-	err := client.DeleteSSHKey(ctx, int(data.ID.ValueInt64()))
+	keyID := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	err := client.DeleteSSHKey(ctx, keyID)
 	if err != nil {
 		if lErr, ok := err.(*linodego.Error); (ok && lErr.Code != 404) || !ok {
 			resp.Diagnostics.AddError(

--- a/linode/volume/framework_datasource.go
+++ b/linode/volume/framework_datasource.go
@@ -43,8 +43,11 @@ func (r *DataSource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	volume, err := client.GetVolume(ctx, int(data.ID.ValueInt64()))
+	volumeID := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	volume, err := client.GetVolume(ctx, volumeID)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get the volume.", err.Error())
 	}


### PR DESCRIPTION
## 📝 Description

Making int64 to int conversion safer.

## ✔️ How to Test

```
make unittest
make PKG_NAME=linode/databasemysql testacc
make PKG_NAME=linode/databasepostgresql testacc
make PKG_NAME=linode/domain testacc
make PKG_NAME=linode/domainrecord testacc
make PKG_NAME=linode/domainzonefile testacc
make PKG_NAME=linode/firewall testacc
make PKG_NAME=linode/instancenetworking testacc
make PKG_NAME=linode/ipv6range testacc
make PKG_NAME=linode/nbconfig testacc
make PKG_NAME=linode/nbnode testacc
make PKG_NAME=linode/objkey testacc
make PKG_NAME=linode/sshkey testacc
make PKG_NAME=linode/volume testacc
```

