### PR TITLE
Add `ComputeS3EndpointFromBucket` helper function

### DIFF
--- a/linode/helper/objects.go
+++ b/linode/helper/objects.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
 )
 
 const (
@@ -57,7 +58,11 @@ func ComputeS3Endpoint(ctx context.Context, d *schema.ResourceData, meta interfa
 		return "", fmt.Errorf("failed to find the specified Linode ObjectStorageBucket: %s", err)
 	}
 
-	return strings.TrimPrefix(b.Hostname, fmt.Sprintf("%s.", bucket)), nil
+	return ComputeS3EndpointFromBucket(*b), nil
+}
+
+func ComputeS3EndpointFromBucket(bucket linodego.ObjectStorageBucket) string {
+	return strings.TrimPrefix(bucket.Hostname, fmt.Sprintf("%s.", bucket.Label))
 }
 
 func BuildObjectStorageObjectID(d *schema.ResourceData) string {

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -74,7 +74,7 @@ func readResource(
 	// Functionality requiring direct S3 API access
 	accessKey := d.Get("access_key").(string)
 	secretKey := d.Get("secret_key").(string)
-	endpoint := strings.TrimPrefix(bucket.Hostname, fmt.Sprintf("%s.", bucket.Label))
+	endpoint := helper.ComputeS3EndpointFromBucket(*bucket)
 
 	_, versioningPresent := d.GetOk("versioning")
 	_, lifecyclePresent := d.GetOk("lifecycle_rule")
@@ -102,7 +102,6 @@ func readResource(
 	d.Set("cluster", bucket.Cluster)
 	d.Set("label", bucket.Label)
 	d.Set("hostname", bucket.Hostname)
-	d.Set("endpoint", strings.TrimPrefix(bucket.Hostname, fmt.Sprintf("%s.", bucket.Label)))
 	d.Set("acl", access.ACL)
 	d.Set("cors_enabled", access.CorsEnabled)
 	d.Set("endpoint", endpoint)
@@ -132,7 +131,7 @@ func createResource(
 		return diag.Errorf("failed to create a Linode ObjectStorageBucket: %s", err)
 	}
 
-	d.Set("endpoint", strings.TrimPrefix(bucket.Hostname, fmt.Sprintf("%s.", bucket.Label)))
+	d.Set("endpoint", helper.ComputeS3EndpointFromBucket(*bucket))
 	d.SetId(fmt.Sprintf("%s:%s", bucket.Cluster, bucket.Label))
 
 	return updateResource(ctx, d, meta)


### PR DESCRIPTION
## 📝 Description

This is a little cleanup for the [previous change](https://github.com/linode/terraform-provider-linode/pull/1090).

## ✔️ How to Test

`make PKG_NAME="linode/obj" testacc`
`make PKG_NAME="linode/objbucket" testacc`