### PR TITLE
new: Add support for Unified Migrations

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -79,7 +79,7 @@ The following arguments apply to uploading an image:
 
 ### Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 20 mins) Used when creating the instance image (until the instance is available)
 

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -270,7 +270,7 @@ The following arguments are available in an `ipv4` configuration block of an `in
 
 ### Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when launching the instance (until it reaches the initial `running` state)
 * `update` - (Defaults to 1 hour) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -94,7 +94,7 @@ resource "linode_instance_config" "boot_config" {
 
 The following arguments are supported:
 
-* `region` - (Required) This is the location where the Linode is deployed. Examples are `"us-east"`, `"us-west"`, `"ap-south"`, etc. See all regions [here](https://api.linode.com/v4/regions). *Changing `region` forces the creation of a new Linode Instance.*.
+* `region` - (Required) This is the location where the Linode is deployed. Examples are `"us-east"`, `"us-west"`, `"ap-south"`, etc. See all regions [here](https://api.linode.com/v4/regions). *Changing `region` will trigger a migration of this Linode. Migration operations are typically long-running operations, so the [update timeout](#timeouts) should be adjusted accordingly.*.
 
 * `type` - (Required) The Linode type defines the pricing, CPU, disk, and RAM specs of the instance. Examples are `"g6-nanode-1"`, `"g6-standard-2"`, `"g6-highmem-16"`, `"g6-dedicated-16"`, etc. See all types [here](https://api.linode.com/v4/linode/types).
 
@@ -129,6 +129,8 @@ The following arguments are supported:
 * `watchdog_enabled` - (Optional) The watchdog, named Lassie, is a Shutdown Watchdog that monitors your Linode and will reboot it if it powers off unexpectedly. It works by issuing a boot job when your Linode powers off without a shutdown job being responsible. To prevent a loop, Lassie will give up if there have been more than 5 boot jobs issued within 15 minutes.
 
 * `booted` - (Optional) If true, then the instance is kept or converted into in a running state. If false, the instance will be shutdown. If unspecified, the Linode's power status will not be managed by the Provider.
+
+* `migration_type` - (Optional) The type of migration to use when updating the type or region of a Linode. (`cold`, `warm`; default `cold`)
 
 * [`interface`](#interface) - (Optional) A list of network interfaces to be assigned to the Linode on creation. If an explicit config or disk is defined, interfaces must be declared in the [`config` block](#configs).
 
@@ -271,7 +273,7 @@ The following arguments are available in an `ipv4` configuration block of an `in
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when launching the instance (until it reaches the initial `running` state)
-* `update` - (Defaults to 20 mins) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
+* `update` - (Defaults to 1 hour) Used when stopping and starting the instance when necessary during update - e.g. when changing instance type
 * `delete` - (Defaults to 10 mins) Used when terminating the instance
 
 ## Attributes Reference

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 ### Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when creating the volume (until the volume is reaches the initial `active` state)
 * `update` - (Defaults to 20 mins) Used when updating the volume when necessary during update - e.g. when resizing the volume

--- a/go.mod
+++ b/go.mod
@@ -108,4 +108,4 @@ require (
 
 // Temporary replacement, replace with project branch once
 // Zhiwei's PR is merged.
-replace github.com/linode/linodego => github.com/zliang-akamai/linodego v1.16.2-0.20231117064335-cddc6f17d034
+replace github.com/linode/linodego => github.com/linode/linodego v1.25.1-0.20231128213456-3a4cc7014c2e

--- a/go.mod
+++ b/go.mod
@@ -105,3 +105,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+// Temporary replacement, replace with project branch once
+// Zhiwei's PR is merged.
+replace github.com/linode/linodego => github.com/zliang-akamai/linodego v1.16.2-0.20231117064335-cddc6f17d034

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/linode/linodego v1.25.1-0.20231128213456-3a4cc7014c2e h1:g+Yst9q7MtK6XbS79ploRb1Q7IQkMHDHlKQ3d8nIcDE=
+github.com/linode/linodego v1.25.1-0.20231128213456-3a4cc7014c2e/go.mod h1:yOHXDjg7qgbMi4XTvWeygxPiKEClgQ/CumSOSD8x6nw=
 github.com/linode/linodego/k8s v1.25.1 h1:sEUQBTlEshfREzrifLb9aRPLHfmf1tNjyfBegJEBtFg=
 github.com/linode/linodego/k8s v1.25.1/go.mod h1:FYYpvcixQYOs6Rm5kEmfBE3bO6YkwtfjMRuwcQStjJs=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -197,8 +199,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA=
 github.com/zclconf/go-cty v1.14.1/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zliang-akamai/linodego v1.16.2-0.20231117064335-cddc6f17d034 h1:353pxK2ki1nDezQs/1BVjzXhDBedAbIXtPT2h7gXSPY=
-github.com/zliang-akamai/linodego v1.16.2-0.20231117064335-cddc6f17d034/go.mod h1:yOHXDjg7qgbMi4XTvWeygxPiKEClgQ/CumSOSD8x6nw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
-github.com/linode/linodego v1.25.0 h1:zYMz0lTasD503jBu3tSRhzEmXHQN1zptCw5o71ibyyU=
-github.com/linode/linodego v1.25.0/go.mod h1:BMZI0pMM/YGjBis7pIXDPbcgYfCZLH0/UvzqtsGtG1c=
 github.com/linode/linodego/k8s v1.25.1 h1:sEUQBTlEshfREzrifLb9aRPLHfmf1tNjyfBegJEBtFg=
 github.com/linode/linodego/k8s v1.25.1/go.mod h1:FYYpvcixQYOs6Rm5kEmfBE3bO6YkwtfjMRuwcQStjJs=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -199,6 +197,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA=
 github.com/zclconf/go-cty v1.14.1/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
+github.com/zliang-akamai/linodego v1.16.2-0.20231117064335-cddc6f17d034 h1:353pxK2ki1nDezQs/1BVjzXhDBedAbIXtPT2h7gXSPY=
+github.com/zliang-akamai/linodego v1.16.2-0.20231117064335-cddc6f17d034/go.mod h1:yOHXDjg7qgbMi4XTvWeygxPiKEClgQ/CumSOSD8x6nw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,9 +37,11 @@ const (
 		"If you would like to run this test, please set the RUN_LONG_TEST environment variable to true."
 )
 
-type AttrValidateFunc func(val string) error
-
-type ListAttrValidateFunc func(resourceName, path string, state *terraform.State) error
+type (
+	AttrValidateFunc     func(val string) error
+	ListAttrValidateFunc func(resourceName, path string, state *terraform.State) error
+	RegionFilterFunc     func(v linodego.Region) bool
+)
 
 var (
 	optInTests               map[string]struct{}
@@ -569,9 +572,7 @@ func ModifyProviderMeta(provider *schema.Provider, modifier ProviderMetaModifier
 }
 
 // GetRegionsWithCaps returns a list of regions that support the given capabilities.
-func GetRegionsWithCaps(capabilities []string) ([]string, error) {
-	result := make([]string, 0)
-
+func GetRegionsWithCaps(capabilities []string, filters ...RegionFilterFunc) ([]string, error) {
 	client, err := GetTestClient()
 	if err != nil {
 		return nil, err
@@ -582,36 +583,46 @@ func GetRegionsWithCaps(capabilities []string) ([]string, error) {
 		return nil, err
 	}
 
-	regionHasCaps := func(r linodego.Region) bool {
+	// Filter on capabilities
+	regionsWithCaps := slices.DeleteFunc(regions, func(region linodego.Region) bool {
 		capsMap := make(map[string]bool)
 
-		for _, c := range r.Capabilities {
+		for _, c := range region.Capabilities {
 			capsMap[strings.ToUpper(c)] = true
 		}
 
 		for _, c := range capabilities {
 			if _, ok := capsMap[strings.ToUpper(c)]; !ok {
-				return false
+				return true
 			}
 		}
 
-		return true
-	}
+		return false
+	})
 
-	for _, region := range regions {
-		if region.Status != "ok" || !regionHasCaps(region) {
-			continue
+	// Apply test-supplied filters
+	filteredRegions := slices.DeleteFunc(regionsWithCaps, func(region linodego.Region) bool {
+		for _, filter := range filters {
+			if !filter(region) {
+				return true
+			}
 		}
 
-		result = append(result, region.ID)
+		return false
+	})
+
+	result := make([]string, len(filteredRegions))
+
+	for i, r := range filteredRegions {
+		result[i] = r.ID
 	}
 
 	return result, nil
 }
 
 // GetRandomRegionWithCaps gets a random region given a list of region capabilities.
-func GetRandomRegionWithCaps(capabilities []string) (string, error) {
-	regions, err := GetRegionsWithCaps(capabilities)
+func GetRandomRegionWithCaps(capabilities []string, filters ...RegionFilterFunc) (string, error) {
+	regions, err := GetRegionsWithCaps(capabilities, filters...)
 	if err != nil {
 		return "", err
 	}

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -32,7 +32,7 @@ const (
 	SkipInstanceReadyPollKey = "skip_instance_ready_poll"
 
 	runLongTestsEnvVar  = "RUN_LONG_TEST"
-	skipLongTestMessage = "This test has been marked as a long-running test and is skipped by default." +
+	skipLongTestMessage = "This test has been marked as a long-running test and is skipped by default. " +
 		"If you would like to run this test, please set the RUN_LONG_TEST environment variable to true."
 )
 

--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -727,6 +727,7 @@ func changeInstanceType(
 	client *linodego.Client,
 	instanceID int,
 	targetType string,
+	migrationType linodego.InstanceMigrationType,
 	diskResize bool,
 	d *schema.ResourceData,
 ) (*linodego.Instance, error) {
@@ -748,6 +749,7 @@ func changeInstanceType(
 	resizeOpts := linodego.InstanceResizeOptions{
 		AllowAutoDiskResize: &diskResize,
 		Type:                targetType,
+		MigrationType:       migrationType,
 	}
 
 	tflog.Debug(ctx, "Resizing instance", map[string]any{
@@ -981,6 +983,10 @@ func applyInstanceTypeChange(
 	typ *linodego.LinodeType,
 ) (*linodego.Instance, error) {
 	resizeDisk := d.Get("resize_disk").(bool)
+	migrationType := linodego.InstanceMigrationType(
+		d.Get("migration_type").(string),
+	)
+
 	if resizeDisk {
 		// Verify that there are implicit disks defined
 		if d.GetRawConfig().GetAttr("image").IsNull() && d.GetRawConfig().GetAttr("disk").LengthInt() > 0 {
@@ -1005,7 +1011,7 @@ func applyInstanceTypeChange(
 		return nil, err
 	}
 
-	return changeInstanceType(ctx, client, instance.ID, typ.ID, resizeDisk, d)
+	return changeInstanceType(ctx, client, instance.ID, typ.ID, migrationType, resizeDisk, d)
 }
 
 // detachConfigVolumes detaches any volumes associated with an InstanceConfig.Devices struct.

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	LinodeInstanceCreateTimeout = 15 * time.Minute
-	LinodeInstanceUpdateTimeout = 25 * time.Minute
+	LinodeInstanceUpdateTimeout = time.Hour
 	LinodeInstanceDeleteTimeout = 10 * time.Minute
 )
 

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -607,6 +607,21 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 		rebootInstance = true
 	}
 
+	// If the region has changed,
+	// we should migrate the Linode.
+	if d.HasChange("region") {
+		instance, err = applyInstanceMigration(
+			ctx,
+			d,
+			&client,
+			instance,
+			d.Get("region").(string),
+		)
+		if err != nil {
+			return diag.Errorf("failed to migrate instance: %s", err)
+		}
+	}
+
 	oldSpec, newSpec, err := getInstanceTypeChange(ctx, d, &client)
 	if err != nil {
 		return diag.Errorf("Error getting resize info for instance: %s", err)

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 	"strconv"
 	"sync"
@@ -22,7 +21,7 @@ import (
 	"github.com/linode/terraform-provider-linode/linode/instance/tmpl"
 )
 
-var testRegion string
+var testRegion = "us-east"
 
 func init() {
 	resource.AddTestSweepers("linode_instance", &resource.Sweeper{
@@ -30,12 +29,12 @@ func init() {
 		F:    sweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{"Vlans", "VPCs"})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	testRegion = region
+	//region, err := acceptance.GetRandomRegionWithCaps([]string{"Vlans", "VPCs"})
+	//if err != nil {
+	//	log.Fatal(err)
+	//}
+	//
+	//testRegion = region
 }
 
 func sweep(prefix string) error {
@@ -1702,6 +1701,15 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 			{
 				Config:      tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", testRegion, true),
 				ExpectError: regexp.MustCompile("Did you try to resize a linode with implicit"),
+			},
+			// Run a warm resize
+			{
+				Config: tmpl.TypeChangeWarm(t, instanceName, "g6-standard-1", testRegion, false),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "type", "g6-standard-1"),
+				),
 			},
 		},
 	})

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -92,7 +92,7 @@ func TestAccResourceInstance_basic_smoke(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -152,7 +152,7 @@ func TestAccResourceInstance_authorizedUsers(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_users", "image", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_users", "image", "resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -231,7 +231,7 @@ func TestAccResourceInstance_interfaces(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -274,7 +274,7 @@ func TestAccResourceInstance_config(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -311,7 +311,7 @@ func TestAccResourceInstance_configPair(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -379,7 +379,7 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -431,7 +431,7 @@ func TestAccResourceInstance_configInterfacesNoReboot(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk", "boot_config_label"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "boot_config_label", "migration_type"},
 			},
 		},
 	})
@@ -493,7 +493,7 @@ func TestAccResourceInstance_disk(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -531,7 +531,7 @@ func TestAccResourceInstance_diskImage(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -571,7 +571,7 @@ func TestAccResourceInstance_diskPair(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -610,7 +610,7 @@ func TestAccResourceInstance_diskAndConfig(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -658,7 +658,7 @@ func TestAccResourceInstance_disksAndConfigs(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -704,7 +704,7 @@ func TestAccResourceInstance_volumeAndConfig(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -742,7 +742,7 @@ func TestAccResourceInstance_privateImage(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -775,7 +775,7 @@ func TestAccResourceInstance_noImage(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"resize_disk"},
+				ImportStateVerifyIgnore: []string{"resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -911,7 +911,7 @@ func TestAccResourceInstance_configPairUpdate(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label", "status", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "status", "resize_disk", "migration_type"},
 			},
 			{
 				Config: tmpl.WithConfig(t, instanceName, testRegion),
@@ -931,7 +931,7 @@ func TestAccResourceInstance_configPairUpdate(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_config_label", "status", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"boot_config_label", "status", "resize_disk", "migration_type"},
 			},
 			{
 				Config: tmpl.ConfigsAllUpdated(t, instanceName, testRegion),
@@ -1597,7 +1597,7 @@ func TestAccResourceInstance_stackScriptInstance(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       false,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -1636,7 +1636,7 @@ func TestAccResourceInstance_diskImageUpdate(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       false,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "migration_type"},
 			},
 		},
 	})
@@ -1702,15 +1702,6 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 			{
 				Config:      tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", testRegion, true),
 				ExpectError: regexp.MustCompile("Did you try to resize a linode with implicit"),
-			},
-			// Run a warm resize
-			{
-				Config: tmpl.TypeChangeWarm(t, instanceName, "g6-standard-1", testRegion, false),
-				Check: resource.ComposeTestCheckFunc(
-					acceptance.CheckInstanceExists(resName, &instance),
-					resource.TestCheckResourceAttr(resName, "label", instanceName),
-					resource.TestCheckResourceAttr(resName, "type", "g6-standard-1"),
-				),
 			},
 		},
 	})
@@ -2159,7 +2150,7 @@ func TestAccResourceInstance_firewallOnCreation(t *testing.T) {
 				ResourceName:            instanceResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "firewall_id"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "firewall_id", "migration_type"},
 			},
 		},
 	})
@@ -2196,7 +2187,7 @@ func TestAccResourceInstance_VPCInterface(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk"},
+				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk", "migration_type"},
 			},
 		},
 	})

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -2204,7 +2204,7 @@ func TestAccResourceInstance_VPCInterface(t *testing.T) {
 func TestAccResourceInstance_migration(t *testing.T) {
 	// This is a very long-running test so we should
 	// only run it if necessary.
-	acceptance.OptInTest(t)
+	acceptance.LongRunningTest(t)
 
 	t.Parallel()
 

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -2201,6 +2201,48 @@ func TestAccResourceInstance_VPCInterface(t *testing.T) {
 	})
 }
 
+func TestAccResourceInstance_migration(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_instance.foobar"
+	var instance linodego.Instance
+	instanceName := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             acceptance.CheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Basic(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
+					resource.TestCheckResourceAttr(resName, "image", acceptance.TestImageLatest),
+					resource.TestCheckResourceAttr(resName, "region", testRegion),
+				),
+			},
+			{
+				Config: tmpl.Basic(t, instanceName, acceptance.PublicKeyMaterial, "us-mia"),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "label", instanceName),
+					resource.TestCheckResourceAttr(resName, "type", "g6-nanode-1"),
+					resource.TestCheckResourceAttr(resName, "image", acceptance.TestImageLatest),
+					resource.TestCheckResourceAttr(resName, "region", "us-mia"),
+				),
+			},
+			{
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "metadata"},
+			},
+		},
+	})
+}
+
 func checkInstancePrivateNetworkAttributes(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -2057,7 +2057,7 @@ func TestAccResourceInstance_userData(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "metadata"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "metadata", "migration_type"},
 			},
 		},
 	})
@@ -2202,6 +2202,10 @@ func TestAccResourceInstance_VPCInterface(t *testing.T) {
 }
 
 func TestAccResourceInstance_migration(t *testing.T) {
+	// This is a very long-running test so we should
+	// only run it if necessary.
+	acceptance.OptInTest(t)
+
 	t.Parallel()
 
 	resName := "linode_instance.foobar"
@@ -2237,7 +2241,7 @@ func TestAccResourceInstance_migration(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "metadata"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "metadata", "migration_type"},
 			},
 		},
 	})

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -2212,20 +2211,16 @@ func TestAccResourceInstance_migration(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
-	regions, err := acceptance.GetRegionsWithCaps([]string{"Linodes"})
+	// Resolve a region to migrate to
+	targetRegion, err := acceptance.GetRandomRegionWithCaps(
+		[]string{"Linodes"},
+		func(v linodego.Region) bool {
+			return v.ID != testRegion
+		},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	regionIndex := slices.IndexFunc(regions, func(s string) bool {
-		return s != testRegion
-	})
-
-	if regionIndex < 0 {
-		t.Fatal("Could not resolve adequate region for migrations")
-	}
-
-	targetRegion := regions[regionIndex]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -257,6 +257,15 @@ var resourceSchema = map[string]*schema.Schema{
 		Optional: true,
 		Default:  false,
 	},
+	"migration_type": {
+		Type:        schema.TypeString,
+		Description: "The type of migration to use for resize and migration operations.",
+		Optional:    true,
+		Default:     "cold",
+		ValidateDiagFunc: validation.ToDiagFunc(
+			validation.StringInSlice([]string{"cold", "warm"}, true),
+		),
+	},
 	"status": {
 		Type:        schema.TypeString,
 		Description: "The status of the instance, indicating the current readiness state.",

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -240,7 +240,6 @@ var resourceSchema = map[string]*schema.Schema{
 		Description: "This is the location where the Linode was deployed. This cannot be changed without " +
 			"opening a support ticket.",
 		Required:     true,
-		ForceNew:     true,
 		InputDefault: "us-east",
 	},
 	"type": {

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -492,6 +492,17 @@ func TypeChangeDiskNone(t *testing.T, label, instanceType, region string, resize
 		})
 }
 
+func TypeChangeWarm(t *testing.T, label, instanceType, region string, resizeDisk bool) string {
+	return acceptance.ExecuteTemplate(t,
+		"instance_type_change_warm", TemplateData{
+			Label:      label,
+			Type:       instanceType,
+			Image:      acceptance.TestImageLatest,
+			ResizeDisk: resizeDisk,
+			Region:     region,
+		})
+}
+
 func IPv4Sharing(t *testing.T, label, region string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_ipv4_sharing", TemplateData{

--- a/linode/instance/tmpl/templates/type_change_warm.gotf
+++ b/linode/instance/tmpl/templates/type_change_warm.gotf
@@ -1,0 +1,13 @@
+{{ define "instance_type_change_warm" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "{{.Type}}"
+    region = "{{ .Region }}"
+    image = "{{.Image}}"
+    resize_disk = true
+    migration_type = "warm"
+}
+
+{{ end }}


### PR DESCRIPTION
## 📝 Description

This change adds support for the following new linode_instance `migration_type` field introduced in Unified Migrations project. Additionally this change adds support for cross-region migrations on updates to the `region` field rather than just instance recreation.

## ✔️ How to Test

### E2E Testing:

**Cross-Region Migration**

NOTE: This test currently needs to be run against prod due to availability limitations.

```
export RUN_LONG_TEST=1

make PKG_NAME=linode/instance TESTARGS="-run TestAccResourceInstance_migration" testacc
```

**Resize Migration**

```
export LINODE_URL=...
export LINODE_TOKEN=...

make PKG_NAME=linode/instance TESTARGS="-run TestAccResourceInstance_typeChangeDiskImplicit" testacc
```

### Manual Testing

**TODO**