### PR TITLE
test: Refactor `RUN_LONG_TESTS` system; skip all DBaaS tests

### DIFF
--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -30,6 +30,10 @@ import (
 const (
 	optInTestsEnvVar         = "ACC_OPT_IN_TESTS"
 	SkipInstanceReadyPollKey = "skip_instance_ready_poll"
+
+	runLongTestsEnvVar  = "RUN_LONG_TEST"
+	skipLongTestMessage = "This test has been marked as a long-running test and is skipped by default." +
+		"If you would like to run this test, please set the RUN_LONG_TEST environment variable to true."
 )
 
 type AttrValidateFunc func(val string) error
@@ -155,6 +159,24 @@ func OptInTest(t *testing.T) {
 
 	if _, ok := optInTests[t.Name()]; !ok {
 		t.Skipf("skipping opt-in test; specify test in environment variable %q to run", optInTestsEnvVar)
+	}
+}
+
+func LongRunningTest(t *testing.T) {
+	t.Helper()
+
+	shouldRunStr := os.Getenv(runLongTestsEnvVar)
+	if len(shouldRunStr) == 0 {
+		t.Skip(skipLongTestMessage)
+	}
+
+	shouldRun, err := strconv.ParseBool(shouldRunStr)
+	if err != nil {
+		t.Fatalf("failed to parse %s as bool: %s", runLongTestsEnvVar, err)
+	}
+
+	if !shouldRun {
+		t.Skip(skipLongTestMessage)
 	}
 }
 

--- a/linode/databaseaccesscontrols/resource_test.go
+++ b/linode/databaseaccesscontrols/resource_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"testing"
 
@@ -54,9 +53,7 @@ func init() {
 }
 
 func TestAccResourceDatabaseAccessControls_MySQL(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	resName := "linode_database_access_controls.foobar"
@@ -93,9 +90,7 @@ func TestAccResourceDatabaseAccessControls_MySQL(t *testing.T) {
 }
 
 func TestAccResourceDatabaseAccessControls_PostgreSQL(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	resName := "linode_database_access_controls.foobar"

--- a/linode/databasebackups/datasource_test.go
+++ b/linode/databasebackups/datasource_test.go
@@ -5,7 +5,6 @@ package databasebackups_test
 import (
 	"context"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -44,9 +43,7 @@ func init() {
 }
 
 func TestAccDataSourcePostgresBackups_basic(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	var db linodego.PostgresDatabase

--- a/linode/databasemysql/datasource_test.go
+++ b/linode/databasemysql/datasource_test.go
@@ -3,7 +3,6 @@
 package databasemysql_test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -14,9 +13,7 @@ import (
 )
 
 func TestAccDataSourceDatabaseMySQL_basic(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	resName := "data.linode_database_mysql.foobar"

--- a/linode/databasemysql/resource_test.go
+++ b/linode/databasemysql/resource_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -99,9 +98,8 @@ func TestResourceDatabaseMySQL_expandFlatten(t *testing.T) {
 }
 
 func TestAccResourceDatabaseMySQL_basic(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
+	acceptance.LongRunningTest(t)
+
 	t.Parallel()
 
 	resName := "linode_database_mysql.foobar"
@@ -149,9 +147,7 @@ func TestAccResourceDatabaseMySQL_basic(t *testing.T) {
 }
 
 func TestAccResourceDatabaseMySQL_complex(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	resName := "linode_database_mysql.foobar"

--- a/linode/databasemysqlbackups/datasource_test.go
+++ b/linode/databasemysqlbackups/datasource_test.go
@@ -5,7 +5,6 @@ package databasemysqlbackups_test
 import (
 	"context"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -43,9 +42,7 @@ func init() {
 }
 
 func TestAccDataSourceMySQLBackups_basic(t *testing.T) {
-	if os.Getenv("RUN_LONG_TESTS") != "true" {
-		t.Skip("Skipping test if RUN_LONG_TESTS environment variable is not set or not true.")
-	}
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	var db linodego.MySQLDatabase

--- a/linode/databasepostgresql/datasource_test.go
+++ b/linode/databasepostgresql/datasource_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccDataSourceDatabasePostgres_basic(t *testing.T) {
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	resName := "data.linode_database_postgresql.foobar"

--- a/linode/databasepostgresql/resource_test.go
+++ b/linode/databasepostgresql/resource_test.go
@@ -76,6 +76,8 @@ func sweep(prefix string) error {
 }
 
 func TestAccResourceDatabasePostgres_basic_smoke(t *testing.T) {
+	acceptance.LongRunningTest(t)
+
 	t.Parallel()
 
 	resName := "linode_database_postgresql.foobar"
@@ -123,6 +125,8 @@ func TestAccResourceDatabasePostgres_basic_smoke(t *testing.T) {
 }
 
 func TestAccResourceDatabasePostgres_complex(t *testing.T) {
+	acceptance.LongRunningTest(t)
+
 	t.Parallel()
 
 	resName := "linode_database_postgresql.foobar"

--- a/linode/databases/datasource_test.go
+++ b/linode/databases/datasource_test.go
@@ -41,6 +41,7 @@ func init() {
 }
 
 func TestAccDataSourceDatabases_byAttr(t *testing.T) {
+	acceptance.LongRunningTest(t)
 	t.Parallel()
 
 	resourceName := "data.linode_databases.foobar"


### PR DESCRIPTION
## 📝 Description

This change refactors the `RUN_LONG_TESTS` logic into a single helper function that can be called at the beginning of tests. Additionally, this PR disables all tests that provision a Managed Database unless `RUN_LONG_TESTS` is set to true.

## ✔️ How to Test

```
make PKG_NAME=linode/databaseaccesscontrols testacc
make PKG_NAME=linode/databasebackups testacc
make PKG_NAME=linode/databaseengines testacc
make PKG_NAME=linode/databasemysql testacc
make PKG_NAME=linode/databasemysqlbackups testacc
make PKG_NAME=linode/databasepostgresql testacc
make PKG_NAME=linode/databases testacc
```

For each of these test commands, observe that all database-provisioning tests are skipped.
