### PR TITLE
test: add release info to xml file before uploading to obj storage

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,7 +53,6 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
-          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install Python deps
         run: pip3 install requests wheel boto3
 
-      - name: Set release version env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report/v2@latest
 
@@ -55,7 +52,7 @@ jobs:
         run: |
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
-          --branch_name "${{ env.RELEASE_VERSION }}" \
+          --branch_name "${GITHUB_REF#refs/*/}" \
           --gha_run_id "$GITHUB_RUN_ID" \
           --gha_run_number "$GITHUB_RUN_NUMBER" \
           --xmlfile "${filename}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
+          ls -ltrh
           filename=$(ls | grep -E '^[0-9]{12}_terraform_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \

--- a/scripts/add_to_xml_test_report.py
+++ b/scripts/add_to_xml_test_report.py
@@ -1,11 +1,38 @@
 import argparse
 import xml.etree.ElementTree as ET
+import requests
+
+latest_release_url = "https://api.github.com/repos/linode/terraform-provider-linode/releases/latest"
+
+
+def get_release_version():
+    url = latest_release_url
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Check for HTTP errors
+
+        release_info = response.json()
+        version = release_info["tag_name"]
+
+        # Remove 'v' prefix if it exists
+        if version.startswith("v"):
+            version = version[1:]
+
+        return str(version)
+
+    except requests.exceptions.RequestException as e:
+        print("Error:", e)
+    except KeyError:
+        print("Error: Unable to fetch release information from GitHub API.")
+
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description='Modify XML with workflow information')
 parser.add_argument('--branch_name', required=True)
 parser.add_argument('--gha_run_id', required=True)
 parser.add_argument('--gha_run_number', required=True)
+parser.add_argument('--release_tag', required=False)
 parser.add_argument('--xmlfile', required=True)  # Added argument for XML file path
 
 args = parser.parse_args()
@@ -25,10 +52,14 @@ gha_run_id_element.text = args.gha_run_id
 gha_run_number_element = ET.Element('gha_run_number')
 gha_run_number_element.text = args.gha_run_number
 
+gha_release_tag_element = ET.Element('release_tag')
+gha_release_tag_element.text = get_release_version()
+
 # Add the new elements to the root of the XML
 root.append(branch_name_element)
 root.append(gha_run_id_element)
 root.append(gha_run_number_element)
+root.append(gha_release_tag_element)
 
 # Save the modified XML
 modified_xml_file_path = xml_file_path  # Overwrite it


### PR DESCRIPTION
## 📝 Description

Problem: For some context, the script that is used to upload test report from OBJ storage to TOD is currently calling GitHub API endpoints from ECP Test VM to get the release info for corresponding repository. However recently there has been a rate limiting issue that is causing an error calling endpoint from that particular VM. E.g.
Error: 403 Client Error: rate limit exceeded for url: https://api.github.com/repos/linode/terraform-provider-linode/releases/latest linode-terraform None

Fix: Use existing add_to_xml_report.py script to add the release information to the xml report before uploading it to Object Storage so we don't have to rely on calling any endpoints from the Test VM

## ✔️ How to Test

Monitor TOD after merged to dev

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**