### PR TITLE
Wait for disk deletion to complete

### DIFF
--- a/linode/instancedisk/resource.go
+++ b/linode/instancedisk/resource.go
@@ -278,7 +278,13 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	tflog.Info(ctx, "Deleting instance disk")
-	p, err := client.NewEventPoller(ctx, linodeID, linodego.EntityLinode, linodego.ActionDiskDelete)
+	p, err := client.NewEventPollerWithSecondary(
+		ctx,
+		linodeID,
+		linodego.EntityLinode,
+		id,
+		linodego.ActionDiskDelete,
+	)
 	if err != nil {
 		return diag.Errorf("failed to initialize event poller: %s", err)
 	}

--- a/linode/instancedisk/resource.go
+++ b/linode/instancedisk/resource.go
@@ -278,8 +278,6 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	tflog.Info(ctx, "Deleting instance disk")
-	err = client.DeleteInstanceDisk(ctx, linodeID, id)
-
 	p, err := client.NewEventPoller(ctx, linodeID, linodego.EntityLinode, linodego.ActionDiskDelete)
 	if err != nil {
 		return diag.Errorf("failed to initialize event poller: %s", err)

--- a/linode/instancedisk/resource.go
+++ b/linode/instancedisk/resource.go
@@ -279,8 +279,19 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	tflog.Info(ctx, "Deleting instance disk")
 	err = client.DeleteInstanceDisk(ctx, linodeID, id)
+
+	p, err := client.NewEventPoller(ctx, linodeID, linodego.EntityLinode, linodego.ActionDiskDelete)
 	if err != nil {
+		return diag.Errorf("failed to initialize event poller: %s", err)
+	}
+
+	if err := client.DeleteInstanceDisk(ctx, linodeID, id); err != nil {
 		return diag.Errorf("Error deleting Linode Instance Disk %d: %s", id, err)
+	}
+
+	if _, err := p.WaitForFinished(ctx, helper.GetDeadlineSeconds(ctx, d)); err != nil {
+		return diag.Errorf(
+			"Error waiting for Instance %d Disk %d to finish deleting: %s", linodeID, id, err)
 	}
 
 	d.SetId("")


### PR DESCRIPTION
## 📝 Description

This PR addresses the issues with disk replacement described in https://github.com/linode/terraform-provider-linode/issues/1088.

From the events API it appears that instance disk deletion is an asynchronous process. At the moment, however, the `terraform` provider does not seem to wait for its completion before sending a request to create a new disk. This may occasionally result in the instance disk creation call to hang indefinitely (until a timeout is reached).

This PR modifies the provider so that the `deleteResource` function for the `instancedisk` resource does in fact wait for disk deletion to complete before returning.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**
Issue typically surfaces when it takes longer than a few seconds for the instance disk deletion to complete.

**How do I run the relevant unit/integration tests?**
```bash
make PKG_NAME="linode/instancedisk" testacc 
```