### PR TITLE
test: randomize root password for linode/disk creations

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,7 +53,6 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
-          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
+          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/linode/firewall/tmpl/inst.gotf
+++ b/linode/firewall/tmpl/inst.gotf
@@ -8,7 +8,7 @@ resource "linode_instance" "{{.ID}}" {
     disk {
         label = "disk"
         image = "linode/alpine3.15"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }

--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -16,6 +16,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 
 	resName := "data.linode_instances.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -23,7 +24,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataBasic(t, instanceName, testRegion),
+				Config: tmpl.DataBasic(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "instances.#", "1"),
 					resource.TestCheckResourceAttrSet(resName, "instances.0.id"),
@@ -53,6 +54,7 @@ func TestAccDataSourceInstances_multipleInstances(t *testing.T) {
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	tagName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -80,7 +82,7 @@ func TestAccDataSourceInstances_multipleInstances(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.DataClientFilter(t, instanceName, tagName, testRegion),
+				Config: tmpl.DataClientFilter(t, instanceName, tagName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "instances.#", "1"),
 					resource.TestCheckResourceAttr(resName, "instances.0.status", "running"),

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -68,6 +68,7 @@ func TestAccResourceInstance_basic_smoke(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandomWithPrefix(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -75,7 +76,7 @@ func TestAccResourceInstance_basic_smoke(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Basic(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.Basic(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -103,20 +104,22 @@ func TestAccResourceInstance_watchdogDisabled(t *testing.T) {
 
 	resName := "linode_instance.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.WatchdogDisabled(t, instanceName, testRegion),
+				Config: tmpl.WatchdogDisabled(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
 					resource.TestCheckResourceAttr(resName, "watchdog_enabled", "false"),
 				),
 			},
 			{
-				Config:   tmpl.WatchdogDisabled(t, instanceName, testRegion),
+				Config:   tmpl.WatchdogDisabled(t, instanceName, testRegion, rootPass),
 				PlanOnly: true,
 			},
 		},
@@ -129,14 +132,14 @@ func TestAccResourceInstance_authorizedUsers(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-
+	rootPass := acctest.RandString(12)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.AuthorizedUsers(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.AuthorizedUsers(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -162,6 +165,7 @@ func TestAccResourceInstance_validateAuthorizedKeys(t *testing.T) {
 	t.Parallel()
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -174,7 +178,7 @@ func TestAccResourceInstance_validateAuthorizedKeys(t *testing.T) {
 					"invalid input for authorized_keys"),
 			},
 			{
-				Config: tmpl.DiskAuthorizedKeysEmpty(t, instanceName, testRegion),
+				Config: tmpl.DiskAuthorizedKeysEmpty(t, instanceName, testRegion, rootPass),
 				ExpectError: regexp.MustCompile(
 					"invalid input for disk authorized_keys"),
 			},
@@ -323,6 +327,7 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -330,7 +335,7 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.ConfigInterfaces(t, instanceName, testRegion),
+				Config: tmpl.ConfigInterfaces(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -347,7 +352,7 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.ConfigInterfacesMultiple(t, instanceName, testRegion),
+				Config: tmpl.ConfigInterfacesMultiple(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "config.#", "2"),
 					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "1"),
@@ -360,7 +365,7 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 			},
 			{
 				PreConfig: testAccAssertReboot(t, true, &instance),
-				Config:    tmpl.ConfigInterfacesUpdate(t, instanceName, testRegion),
+				Config:    tmpl.ConfigInterfacesUpdate(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "config.#", "2"),
 					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "2"),
@@ -370,7 +375,7 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 			},
 			{
 				PreConfig: testAccAssertReboot(t, true, &instance),
-				Config:    tmpl.ConfigInterfacesUpdateEmpty(t, instanceName, testRegion),
+				Config:    tmpl.ConfigInterfacesUpdateEmpty(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "0"),
 				),
@@ -391,6 +396,7 @@ func TestAccResourceInstance_configInterfacesNoReboot(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -398,7 +404,7 @@ func TestAccResourceInstance_configInterfacesNoReboot(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.ConfigInterfaces(t, instanceName, testRegion),
+				Config: tmpl.ConfigInterfaces(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -415,7 +421,7 @@ func TestAccResourceInstance_configInterfacesNoReboot(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.ConfigInterfacesUpdateNoReboot(t, instanceName, testRegion),
+				Config: tmpl.ConfigInterfacesUpdateNoReboot(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "config.#", "2"),
 					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "0"),
@@ -425,7 +431,7 @@ func TestAccResourceInstance_configInterfacesNoReboot(t *testing.T) {
 			},
 			{
 				PreConfig: testAccAssertReboot(t, false, &instance),
-				Config:    tmpl.ConfigInterfacesUpdateNoReboot(t, instanceName, testRegion),
+				Config:    tmpl.ConfigInterfacesUpdateNoReboot(t, instanceName, testRegion, rootPass),
 			},
 			{
 				ResourceName:            resName,
@@ -505,6 +511,7 @@ func TestAccResourceInstance_diskImage(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -513,7 +520,7 @@ func TestAccResourceInstance_diskImage(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Disk(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.Disk(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -544,6 +551,7 @@ func TestAccResourceInstance_diskPair(t *testing.T) {
 	var instance linodego.Instance
 	var instanceDisk linodego.InstanceDisk
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -551,7 +559,7 @@ func TestAccResourceInstance_diskPair(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DiskMultiple(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskMultiple(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -583,6 +591,7 @@ func TestAccResourceInstance_diskAndConfig(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -590,7 +599,7 @@ func TestAccResourceInstance_diskAndConfig(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -625,6 +634,8 @@ func TestAccResourceInstance_disksAndConfigs(t *testing.T) {
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
+	rootPass := acctest.RandString(12)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
@@ -634,7 +645,7 @@ func TestAccResourceInstance_disksAndConfigs(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DiskConfigMultiple(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfigMultiple(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -674,6 +685,7 @@ func TestAccResourceInstance_volumeAndConfig(t *testing.T) {
 	var instanceDisk linodego.InstanceDisk
 	var volume linodego.Volume
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -681,7 +693,7 @@ func TestAccResourceInstance_volumeAndConfig(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.VolumeConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.VolumeConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					acceptance.CheckVolumeExists(volName, &volume),
@@ -786,6 +798,7 @@ func TestAccResourceInstance_updateSimple(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -793,7 +806,7 @@ func TestAccResourceInstance_updateSimple(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Basic(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.Basic(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -959,6 +972,7 @@ func TestAccResourceInstance_upsizeWithoutDisk(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -966,7 +980,7 @@ func TestAccResourceInstance_upsizeWithoutDisk(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-nanode-1", testRegion),
+				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-nanode-1", testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "25600"),
@@ -977,7 +991,7 @@ func TestAccResourceInstance_upsizeWithoutDisk(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-standard-1", testRegion),
+				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-standard-1", testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "51200"),
@@ -1113,6 +1127,7 @@ func TestAccResourceInstance_diskResize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1121,7 +1136,7 @@ func TestAccResourceInstance_diskResize(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Start off with a Linode 1024
 			{
-				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "25600"),
@@ -1154,6 +1169,7 @@ func TestAccResourceInstance_withDiskLinodeUpsize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1162,7 +1178,7 @@ func TestAccResourceInstance_withDiskLinodeUpsize(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Start with g6-nanode-1
 			{
-				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "25600"),
@@ -1175,7 +1191,7 @@ func TestAccResourceInstance_withDiskLinodeUpsize(t *testing.T) {
 			},
 			// Upsize to g6-standard-1 with fully allocated disk
 			{
-				Config: tmpl.DiskConfigExpanded(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfigExpanded(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "51200"),
@@ -1195,6 +1211,7 @@ func TestAccResourceInstance_withDiskLinodeDownsize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1203,7 +1220,7 @@ func TestAccResourceInstance_withDiskLinodeDownsize(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Start with g6-standard-1 with fully allocated disk
 			{
-				Config: tmpl.DiskConfigExpanded(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfigExpanded(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "51200"),
@@ -1216,7 +1233,7 @@ func TestAccResourceInstance_withDiskLinodeDownsize(t *testing.T) {
 			},
 			// Downsize to g6-nanode-1
 			{
-				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "25600"),
@@ -1237,6 +1254,7 @@ func TestAccResourceInstance_downsizeWithoutDisk(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1245,7 +1263,7 @@ func TestAccResourceInstance_downsizeWithoutDisk(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-standard-1", testRegion),
+				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-standard-1", testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					checkInstanceDisks(&instance,
@@ -1255,7 +1273,7 @@ func TestAccResourceInstance_downsizeWithoutDisk(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-nanode-1", testRegion),
+				Config: tmpl.WithType(t, instanceName, acceptance.PublicKeyMaterial, "g6-nanode-1", testRegion, rootPass),
 				ExpectError: regexp.MustCompile(
 					"insufficient disk capacity"),
 			},
@@ -1270,6 +1288,7 @@ func TestAccResourceInstance_fullDiskSwapUpsize(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	stackScriptName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1278,7 +1297,7 @@ func TestAccResourceInstance_fullDiskSwapUpsize(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.FullDisk(t, instanceName, acceptance.PublicKeyMaterial, stackScriptName, testRegion, 256),
+				Config: tmpl.FullDisk(t, instanceName, acceptance.PublicKeyMaterial, stackScriptName, testRegion, 256, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					checkInstanceDisks(&instance,
@@ -1320,7 +1339,7 @@ func TestAccResourceInstance_fullDiskSwapUpsize(t *testing.T) {
 						}
 					}
 				},
-				Config:      tmpl.FullDisk(t, instanceName, acceptance.PublicKeyMaterial, stackScriptName, testRegion, 512),
+				Config:      tmpl.FullDisk(t, instanceName, acceptance.PublicKeyMaterial, stackScriptName, testRegion, 512, rootPass),
 				ExpectError: regexp.MustCompile("Error waiting for resize of Instance \\d+ Disk \\d+"),
 			},
 		},
@@ -1333,6 +1352,7 @@ func TestAccResourceInstance_swapUpsize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1340,7 +1360,7 @@ func TestAccResourceInstance_swapUpsize(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 256),
+				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 256, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					checkInstanceDisks(&instance,
@@ -1350,7 +1370,7 @@ func TestAccResourceInstance_swapUpsize(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 512),
+				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 512, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					checkInstanceDisks(&instance,
@@ -1370,13 +1390,15 @@ func TestAccResourceInstance_swapDownsize(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
 
+	rootPass := acctest.RandString(12)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 512),
+				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 512, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					checkInstanceDisks(&instance,
@@ -1386,7 +1408,7 @@ func TestAccResourceInstance_swapDownsize(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 256),
+				Config: tmpl.WithSwapSize(t, instanceName, acceptance.PublicKeyMaterial, testRegion, 256, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					checkInstanceDisks(&instance,
@@ -1404,6 +1426,7 @@ func TestAccResourceInstance_diskResizeAndExpanded(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1412,7 +1435,7 @@ func TestAccResourceInstance_diskResizeAndExpanded(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Start off with a Linode 1024
 			{
-				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "25600"),
@@ -1426,7 +1449,7 @@ func TestAccResourceInstance_diskResizeAndExpanded(t *testing.T) {
 
 			// Bump to 2048 and expand disk
 			{
-				Config: tmpl.DiskConfigResizedExpanded(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfigResizedExpanded(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "51200"),
@@ -1451,6 +1474,7 @@ func TestAccResourceInstance_diskSlotReorder(t *testing.T) {
 	)
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1459,7 +1483,7 @@ func TestAccResourceInstance_diskSlotReorder(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Start off with a Linode 1024
 			{
-				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfig(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "25600"),
@@ -1474,7 +1498,7 @@ func TestAccResourceInstance_diskSlotReorder(t *testing.T) {
 			},
 			// Add a disk, reorder the disks
 			{
-				Config: tmpl.DiskConfigReordered(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskConfigReordered(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "specs.0.disk", "51200"),
@@ -1603,6 +1627,7 @@ func TestAccResourceInstance_stackScriptDisk(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1610,7 +1635,7 @@ func TestAccResourceInstance_stackScriptDisk(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DiskStackScript(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.DiskStackScript(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -1983,13 +2008,15 @@ func TestAccResourceInstance_userData(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rootPass := acctest.RandString(12)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.UserData(t, instanceName, region),
+				Config: tmpl.UserData(t, instanceName, region, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2024,6 +2051,8 @@ func TestAccResourceInstance_requestQuantity(t *testing.T) {
 
 	provider, providerMap := acceptance.CreateTestProvider()
 
+	rootPass := acctest.RandString(12)
+
 	acceptance.ModifyProviderMeta(provider,
 		func(ctx context.Context, config *helper.ProviderMeta) error {
 			config.Client.OnBeforeRequest(func(request *linodego.Request) error {
@@ -2047,7 +2076,7 @@ func TestAccResourceInstance_requestQuantity(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Provision a bunch of Linodes and wait for them to boot into an image
-				Config: tmpl.ManyLinodes(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.ManyLinodes(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 			},
 			{
 				PreConfig: func() {
@@ -2060,7 +2089,7 @@ func TestAccResourceInstance_requestQuantity(t *testing.T) {
 						t.Fatalf("too many requests: %f > %f", requestsPerSecond, maxRequestsPerSecond)
 					}
 				},
-				Config: tmpl.ManyLinodes(t, instanceName, acceptance.PublicKeyMaterial, testRegion),
+				Config: tmpl.ManyLinodes(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass),
 			},
 		},
 	})
@@ -2075,6 +2104,7 @@ func TestAccResourceInstance_firewallOnCreation(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
 	region, err := acceptance.GetRandomRegionWithCaps([]string{"Cloud Firewall"})
+	rootPass := acctest.RandString(12)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2085,7 +2115,7 @@ func TestAccResourceInstance_firewallOnCreation(t *testing.T) {
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.FirewallOnCreation(t, instanceName, region),
+				Config: tmpl.FirewallOnCreation(t, instanceName, region, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(instanceResourceName, &instance),
 				),

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -7,13 +7,14 @@ import (
 )
 
 type TemplateData struct {
-	Label  string
-	PubKey string
-	Type   string
-	Image  string
-	Group  string
-	Tag    string
-	Region string
+	Label    string
+	PubKey   string
+	Type     string
+	Image    string
+	Group    string
+	Tag      string
+	Region   string
+	RootPass string
 
 	SwapSize int
 
@@ -23,13 +24,14 @@ type TemplateData struct {
 	ResizeDisk bool
 }
 
-func Basic(t *testing.T, label, pubKey, region string) string {
+func Basic(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_basic", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -42,27 +44,29 @@ func Updates(t *testing.T, label, region string) string {
 		})
 }
 
-func WatchdogDisabled(t *testing.T, label, region string) string {
+func WatchdogDisabled(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_watchdog_disabled", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func WithType(t *testing.T, label, pubKey, typ, region string) string {
+func WithType(t *testing.T, label, pubKey, typ, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_with_type", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Type:   typ,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Type:     typ,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func WithSwapSize(t *testing.T, label, pubKey, region string, swapSize int) string {
+func WithSwapSize(t *testing.T, label, pubKey, region string, swapSize int, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_with_swap_size", TemplateData{
 			Label:    label,
@@ -70,10 +74,11 @@ func WithSwapSize(t *testing.T, label, pubKey, region string, swapSize int) stri
 			SwapSize: swapSize,
 			Image:    acceptance.TestImageLatest,
 			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func FullDisk(t *testing.T, label, pubKey, stackScriptName, region string, swapSize int) string {
+func FullDisk(t *testing.T, label, pubKey, stackScriptName, region string, swapSize int, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_full_disk", TemplateData{
 			Label:           label,
@@ -82,6 +87,7 @@ func FullDisk(t *testing.T, label, pubKey, stackScriptName, region string, swapS
 			StackScriptName: stackScriptName,
 			Image:           acceptance.TestImageLatest,
 			Region:          region,
+			RootPass:        rootPass,
 		})
 }
 
@@ -130,48 +136,53 @@ func InterfacesUpdateEmpty(t *testing.T, label, region string) string {
 		})
 }
 
-func ConfigInterfaces(t *testing.T, label, region string) string {
+func ConfigInterfaces(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_config_interfaces", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func ConfigInterfacesMultiple(t *testing.T, label, region string) string {
+func ConfigInterfacesMultiple(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_config_interfaces_multiple", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func ConfigInterfacesUpdate(t *testing.T, label, region string) string {
+func ConfigInterfacesUpdate(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_config_interfaces_update", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func ConfigInterfacesUpdateNoReboot(t *testing.T, label, region string) string {
+func ConfigInterfacesUpdateNoReboot(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_config_interfaces_update_no_reboot", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func ConfigInterfacesUpdateEmpty(t *testing.T, label, region string) string {
+func ConfigInterfacesUpdateEmpty(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_config_interfaces_update_empty", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -248,83 +259,91 @@ func RawDiskExpanded(t *testing.T, label, region string) string {
 		})
 }
 
-func Disk(t *testing.T, label, pubKey, region string) string {
+func Disk(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DiskMultiple(t *testing.T, label, pubKey, region string) string {
+func DiskMultiple(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_multiple", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DiskConfig(t *testing.T, label, pubKey, region string) string {
+func DiskConfig(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_config", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DiskConfigExpanded(t *testing.T, label, pubKey, region string) string {
+func DiskConfigExpanded(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_config_expanded", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DiskConfigResized(t *testing.T, label, pubKey, region string) string {
+func DiskConfigResized(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_config_resized", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DiskConfigResizedExpanded(t *testing.T, label, pubKey, region string) string {
+func DiskConfigResizedExpanded(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_config_resized_expanded", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DiskConfigReordered(t *testing.T, label, pubKey, region string) string {
+func DiskConfigReordered(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_config_reordered", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DiskConfigMultiple(t *testing.T, label, pubKey, region string) string {
+func DiskConfigMultiple(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_config_multiple", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -337,13 +356,14 @@ func DiskBootImage(t *testing.T, label, image, region string) string {
 		})
 }
 
-func VolumeConfig(t *testing.T, label, pubKey, region string) string {
+func VolumeConfig(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_volume_config", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -375,13 +395,14 @@ func PrivateNetworking(t *testing.T, label, pubKey, region string) string {
 		})
 }
 
-func AuthorizedUsers(t *testing.T, label, pubKey, region string) string {
+func AuthorizedUsers(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_authorized_users", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -394,12 +415,13 @@ func AuthorizedKeysEmpty(t *testing.T, label, region string) string {
 		})
 }
 
-func DiskAuthorizedKeysEmpty(t *testing.T, label, region string) string {
+func DiskAuthorizedKeysEmpty(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_authorized_keys_empty", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -412,13 +434,14 @@ func StackScript(t *testing.T, label, region string) string {
 		})
 }
 
-func DiskStackScript(t *testing.T, label, pubKey, region string) string {
+func DiskStackScript(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_stackscript", TemplateData{
-			Label:  label,
-			PubKey: pubKey,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			PubKey:   pubKey,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -524,31 +547,34 @@ func IPv4SharingBadInput(t *testing.T, label, region string) string {
 		})
 }
 
-func ManyLinodes(t *testing.T, label, pubKey, region string) string {
+func ManyLinodes(t *testing.T, label, pubKey, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_many_linodes", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			PubKey: pubKey,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			PubKey:   pubKey,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func UserData(t *testing.T, label, region string) string {
+func UserData(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_userdata", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DataBasic(t *testing.T, label, region string) string {
+func DataBasic(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_data_basic", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -582,22 +608,24 @@ func DataMultipleRegex(t *testing.T, label, tag, region string) string {
 		})
 }
 
-func DataClientFilter(t *testing.T, label, tag, region string) string {
+func DataClientFilter(t *testing.T, label, tag, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_data_clientfilter", TemplateData{
-			Label:  label,
-			Tag:    tag,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Tag:      tag,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func FirewallOnCreation(t *testing.T, label, region string) string {
+func FirewallOnCreation(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_firewall_on_creation", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 

--- a/linode/instance/tmpl/templates/authorized_users.gotf
+++ b/linode/instance/tmpl/templates/authorized_users.gotf
@@ -13,7 +13,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = 256
     authorized_users = [ "${data.linode_profile.profile.username}" ]
 }

--- a/linode/instance/tmpl/templates/basic.gotf
+++ b/linode/instance/tmpl/templates/basic.gotf
@@ -6,7 +6,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = 256
     authorized_keys = ["{{.PubKey}}"]
 }

--- a/linode/instance/tmpl/templates/config_interfaces.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces.gotf
@@ -34,7 +34,7 @@ resource "linode_instance" "foobar" {
         label = "boot"
         size = 3000
         image  = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{.RootPass}}"
     }
 
     boot_config_label = "config"

--- a/linode/instance/tmpl/templates/config_interfaces_multiple.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces_multiple.gotf
@@ -57,7 +57,7 @@ resource "linode_instance" "foobar" {
         label = "boot"
         size = 3000
         image  = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{.RootPass}"
     }
 
     boot_config_label = "config"

--- a/linode/instance/tmpl/templates/config_interfaces_update.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces_update.gotf
@@ -60,7 +60,7 @@ resource "linode_instance" "foobar" {
         label = "boot"
         size = 3000
         image  = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{.RootPass}}"
     }
 
     boot_config_label = "config"

--- a/linode/instance/tmpl/templates/config_interfaces_update_empty.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces_update_empty.gotf
@@ -26,7 +26,7 @@ resource "linode_instance" "foobar" {
         label = "boot"
         size = 3000
         image  = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{.RootPass}}"
     }
 
     boot_config_label = "config"

--- a/linode/instance/tmpl/templates/config_interfaces_update_no_reboot.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces_update_no_reboot.gotf
@@ -46,7 +46,7 @@ resource "linode_instance" "foobar" {
         label = "boot"
         size = 3000
         image  = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{.RootPass}}"
     }
 
     boot_config_label = "config"

--- a/linode/instance/tmpl/templates/data_basic.gotf
+++ b/linode/instance/tmpl/templates/data_basic.gotf
@@ -7,7 +7,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = 256
     private_ip = true
 

--- a/linode/instance/tmpl/templates/data_clientfilter.gotf
+++ b/linode/instance/tmpl/templates/data_clientfilter.gotf
@@ -8,7 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
 }
 
 data "linode_instances" "foobar" {

--- a/linode/instance/tmpl/templates/data_multiple_base.gotf
+++ b/linode/instance/tmpl/templates/data_multiple_base.gotf
@@ -8,7 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
 }
 
 {{ end }}

--- a/linode/instance/tmpl/templates/disk.gotf
+++ b/linode/instance/tmpl/templates/disk.gotf
@@ -8,7 +8,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }

--- a/linode/instance/tmpl/templates/disk_authorized_keys_empty.gotf
+++ b/linode/instance/tmpl/templates/disk_authorized_keys_empty.gotf
@@ -10,7 +10,7 @@ resource "linode_instance" "foobar" {
         size = 4096
         image = "{{.Image}}"
         authorized_keys = [""]
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{.RootPass}}"
     }
 }
 

--- a/linode/instance/tmpl/templates/disk_config.gotf
+++ b/linode/instance/tmpl/templates/disk_config.gotf
@@ -9,7 +9,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }

--- a/linode/instance/tmpl/templates/disk_config_expanded.gotf
+++ b/linode/instance/tmpl/templates/disk_config_expanded.gotf
@@ -9,7 +9,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 51200
     }

--- a/linode/instance/tmpl/templates/disk_config_multiple.gotf
+++ b/linode/instance/tmpl/templates/disk_config_multiple.gotf
@@ -9,7 +9,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "diska"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }

--- a/linode/instance/tmpl/templates/disk_config_reordered.gotf
+++ b/linode/instance/tmpl/templates/disk_config_reordered.gotf
@@ -9,7 +9,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }
@@ -17,7 +17,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "diskb"
         image = "linode/ubuntu18.04"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }

--- a/linode/instance/tmpl/templates/disk_config_resized.gotf
+++ b/linode/instance/tmpl/templates/disk_config_resized.gotf
@@ -9,7 +9,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 6000
     }

--- a/linode/instance/tmpl/templates/disk_config_resized_expanded.gotf
+++ b/linode/instance/tmpl/templates/disk_config_resized_expanded.gotf
@@ -9,7 +9,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{.RootPass}}"
         authorized_keys = ["{{.PubKey}}"]
         size = 6000
     }

--- a/linode/instance/tmpl/templates/disk_multiple.gotf
+++ b/linode/instance/tmpl/templates/disk_multiple.gotf
@@ -8,7 +8,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "diska"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }

--- a/linode/instance/tmpl/templates/disk_stackscript.gotf
+++ b/linode/instance/tmpl/templates/disk_stackscript.gotf
@@ -22,7 +22,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
         stackscript_id = "${linode_stackscript.foo-script.id}"

--- a/linode/instance/tmpl/templates/firewall_on_creation.gotf
+++ b/linode/instance/tmpl/templates/firewall_on_creation.gotf
@@ -12,7 +12,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.foobar.id
 }
 

--- a/linode/instance/tmpl/templates/full_disk.gotf
+++ b/linode/instance/tmpl/templates/full_disk.gotf
@@ -7,7 +7,7 @@ resource "linode_instance" "foobar" {
     # This needs to be hardcoded to support the StackScript
     image = "linode/ubuntu18.04"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = {{.SwapSize}}
     authorized_keys = ["{{.PubKey}}"]
     stackscript_id = linode_stackscript.flooddisk.id

--- a/linode/instance/tmpl/templates/many_linodes.gotf
+++ b/linode/instance/tmpl/templates/many_linodes.gotf
@@ -6,7 +6,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = 256
     authorized_keys = ["{{.PubKey}}"]
 }

--- a/linode/instance/tmpl/templates/power_state_config.gotf
+++ b/linode/instance/tmpl/templates/power_state_config.gotf
@@ -10,7 +10,7 @@ resource "linode_instance" "foobar" {
         label = "boot"
         size = 3000
         image  = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
     }
 
     config {

--- a/linode/instance/tmpl/templates/private_networking.gotf
+++ b/linode/instance/tmpl/templates/private_networking.gotf
@@ -5,7 +5,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = 256
     private_ip = true
     authorized_keys = ["{{.PubKey}}"]

--- a/linode/instance/tmpl/templates/userdata.gotf
+++ b/linode/instance/tmpl/templates/userdata.gotf
@@ -5,7 +5,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     booted = false
 
     metadata {

--- a/linode/instance/tmpl/templates/volume_config.gotf
+++ b/linode/instance/tmpl/templates/volume_config.gotf
@@ -15,7 +15,7 @@ resource "linode_instance" "foobar" {
     disk {
         label = "disk"
         image = "{{.Image}}"
-        root_pass = "myr00tp@ssw0rd!!!"
+        root_pass = "{{ .RootPass }}"
         authorized_keys = ["{{.PubKey}}"]
         size = 3000
     }

--- a/linode/instance/tmpl/templates/watchdog_disabled.gotf
+++ b/linode/instance/tmpl/templates/watchdog_disabled.gotf
@@ -5,7 +5,7 @@ resource "linode_instance" "foobar" {
     region    = "{{ .Region }}"
     image     = "{{.Image}}"
     type      = "g6-nanode-1"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
 
     watchdog_enabled = false
 }

--- a/linode/instance/tmpl/templates/with_swapsize.gotf
+++ b/linode/instance/tmpl/templates/with_swapsize.gotf
@@ -6,7 +6,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = {{.SwapSize}}
     authorized_keys = ["{{.PubKey}}"]
 }

--- a/linode/instance/tmpl/templates/with_type.gotf
+++ b/linode/instance/tmpl/templates/with_type.gotf
@@ -6,7 +6,7 @@ resource "linode_instance" "foobar" {
     type = "{{.Type}}"
     image = "{{.Image}}"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = 256
     authorized_keys = ["{{.PubKey}}"]
 }

--- a/linode/instanceconfig/tmpl/instance_disk.gotf
+++ b/linode/instanceconfig/tmpl/instance_disk.gotf
@@ -6,7 +6,7 @@ resource "linode_instance_disk" "foobar" {
   size = linode_instance.foobar.specs.0.disk
 
   image = "linode/alpine3.18"
-  root_pass = "myr00tp@ssw0rd!!!"
+  root_pass = "{{ .RootPass }}"
 }
 
 {{ end }}

--- a/linode/instanceconfig/tmpl/instance_disk_with_swap.gotf
+++ b/linode/instanceconfig/tmpl/instance_disk_with_swap.gotf
@@ -6,7 +6,7 @@ resource "linode_instance_disk" "foobar" {
   size = linode_instance.foobar.specs.0.disk - linode_instance_disk.foobar_swap.size
 
   image = "linode/ubuntu22.04"
-  root_pass = "myr00tp@ssw0rd!!!"
+  root_pass = "{{ .RootPass }}"
 }
 
 resource "linode_instance_disk" "foobar_swap" {

--- a/linode/instanceconfig/tmpl/provisioner.gotf
+++ b/linode/instanceconfig/tmpl/provisioner.gotf
@@ -19,7 +19,7 @@ resource "linode_instance_config" "foobar" {
   connection {
     host        = linode_instance.foobar.ip_address
     user        = "root"
-    password    = "myr00tp@ssw0rd!!!"
+    password    = "{{ .RootPass }}"
   }
 
   provisioner "remote-exec" {

--- a/linode/instancedisk/resource_test.go
+++ b/linode/instancedisk/resource_test.go
@@ -90,6 +90,7 @@ func TestAccResourceInstanceDisk_complex(t *testing.T) {
 
 	resName := "linode_instance_disk.foobar"
 	label := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -97,7 +98,7 @@ func TestAccResourceInstanceDisk_complex(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Complex(t, label, testRegion, 2048),
+				Config: tmpl.Complex(t, label, testRegion, 2048, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resName, nil),
 					resource.TestCheckResourceAttr(resName, "label", label),
@@ -122,6 +123,7 @@ func TestAccResourceInstanceDisk_bootedResize(t *testing.T) {
 
 	resName := "linode_instance_disk.foobar"
 	label := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(12)
 
 	var instance linodego.Instance
 
@@ -131,7 +133,7 @@ func TestAccResourceInstanceDisk_bootedResize(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.BootedResize(t, label, testRegion, 2048),
+				Config: tmpl.BootedResize(t, label, testRegion, 2048, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resName, nil),
 					resource.TestCheckResourceAttr(resName, "label", label),
@@ -143,7 +145,7 @@ func TestAccResourceInstanceDisk_bootedResize(t *testing.T) {
 			},
 			// Resize up
 			{
-				Config: tmpl.BootedResize(t, label, testRegion, 2049),
+				Config: tmpl.BootedResize(t, label, testRegion, 2049, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resName, nil),
 					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
@@ -160,7 +162,7 @@ func TestAccResourceInstanceDisk_bootedResize(t *testing.T) {
 						t.Fatalf("expected instance to be running, found %s", instance.Status)
 					}
 				},
-				Config: tmpl.BootedResize(t, label, testRegion, 2049),
+				Config: tmpl.BootedResize(t, label, testRegion, 2049, rootPass),
 			},
 			{
 				ResourceName:            resName,

--- a/linode/instancedisk/tmpl/booted_resize.gotf
+++ b/linode/instancedisk/tmpl/booted_resize.gotf
@@ -12,7 +12,7 @@ resource "linode_instance_disk" "foobar" {
   size = {{ .Size }}
 
   image = "linode/alpine3.15"
-  root_pass = "myr00tp@ssw0rd!!!"
+  root_pass = "{{ .RootPass }}"
 }
 
 resource "linode_instance_config" "cfg" {

--- a/linode/instancedisk/tmpl/complex.gotf
+++ b/linode/instancedisk/tmpl/complex.gotf
@@ -27,7 +27,7 @@ resource "linode_instance_disk" "foobar" {
   ]
   filesystem = "ext4"
   image = "linode/alpine3.15"
-  root_pass = "myr00tp@ssw0rd!!!"
+  root_pass = "{{ .RootPass }}"
 
   stackscript_id = linode_stackscript.foo.id
   stackscript_data = {

--- a/linode/instancedisk/tmpl/template.go
+++ b/linode/instancedisk/tmpl/template.go
@@ -7,10 +7,11 @@ import (
 )
 
 type TemplateData struct {
-	Label  string
-	Size   int
-	PubKey string
-	Region string
+	Label    string
+	Size     int
+	PubKey   string
+	Region   string
+	RootPass string
 }
 
 func Basic(t *testing.T, label, region string, size int) string {
@@ -32,11 +33,12 @@ func Complex(t *testing.T, label, region string, size int) string {
 		})
 }
 
-func BootedResize(t *testing.T, label, region string, size int) string {
+func BootedResize(t *testing.T, label, region string, size int, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_booted_resize", TemplateData{
-			Label:  label,
-			Size:   size,
-			Region: region,
+			Label:    label,
+			Size:     size,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }

--- a/linode/nbnode/tmpl/networking.gotf
+++ b/linode/nbnode/tmpl/networking.gotf
@@ -5,7 +5,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "linode/ubuntu18.04"
     region = "{{ .Region }}"
-    root_pass = "myr00tp@ssw0rd!!!"
+    root_pass = "{{ .RootPass }}"
     swap_size = 256
     private_ip = true
     authorized_keys = ["{{.PubKey}}"]


### PR DESCRIPTION
## 📝 Description

In integration tests, we currently use public hard coded root passwords for Linode instances. To enhance security, transitioning to randomly generated root passwords during tests instead.

## ✔️ How to Test

make testacc

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**