### PR TITLE
Fix `nosec` Comment for `gosec` and remove deprecated `io/ioutil` package

### DIFF
--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -502,7 +501,7 @@ func ExecuteTemplate(t *testing.T, templateName string, data interface{}) string
 }
 
 func CreateTempFile(t *testing.T, name, content string) *os.File {
-	file, err := ioutil.TempFile(os.TempDir(), name)
+	file, err := os.CreateTemp(os.TempDir(), name)
 	if err != nil {
 		t.Fatalf("failed to create temp file: %s", err)
 	}
@@ -513,7 +512,7 @@ func CreateTempFile(t *testing.T, name, content string) *os.File {
 		}
 	})
 
-	if _, err := file.Write([]byte(content)); err != nil {
+	if _, err := file.WriteString(content); err != nil {
 		t.Fatalf("failed to write to temp file: %s", err)
 	}
 

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -167,10 +167,10 @@ func GetSSHClient(t *testing.T, user, addr string) (client *ssh.Client) {
 		t.Fatalf("failed to parse private key: %s", err)
 	}
 
-	// #nosec G106 -- Test data, not used in production
 	config := &ssh.ClientConfig{
-		User:            "root",
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		User: "root",
+		Auth: []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		//#nosec G106 -- Test data, not used in production
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         time.Minute,
 	}

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -5,7 +5,6 @@ package image_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -250,7 +249,7 @@ func checkImageDestroy(s *terraform.State) error {
 }
 
 func createTempFile(name string, content []byte) (*os.File, error) {
-	file, err := ioutil.TempFile(os.TempDir(), name)
+	file, err := os.CreateTemp(os.TempDir(), name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %s", err)
 	}

--- a/linode/obj/resource_test.go
+++ b/linode/obj/resource_test.go
@@ -4,7 +4,7 @@ package obj_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -155,7 +155,7 @@ func checkObjectDestroy(s *terraform.State) error {
 
 func checkObjectBodyContains(obj *s3.GetObjectOutput, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		body, err := ioutil.ReadAll(obj.Body)
+		body, err := io.ReadAll(obj.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read body: %s", err)
 		}

--- a/linode/provider_test.go
+++ b/linode/provider_test.go
@@ -5,7 +5,6 @@ package linode_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -74,7 +73,7 @@ api_version = v4beta
 }
 
 func createTestConfig(t *testing.T, conf string) *os.File {
-	file, err := ioutil.TempFile("", "linode")
+	file, err := os.CreateTemp("", "linode")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/linode/provider_test.go
+++ b/linode/provider_test.go
@@ -35,7 +35,7 @@ api_version = v4beta
 		ConfigPath:            file.Name(),
 	}
 
-	client, err := config.Client()
+	client, err := config.Client(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ api_version = v4beta
 	config.APIURL = ""
 	config.APIVersion = ""
 
-	client, err = config.Client()
+	client, err = config.Client(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ api_version = v4beta
 	}
 
 	config.ConfigProfile = "cool"
-	client, err = config.Client()
+	client, err = config.Client(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## 📝 Description

- The newer version of `gosec` requires the `nosec` comment to be inline.
- A linter doesn't allow `Write([]byte(content))` and recommended `WriteString(content)` instead.
- Removed usage of deprecated `io/ioutil` package.