### PR TITLE
test: change generated test report to acceptable xml for TOD

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -42,30 +42,13 @@ jobs:
       - name: Run Integration Tests
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
-          report_filename="${timestamp}_terraform_test_report.log"        
-          
-          if ! make testacc > "$report_filename"; then
+          report_filename="${timestamp}_terraform_test_report.xml"        
+          if ! make testacc > | go-junit-report -set-exit-code > "$report_filename"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat "$report_filename"
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
-
-      - name: Convert test report to XML
-        run: |
-          filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.log')
-          if [ -f "$filename" ]; then
-            go_junit_report_dir=$(go env GOPATH)/bin
-            export PATH="$PATH:$go_junit_report_dir"
-            xml_filename=$(echo "$filename" | sed 's/\.log$/.xml/')
-            go-junit-report -in "$filename" -iocopy -out "$xml_filename"
-            echo "Covert to XML completed successfully."
-          else
-            echo "Test report file not found."
-            exit 1
-          fi
-        env:
-          GO111MODULE: on
 
       - name: Add additional information to XML report
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
+          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,7 +69,6 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
-          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_terraform_test_report.xml"        
-          if ! make testacc > | go-junit-report -set-exit-code > "$report_filename"; then
+          if ! make testacc | go-junit-report -set-exit-code > "$report_filename"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat "$report_filename"

--- a/linode/databasepostgresql/resource_test.go
+++ b/linode/databasepostgresql/resource_test.go
@@ -76,11 +76,6 @@ func sweep(prefix string) error {
 }
 
 func TestAccResourceDatabasePostgres_basic_smoke(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
-	t.Parallel()
-
 	resName := "linode_database_postgresql.foobar"
 	dbName := acctest.RandomWithPrefix("tf_test")
 

--- a/linode/databasepostgresql/resource_test.go
+++ b/linode/databasepostgresql/resource_test.go
@@ -76,6 +76,8 @@ func sweep(prefix string) error {
 }
 
 func TestAccResourceDatabasePostgres_basic_smoke(t *testing.T) {
+	t.Parallel()
+	
 	resName := "linode_database_postgresql.foobar"
 	dbName := acctest.RandomWithPrefix("tf_test")
 

--- a/linode/databasepostgresql/resource_test.go
+++ b/linode/databasepostgresql/resource_test.go
@@ -77,7 +77,7 @@ func sweep(prefix string) error {
 
 func TestAccResourceDatabasePostgres_basic_smoke(t *testing.T) {
 	t.Parallel()
-	
+
 	resName := "linode_database_postgresql.foobar"
 	dbName := acctest.RandomWithPrefix("tf_test")
 

--- a/linode/databasepostgresql/resource_test.go
+++ b/linode/databasepostgresql/resource_test.go
@@ -76,6 +76,9 @@ func sweep(prefix string) error {
 }
 
 func TestAccResourceDatabasePostgres_basic_smoke(t *testing.T) {
+	if os.Getenv("RUN_LONG_TESTS") != "true" {
+		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
+	}
 	t.Parallel()
 
 	resName := "linode_database_postgresql.foobar"

--- a/scripts/test_report_upload_script.py
+++ b/scripts/test_report_upload_script.py
@@ -44,9 +44,8 @@ def change_xml_report_to_tod_acceptable_version(file_name):
             new_testcase.append(child)
 
     # Save the new XML to a file
-    new_tree = ET.ElementTree(new_testsuites)
     try:
-        new_tree = ET.ElementTree(root)
+        new_tree = ET.ElementTree(new_testsuites)
         new_tree.write(file_name, encoding="UTF-8", xml_declaration=True)
         print("XML content successfully over-written to " + file_name)
 

--- a/scripts/test_report_upload_script.py
+++ b/scripts/test_report_upload_script.py
@@ -1,6 +1,7 @@
 import boto3
 import sys
 import os
+import xml.etree.ElementTree as ET
 from botocore.exceptions import NoCredentialsError
 
 ACCESS_KEY = os.environ.get('LINODE_CLI_OBJ_ACCESS_KEY')
@@ -13,6 +14,45 @@ linode_obj_config = {
     "endpoint_url": "https://us-southeast-1.linodeobjects.com",
     "region_name": "us-southeast-1",
 }
+
+def change_xml_report_to_tod_acceptable_version(file_name):
+    # Load the original XML file
+    tree = ET.parse(file_name)
+    root = tree.getroot()
+
+    testsuites_element = root
+
+    # total
+    total_tests = int(testsuites_element.get('tests'))
+    total_failures = int(testsuites_element.get('failures'))
+    total_errors = int(testsuites_element.get('errors'))
+    total_skipped = int(testsuites_element.get('skipped'))
+
+    # Create a new <testsuites> element with aggregated values
+    new_testsuites = ET.Element("testsuites")
+    new_testsuites.set("tests", str(total_tests))
+    new_testsuites.set("failures", str(total_failures))
+    new_testsuites.set("errors", str(total_errors))
+    new_testsuites.set("skipped", str(total_skipped))
+
+    # Create a new <testsuite> element under <testsuites>
+    new_testsuite = ET.SubElement(new_testsuites, "testsuite", attrib=testsuites_element.attrib)
+
+    for testcase in root.findall('.//testcase'):
+        new_testcase = ET.SubElement(new_testsuite, "testcase", attrib=testcase.attrib)
+        for child in testcase:
+            new_testcase.append(child)
+
+    # Save the new XML to a file
+    new_tree = ET.ElementTree(new_testsuites)
+    try:
+        new_tree = ET.ElementTree(root)
+        new_tree.write(file_name, encoding="UTF-8", xml_declaration=True)
+        print("XML content successfully over-written to " + file_name)
+
+    except Exception as e:
+        print("Error writing XML content:", str(e))
+
 
 
 def upload_to_linode_object_storage(file_name):
@@ -38,4 +78,5 @@ if __name__ == '__main__':
         print('Error: The provided file name is empty or invalid.')
         sys.exit(1)
 
+    change_xml_report_to_tod_acceptable_version(file_name)
     upload_to_linode_object_storage(file_name)


### PR DESCRIPTION
## 📝 Description

Workaround for this issue - https://jira.linode.com/browse/QE-334

For some context, I had a change in earlier this week improving xml test report to contain more information about the test run. However, this xml report that was generated caused some issue with TOD (issue linked above) due to multiple `testsuite` parameter in the report.

Fix:

Modified our exsiting test upload script to change the xml report to acceptable one by TOD

## ✔️ How to Test

Tested locally on test instance of TOD - http://198.19.5.79:7272/builds/654bd13d8e31d3000134a4a5?team=DX%20Team&buildName=test_new&bld_id=654bd13d8e31d3000134a4a5

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**