### PR TITLE
fix: Check for null SecondaryEntity when determining Linode boot config

### DIFF
--- a/linode/helper/instance.go
+++ b/linode/helper/instance.go
@@ -129,6 +129,11 @@ func GetCurrentBootedConfig(ctx context.Context, client *linodego.Client, instID
 		return 0, nil
 	}
 
+	// Special case for instances booted into rescue mode
+	if events[0].SecondaryEntity == nil {
+		return 0, nil
+	}
+
 	return int(events[0].SecondaryEntity.ID.(float64)), nil
 }
 


### PR DESCRIPTION
…mode

## 📝 Description

This change adds logic to gracefully handle a null SecondaryEntity in `GetCurrentBootedConfig`, which prevents a panic when an instance has been booted into rescue mode.

Resolves #1153 

## ✔️ How to Test

Automated Testing:

```
make PKG_NAME=linode/instanceconfig TESTARGS="-run TestAccResourceInstanceConfig_rescueBooted" testacc
```

Manual Testing:

1. Run the following Terraform configuration within a provider test environment (e.g. dx-devenv):

```terraform
resource "linode_instance" "foobar" {
  label      = "test_instance"
  region     = "us-central"
  type       = "g6-nanode-1"
  private_ip = true
}


resource "linode_instance_disk" "boot_disk" {
  label = "boot"
  linode_id = linode_instance.web.id

  size = 3000
  image  = "linode/ubuntu18.04"

  root_pass = "terr4form-test"
}

resource "linode_instance_config" "boot_config" {
  label = "boot_config"
  linode_id = linode_instance.web.id

  devices {
    sda {
      disk_id = linode_instance_disk.boot_disk.id
    }
  }

  root_device = "/dev/sda"
  kernel = "linode/latest-64bit"
  booted = true
}
```

2. Navigate to the newly created instance in Cloud Manager and reboot the instance into rescue mode.
3. Once the instance has been booted, re-apply the above Terraform configuration.
4. Observe the provider does not crash and registers the config's `booted` field as false.

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**