### PR TITLE
Implement `FrameworkRebootInstance`

### DIFF
--- a/linode/helper/instance.go
+++ b/linode/helper/instance.go
@@ -22,18 +22,46 @@ const (
 var bootEvents = []linodego.EventAction{linodego.ActionLinodeBoot, linodego.ActionLinodeReboot}
 
 // set bootConfig = 0 if using existing boot config
-func RebootInstance(ctx context.Context, d *schema.ResourceData, entityID int,
+func RebootInstance(ctx context.Context, d *schema.ResourceData, linodeID int,
 	meta interface{}, bootConfig int,
 ) diag.Diagnostics {
+	client := meta.(*ProviderMeta).Client
+	ctx, cancel := context.WithTimeout(
+		ctx,
+		time.Duration(GetDeadlineSeconds(ctx, d))*time.Second,
+	)
+	defer cancel()
+	return diag.FromErr(rebootInstance(ctx, linodeID, &client, bootConfig))
+}
+
+func FrameworkRebootInstance(
+	linodeID int,
+	client *linodego.Client,
+	bootConfig int,
+	timeoutSeconds int,
+) error {
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		time.Duration(timeoutSeconds)*time.Second,
+	)
+	defer cancel()
+
+	return rebootInstance(ctx, linodeID, client, bootConfig)
+}
+
+func rebootInstance(
+	ctx context.Context,
+	entityID int,
+	client *linodego.Client,
+	bootConfig int,
+) error {
 	ctx = SetLogFieldBulk(ctx, map[string]any{
 		"linode_id": entityID,
 		"config_id": bootConfig,
 	})
-
-	client := meta.(*ProviderMeta).Client
 	instance, err := client.GetInstance(ctx, entityID)
 	if err != nil {
-		return diag.Errorf("Error fetching data about the current linode: %s", err)
+		return fmt.Errorf("Error fetching data about the current linode: %s", err)
 	}
 
 	if instance.Status != linodego.InstanceRunning {
@@ -45,23 +73,31 @@ func RebootInstance(ctx context.Context, d *schema.ResourceData, entityID int,
 
 	p, err := client.NewEventPoller(ctx, entityID, linodego.EntityLinode, linodego.ActionLinodeReboot)
 	if err != nil {
-		return diag.Errorf("failed to initialize event poller: %s", err)
+		return fmt.Errorf("failed to initialize event poller: %s", err)
 	}
 
 	err = client.RebootInstance(ctx, instance.ID, bootConfig)
 
 	if err != nil {
-		return diag.Errorf("Error rebooting Instance [%d]: %s", instance.ID, err)
-	}
-	_, err = p.WaitForFinished(ctx, GetDeadlineSeconds(ctx, d))
-	if err != nil {
-		return diag.Errorf("Error waiting for Instance [%d] to finish rebooting: %s", instance.ID, err)
+		return fmt.Errorf("Error rebooting Instance [%d]: %s", instance.ID, err)
 	}
 
+	deadlineSeconds := 600
+	if deadline, ok := ctx.Deadline(); ok {
+		deadlineSeconds = int(time.Until(deadline).Seconds())
+	}
+	_, err = p.WaitForFinished(ctx, deadlineSeconds)
+	if err != nil {
+		return fmt.Errorf("Error waiting for Instance [%d] to finish rebooting: %s", instance.ID, err)
+	}
+
+	if deadline, ok := ctx.Deadline(); ok {
+		deadlineSeconds = int(time.Until(deadline).Seconds())
+	}
 	if _, err = client.WaitForInstanceStatus(
-		ctx, instance.ID, linodego.InstanceRunning, GetDeadlineSeconds(ctx, d),
+		ctx, instance.ID, linodego.InstanceRunning, deadlineSeconds,
 	); err != nil {
-		return diag.Errorf("Timed-out waiting for Linode instance [%d] to boot: %s", instance.ID, err)
+		return fmt.Errorf("Timed-out waiting for Linode instance [%d] to boot: %s", instance.ID, err)
 	}
 
 	tflog.Debug(ctx, "Instance has finished rebooting")


### PR DESCRIPTION
## 📝 Description

Implemented a helper function for framework resource work in the near future.

## ✔️ How to Test

We can test it by running the existent resources that uses `RebootInstance` function, like `instance`.

`make testacc PKG_NAME="linode/instance"`