### PR TITLE
Add make tooldeps to workflows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           go-version: 'stable'
       - run: go version
+      - run: make tooldeps
 
       - name: Update system packages
         run: sudo apt-get update -y

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           go-version: 'stable'
       - run: go version
+      - run: make tooldeps
 
       - uses: actions/github-script@v6
         id: disallowed-character-check


### PR DESCRIPTION
Since the [cleanup PR](https://github.com/linode/terraform-provider-linode/pull/1101) merged, we would need `golangci-lint` for integration test workflows.