### PR TITLE
fix: Add reconciliation logic for simplified `linode_domain_record` names

### DIFF
--- a/linode/domainrecord/resource.go
+++ b/linode/domainrecord/resource.go
@@ -23,6 +23,10 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: importResource,
 		},
+		//CustomizeDiff: customdiff.All(
+		//	// suppressParentSuffix,
+		//	suppressEmptyName,
+		//),
 	}
 }
 
@@ -77,7 +81,12 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diag.Errorf("Error finding the specified Linode DomainRecord: %s", err)
 	}
 
-	d.Set("name", record.Name)
+	reconciledName, err := reconcileName(ctx, client, d, record.Name)
+	if err != nil {
+		return diag.Errorf("failed to reconcile domain record name: %s", err)
+	}
+
+	d.Set("name", reconciledName)
 	d.Set("port", record.Port)
 	d.Set("priority", record.Priority)
 	d.Set("protocol", record.Protocol)
@@ -202,4 +211,28 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 func domainRecordTargetSuppressor(k, provisioned, declared string, d *schema.ResourceData) bool {
 	return len(strings.Split(declared, ".")) == 1 &&
 		strings.Contains(provisioned, declared)
+}
+
+// reconcileName handles cases where the user has specified their FQDN as a part of their
+// planned record name but the API trims the FQDN from the returned record name.
+func reconcileName(ctx context.Context, client linodego.Client, d *schema.ResourceData, apiName string) (string, error) {
+	plannedName, ok := d.GetOk("name")
+	if !ok {
+		return apiName, nil
+	}
+
+	domain, err := client.GetDomain(ctx, d.Get("domain_id").(int))
+	if err != nil {
+		return "", fmt.Errorf("failed to get parent domain: %w", err)
+	}
+
+	simplifiedPlanName := strings.TrimSuffix(strings.TrimSuffix(plannedName.(string), domain.Domain), ".")
+
+	// If the API response matches the planned name with the FQDN removed,
+	// return the planned value.
+	if apiName == simplifiedPlanName {
+		return plannedName.(string), nil
+	}
+
+	return apiName, nil
 }

--- a/linode/domainrecord/tmpl/template.go
+++ b/linode/domainrecord/tmpl/template.go
@@ -71,6 +71,14 @@ func SRV(t *testing.T, domainName string, target string) string {
 		})
 }
 
+func WithDomain(t *testing.T, domainName, domainRecord string) string {
+	return acceptance.ExecuteTemplate(t,
+		"domain_record_with_domain", TemplateData{
+			Domain: domain.TemplateData{Domain: domainName},
+			Record: domainRecord,
+		})
+}
+
 func DataBasic(t *testing.T, domainName string) string {
 	return acceptance.ExecuteTemplate(t,
 		"domain_record_data_basic", TemplateData{

--- a/linode/domainrecord/tmpl/with_domain.gotf
+++ b/linode/domainrecord/tmpl/with_domain.gotf
@@ -1,0 +1,12 @@
+{{ define "domain_record_with_domain" }}
+
+{{ template "domain_basic" .Domain }}
+
+resource "linode_domain_record" "foobar" {
+    domain_id = linode_domain.foobar.id
+    name = "{{.Record}}"
+    record_type = "A"
+    target = "0.0.0.0"
+}
+
+{{ end }}


### PR DESCRIPTION
## 📝 Description

This change adds logic to the `readResource` function of the `linode_domain_record` resource to prevent diffs when users specify their FQDN as a part of their record's name. This issue occurs because the API will always strip the FQDN from the record name before returning it to the client.

Resolves #1082 

## ✔️ How to Test

**Automated Testing:**

```
make PKG_NAME=linode/domainrecord testacc
```

**Manual Testing:**

1. Apply the following Terraform configuration within a provider test environment (e.g. dx-devenv), replacing `my.fake.domain.com` with an arbitrary unused domain name:

```terraform
resource "linode_domain" "website" {
  type      = "master"
  domain    = "my.fake.domain.com"
  soa_email = "cool@example.com"
  ttl_sec   = 300
}

resource "linode_domain_record" "website" {
  domain_id   = linode_domain.website.id
  name        = "very.real.website.com"
  record_type = "A"
  target      = "0.0.0.0"
  ttl_sec     = 300
}
```

2. Once the apply has been completed, re-plan (`terraform plan`) the configuration.
3. Observe that no changes are planned for the `name` field.
4. Update the record's name field to have a prefix (e.g. `subdomain.very.real.website.com`).
5. Apply the updated configuration.
6. Once the apply has been completed, re-plan (`terraform plan`) the configuration.
7. Observe that no changes are planned for the `name` field.
