### PR TITLE
fix: edit test.yml to allow gha to mark build as x when tests fail

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: go install github.com/jstemmer/go-junit-report/v2@latest
 
       - name: Run Integration Tests
-      - run: |
+        run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_terraform_test_report.log"        
           

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,6 +9,8 @@ jobs:
   integration_tests:
     name: Run integration tests
     runs-on: ubuntu-latest
+    env:
+      EXIT_STATUS: 0
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
@@ -37,22 +39,26 @@ jobs:
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report/v2@latest
 
+      - name: Run Integration Tests
       - run: |
           timestamp=$(date +'%Y%m%d%H%M')
-          report_filename="${timestamp}_terraform_test_report.json"
-          make testacc TESTARGS="-json" | tee "$report_filename"
+          report_filename="${timestamp}_terraform_test_report.log"        
+          
+          if ! make PKG_NAME="linode/firewall" TESTARGS="2>&1" testacc > "$report_filename"; then
+            echo "EXIT_STATUS=1" >> $GITHUB_ENV
+          fi
+          cat "$report_filename"
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
 
       - name: Convert JSON Report to XML
         run: |
-          filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.json')
-
+          filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.log')
           if [ -f "$filename" ]; then
             go_junit_report_dir=$(go env GOPATH)/bin
             export PATH="$PATH:$go_junit_report_dir"
             xml_filename=$(echo "$filename" | sed 's/\.json$/.xml/')
-            go-junit-report < "$filename" > "$xml_filename"
+            go-junit-report -in "$filename" -iocopy -out "$xml_filename"
             echo "Conversion from JSON to XML completed successfully."
           else
             echo "JSON test report file not found."
@@ -77,3 +83,12 @@ jobs:
         env:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
+
+      - name: Test Execution Status Handler
+        run: |
+          if [[ "$EXIT_STATUS" != 0 ]]; then
+            echo "Test execution contains failure(s)"
+            exit $EXIT_STATUS 
+          else
+            echo "Tests passed!"
+          fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -57,7 +57,7 @@ jobs:
           if [ -f "$filename" ]; then
             go_junit_report_dir=$(go env GOPATH)/bin
             export PATH="$PATH:$go_junit_report_dir"
-            xml_filename=$(echo "$filename" | sed 's/\.json$/.xml/')
+            xml_filename=$(echo "$filename" | sed 's/\.log$/.xml/')
             go-junit-report -in "$filename" -iocopy -out "$xml_filename"
             echo "Conversion from JSON to XML completed successfully."
           else
@@ -69,7 +69,6 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
-          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
+          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -44,14 +44,14 @@ jobs:
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_terraform_test_report.log"        
           
-          if ! make PKG_NAME="linode/firewall" TESTARGS="2>&1" testacc > "$report_filename"; then
+          if ! make TESTARGS="2>&1" testacc > "$report_filename"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat "$report_filename"
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
 
-      - name: Convert JSON Report to XML
+      - name: Convert test report to XML
         run: |
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.log')
           if [ -f "$filename" ]; then
@@ -59,9 +59,9 @@ jobs:
             export PATH="$PATH:$go_junit_report_dir"
             xml_filename=$(echo "$filename" | sed 's/\.log$/.xml/')
             go-junit-report -in "$filename" -iocopy -out "$xml_filename"
-            echo "Conversion from JSON to XML completed successfully."
+            echo "Covert to XML completed successfully."
           else
-            echo "JSON test report file not found."
+            echo "Test report file not found."
             exit 1
           fi
         env:

--- a/makefile
+++ b/makefile
@@ -49,7 +49,7 @@ testacc: fmtcheck
 	TF_ACC=1 \
 	LINODE_API_VERSION="v4beta" \
 	RUN_LONG_TESTS=$(RUN_LONG_TESTS) \
-	go test --tags=integration -v ./$(PKG_NAME) $(TESTARGS) -count $(ACCTEST_COUNT) -timeout $(ACCTEST_TIMEOUT) -parallel=$(ACCTEST_PARALLELISM) -ldflags="-X=github.com/linode/terraform-provider-linode/version.ProviderVersion=acc"
+	go test --tags=integration -v ./$(PKG_NAME) -count $(ACCTEST_COUNT) -timeout $(ACCTEST_TIMEOUT) -parallel=$(ACCTEST_PARALLELISM) -ldflags="-X=github.com/linode/terraform-provider-linode/version.ProviderVersion=acc" $(TESTARGS)
 
 smoketest: fmtcheck
 	TF_ACC=1 \


### PR DESCRIPTION
## 📝 Description

For most DX repositories, the failing tests are no longer reported on GitHub.

If tests failed, the red cross mark (×) is shown instead of the green check mark.

## ✔️ How to Test

Need final verification with the corresponding integration test workflow after merging to main/dev branch

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**