### PR TITLE
new: Support `accountavailability` Data Source

### DIFF
--- a/linode/accountavailability/datasource_test.go
+++ b/linode/accountavailability/datasource_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package accountavailability_test
+
+import (
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/v2/linode/accountavailability/tmpl"
+)
+
+func TestAccDataSourceNodeBalancers_basic(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_account_availability.foobar"
+
+	region, err := acceptance.GetRandomRegionWithCaps(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, region),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+					resource.TestCheckResourceAttrSet(resourceName, "unavailable.#"),
+				),
+			},
+		},
+	})
+}

--- a/linode/accountavailability/framework_datasource.go
+++ b/linode/accountavailability/framework_datasource.go
@@ -1,0 +1,53 @@
+package accountavailability
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper"
+)
+
+type DataSource struct {
+	helper.BaseDataSource
+}
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{
+		BaseDataSource: helper.NewBaseDataSource(
+			helper.BaseDataSourceConfig{
+				Name:   "linode_account_availability",
+				Schema: &frameworkDataSourceSchema,
+			},
+		),
+	}
+}
+
+func (d *DataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var data DataSourceModel
+	client := d.Meta.Client
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	availability, err := client.GetAccountAvailability(ctx, data.Region.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Failed to get account availability in the region %v", data.Region.ValueString()),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(data.parseAvailability(ctx, availability)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/linode/accountavailability/framework_datasource_schema.go
+++ b/linode/accountavailability/framework_datasource_schema.go
@@ -1,0 +1,22 @@
+package accountavailability
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var frameworkDataSourceSchema = schema.Schema{
+	Attributes: Attributes,
+}
+
+var Attributes = map[string]schema.Attribute{
+	"region": schema.StringAttribute{
+		Description: "The id of a region.",
+		Required:    true,
+	},
+	"unavailable": schema.ListAttribute{
+		Description: "The unavailable resources in a region to a specific customer.",
+		ElementType: types.StringType,
+		Computed:    true,
+	},
+}

--- a/linode/accountavailability/framework_models.go
+++ b/linode/accountavailability/framework_models.go
@@ -1,0 +1,29 @@
+package accountavailability
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+)
+
+type DataSourceModel struct {
+	Region      types.String `tfsdk:"region"`
+	Unavailable types.List   `tfsdk:"unavailable"`
+}
+
+func (d *DataSourceModel) parseAvailability(
+	ctx context.Context,
+	availability *linodego.AccountAvailability,
+) diag.Diagnostics {
+	d.Region = types.StringValue(availability.Region)
+
+	unavailable, diags := types.ListValueFrom(ctx, types.StringType, availability.Unavailable)
+	if diags != nil {
+		return diags
+	}
+	d.Unavailable = unavailable
+
+	return nil
+}

--- a/linode/accountavailability/tmpl/data_basic.gotf
+++ b/linode/accountavailability/tmpl/data_basic.gotf
@@ -1,0 +1,7 @@
+{{ define "account_availability_data_basic" }}
+
+data "linode_account_availability" "foobar" {
+    region = "{{.Region}}"
+}
+
+{{ end }}

--- a/linode/accountavailability/tmpl/template.go
+++ b/linode/accountavailability/tmpl/template.go
@@ -1,0 +1,18 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
+)
+
+type TemplateData struct {
+	Region string
+}
+
+func DataBasic(t *testing.T, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"account_availability_data_basic", TemplateData{
+			Region: region,
+		})
+}

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/linode/terraform-provider-linode/v2/linode/account"
+	"github.com/linode/terraform-provider-linode/v2/linode/accountavailability"
 	"github.com/linode/terraform-provider-linode/v2/linode/accountlogin"
 	"github.com/linode/terraform-provider-linode/v2/linode/accountlogins"
 	"github.com/linode/terraform-provider-linode/v2/linode/accountsettings"
@@ -212,5 +213,6 @@ func (p *FrameworkProvider) DataSources(ctx context.Context) []func() datasource
 		vpcsubnets.NewDataSource,
 		vpcs.NewDataSource,
 		volumes.NewDataSource,
+		accountavailability.NewDataSource,
 	}
 }


### PR DESCRIPTION
## 📝 Description

Implement a new data source `accountavailability` to get resource availability to a customer in a region. It returns unavailable resources in a region to a specific customer depends on region capability.

## ✔️ How to Test

To pass the test locally, we need to set linode url and token to Alpha. Also we will need to replace the linodego to [proj/dc-get-well](https://github.com/linode/linodego/tree/proj/dc-get-well) branch.

`make PKG_NAME="linode/accountavailability" testacc`
