### PR TITLE
new: Expose `id` field in nested `linode_instance` configuration profiles

### DIFF
--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -39,6 +39,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "instances.0.has_user_data"),
 					resource.TestCheckResourceAttr(resName, "instances.0.disk.#", "2"),
 					resource.TestCheckResourceAttr(resName, "instances.0.config.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "instances.0.config.0.id"),
 				),
 			},
 		},

--- a/linode/instance/flatten.go
+++ b/linode/instance/flatten.go
@@ -158,18 +158,12 @@ func flattenInstanceConfigs(
 
 		interfaces := make([]interface{}, len(config.Interfaces))
 		for i, ni := range config.Interfaces {
-			// Workaround for "222" responses for null IPAM
-			// addresses from the API.
-			// TODO: Remove this when issue is resolved.
-			if ni.IPAMAddress == "222" {
-				ni.IPAMAddress = ""
-			}
-
 			interfaces[i] = flattenConfigInterface(ni)
 		}
 
 		// Determine if swap exists and the size.  If it does not exist, swap_size=0
 		c := map[string]interface{}{
+			"id":           config.ID,
 			"root_device":  config.RootDevice,
 			"kernel":       config.Kernel,
 			"run_level":    string(config.RunLevel),

--- a/linode/instance/flatten_unit_test.go
+++ b/linode/instance/flatten_unit_test.go
@@ -246,6 +246,7 @@ func TestFlattenInstanceConfigs(t *testing.T) {
 
 	expectedConfigs := []map[string]interface{}{
 		{
+			"id":           1,
 			"root_device":  "/dev/sda",
 			"kernel":       "linode/latest-64bit",
 			"run_level":    "default",

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -261,6 +261,7 @@ func TestAccResourceInstance_config(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "swap_size", "0"),
 					resource.TestCheckResourceAttr(resName, "alerts.0.cpu", "60"),
 
+					resource.TestCheckResourceAttrSet(resName, "config.0.id"),
 					resource.TestCheckResourceAttr(resName, "config.0.run_level", "binbash"),
 					resource.TestCheckResourceAttr(resName, "config.0.virt_mode", "fullvirt"),
 					resource.TestCheckResourceAttr(resName, "config.0.memory_limit", "1024"),

--- a/linode/instance/schema_datasource.go
+++ b/linode/instance/schema_datasource.go
@@ -233,6 +233,11 @@ var instanceDataSourceSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"id": {
+					Type:        schema.TypeInt,
+					Description: "The unique ID of this Config.",
+					Computed:    true,
+				},
 				"label": {
 					Type:        schema.TypeString,
 					Description: "The Config's label for display purposes.  Also used by `boot_config_label`.",

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -468,6 +468,11 @@ var resourceSchema = map[string]*schema.Schema{
 		},
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"id": {
+					Type:        schema.TypeInt,
+					Description: "The unique ID of this Config.",
+					Computed:    true,
+				},
 				"label": {
 					Type:         schema.TypeString,
 					Description:  "The Config's label for display purposes.  Also used by `boot_config_label`.",


### PR DESCRIPTION
## 📝 Description

This change adds a new `id` field to nested configuration profiles in the `linode_instance` resource, which allows users to easily reference their config by ID in other resources and outputs.

## ✔️ How to Test

Acceptance Tests:

```
make PKG_NAME=linode/instance testacc
```

Manual Testing:

Inside of a provider development environment (e.g. dx-devenv):

1. Add the following configuration inside of `main.tf`:

```terraform
resource "random_password" "password" {
  length  = 16
  special = true
}

resource "linode_instance" "foobar" {
  label      = "foobar"
  region     = "us-east"
  type       = "g6-nanode-1"
  image = "linode/ubuntu22.04"
  root_pass = random_password.password.result
}

output "config_id" {
  value = linode_instance.foobar.config.0.id
}
```

2. Run `terraform init -upgrade` to install the random provider.
3. Run `make apply` to apply the configuration.
4. Observe the implicit config ID in the output. 