### PR TITLE
fix: Remove resource from state if ID is empty

### DIFF
--- a/linode/helper/framework_util.go
+++ b/linode/helper/framework_util.go
@@ -1,0 +1,30 @@
+package helper
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FrameworkAttemptRemoveResourceForEmptyID implements a
+// temporary workaround for a Crossplane/Upjet issue (TPT-2408).
+// Returns true if the resource was removed from state, else false.
+func FrameworkAttemptRemoveResourceForEmptyID(
+	ctx context.Context,
+	id types.String,
+	resp *resource.ReadResponse,
+) bool {
+	if id.ValueString() != "" {
+		return false
+	}
+
+	resp.Diagnostics.AddWarning(
+		"Removing Resource From State",
+		"This resource is being implicitly removed from the Terraform state because "+
+			"its ID attribute is empty.",
+	)
+	resp.State.RemoveResource(ctx)
+
+	return true
+}

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -112,6 +112,10 @@ func (r *Resource) Read(
 		return
 	}
 
+	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
+		return
+	}
+
 	ipv6range, err := client.GetIPv6Range(ctx, data.ID.ValueString())
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && (lerr.Code == 404 || lerr.Code == 405) {

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -92,6 +92,10 @@ func (r *Resource) Read(
 		return
 	}
 
+	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
+		return
+	}
+
 	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -84,6 +84,10 @@ func (r *Resource) Read(
 		return
 	}
 
+	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
+		return
+	}
+
 	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -96,6 +96,10 @@ func (r *Resource) Read(
 		return
 	}
 
+	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
+		return
+	}
+
 	ip, err := client.GetIPAddress(ctx, data.ID.ValueString())
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -71,6 +71,10 @@ func (r *Resource) Read(
 		return
 	}
 
+	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
+		return
+	}
+
 	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/stackscript/framework_resource.go
+++ b/linode/stackscript/framework_resource.go
@@ -86,6 +86,10 @@ func (r *Resource) Read(
 		return
 	}
 
+	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
+		return
+	}
+
 	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -83,6 +83,10 @@ func (r *Resource) Read(
 		return
 	}
 
+	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
+		return
+	}
+
 	id := helper.StringToInt(data.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
## 📝 Description

This change adds logic to all resources implemented using terraform-plugin-framework to remove a resource from the state with a warning if the ID is empty at read-time. This mimics the equivalent logic in SDKv2 and should not break any existing users.

This change should unblock the Crossplane provider from upgrading Terraform provider verisons. 

## ✔️ How to Test

### Manual Testing

To manually test this change, you will need a Terraform development environment setup (dx-devenv).

1. Pull down the changes in this PR.
2. Write the following configuration to your `main.tf` file:

```terraform
resource "linode_object_storage_key" "foobar" {
    label = "foobar"
}
```

3. Apply the resource (`make apply`)
4. Once the resource has been created, open your statefile (`terraform.tfstate`) and set the ID attribute of the resource to an empty string (e.g. `"id": "123456",` -> `"id": "",`)
5. Re-apply the resource (`make apply`)
6. Observe a warning being raised and the resource being recreated. Previously this would have raised a type conversion error.
