### PR TITLE
Implement FlattenVPC with preserveKnown option

### DIFF
--- a/linode/instanceip/framework_resource.go
+++ b/linode/instanceip/framework_resource.go
@@ -231,7 +231,7 @@ func (r *Resource) Update(
 			return
 		}
 	} else {
-		plan.CopyFrom(ctx, state, true)
+		plan.CopyFrom(ctx, state, false)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/linode/instanceip/framework_resource.go
+++ b/linode/instanceip/framework_resource.go
@@ -231,7 +231,7 @@ func (r *Resource) Update(
 			return
 		}
 	} else {
-		plan.CopyFrom(ctx, state, false)
+		plan.CopyFrom(ctx, state, true)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/linode/vpc/framework_datasource.go
+++ b/linode/vpc/framework_datasource.go
@@ -51,10 +51,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.ParseVPC(ctx, vpc)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
+	data.FlattenVPC(ctx, vpc, false)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/linode/vpc/framework_models.go
+++ b/linode/vpc/framework_models.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
 type VPCModel struct {
@@ -18,23 +18,28 @@ type VPCModel struct {
 	Updated     timetypes.RFC3339 `tfsdk:"updated"`
 }
 
-func (d *VPCModel) parseComputedAttributes(
-	ctx context.Context,
-	vpc *linodego.VPC,
-) diag.Diagnostics {
-	d.ID = types.Int64Value(int64(vpc.ID))
-	d.Description = types.StringValue(vpc.Description)
-	d.Created = timetypes.NewRFC3339TimePointerValue(vpc.Created)
-	d.Updated = timetypes.NewRFC3339TimePointerValue(vpc.Updated)
-	return nil
+func (m *VPCModel) FlattenVPC(ctx context.Context, vpc *linodego.VPC, preserveKnown bool) {
+	m.ID = helper.KeepOrUpdateInt64(m.ID, int64(vpc.ID), preserveKnown)
+	m.Description = helper.KeepOrUpdateString(m.Description, vpc.Description, preserveKnown)
+	m.Created = helper.KeepOrUpdateValue(
+		m.Created,
+		timetypes.NewRFC3339TimePointerValue(vpc.Created),
+		preserveKnown,
+	)
+	m.Updated = helper.KeepOrUpdateValue(
+		m.Updated,
+		timetypes.NewRFC3339TimePointerValue(vpc.Updated),
+		preserveKnown,
+	)
+	m.Label = helper.KeepOrUpdateString(m.Label, vpc.Label, preserveKnown)
+	m.Region = helper.KeepOrUpdateString(m.Region, vpc.Region, preserveKnown)
 }
 
-func (d *VPCModel) ParseVPC(
-	ctx context.Context,
-	vpc *linodego.VPC,
-) diag.Diagnostics {
-	d.Label = types.StringValue(vpc.Label)
-	d.Region = types.StringValue(vpc.Region)
-
-	return d.parseComputedAttributes(ctx, vpc)
+func (m *VPCModel) CopyFrom(ctx context.Context, other VPCModel, preserveKnown bool) {
+	m.ID = helper.KeepOrUpdateValue(m.ID, other.ID, preserveKnown)
+	m.Description = helper.KeepOrUpdateValue(m.Description, other.Description, preserveKnown)
+	m.Created = helper.KeepOrUpdateValue(m.Created, other.Created, preserveKnown)
+	m.Updated = helper.KeepOrUpdateValue(m.Updated, other.Updated, preserveKnown)
+	m.Label = helper.KeepOrUpdateValue(m.Label, other.Label, preserveKnown)
+	m.Region = helper.KeepOrUpdateValue(m.Region, other.Region, preserveKnown)
 }

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -56,11 +55,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseComputedAttributes(ctx, vpc)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
+	data.FlattenVPC(ctx, vpc, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -102,11 +97,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.ParseVPC(ctx, vpc)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
+	data.FlattenVPC(ctx, vpc, false)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -152,12 +143,9 @@ func (r *Resource) Update(
 			)
 			return
 		}
-		resp.Diagnostics.Append(plan.parseComputedAttributes(ctx, vpc)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+		plan.FlattenVPC(ctx, vpc, false)
 	} else {
-		req.State.GetAttribute(ctx, path.Root("updated"), &plan.Updated)
+		plan.CopyFrom(ctx, state, true)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -145,7 +145,7 @@ func (r *Resource) Update(
 		}
 		plan.FlattenVPC(ctx, vpc, false)
 	} else {
-		plan.CopyFrom(ctx, state, false)
+		plan.CopyFrom(ctx, state, true)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -145,7 +145,7 @@ func (r *Resource) Update(
 		}
 		plan.FlattenVPC(ctx, vpc, false)
 	} else {
-		plan.CopyFrom(ctx, state, true)
+		plan.CopyFrom(ctx, state, false)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/linode/vpcs/framework_datasource.go
+++ b/linode/vpcs/framework_datasource.go
@@ -53,7 +53,7 @@ func (r *DataSource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseVPCs(ctx, helper.AnySliceToTyped[linodego.VPC](result))...)
+	data.FlattenVPCs(ctx, helper.AnySliceToTyped[linodego.VPC](result), false)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/vpcs/framework_models.go
+++ b/linode/vpcs/framework_models.go
@@ -3,7 +3,6 @@ package vpcs
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
@@ -18,24 +17,18 @@ type VPCFilterModel struct {
 	VPCs    []vpc.VPCModel                   `tfsdk:"vpcs"`
 }
 
-func (model *VPCFilterModel) parseVPCs(
+func (model *VPCFilterModel) FlattenVPCs(
 	ctx context.Context,
 	vpcs []linodego.VPC,
-) diag.Diagnostics {
+	preserveKnown bool,
+) {
 	vpcModels := make([]vpc.VPCModel, len(vpcs))
 
 	for i := range vpcs {
 		var vpc vpc.VPCModel
-
-		diags := vpc.ParseVPC(ctx, &vpcs[i])
-		if diags.HasError() {
-			return diags
-		}
-
+		vpc.FlattenVPC(ctx, &vpcs[i], preserveKnown)
 		vpcModels[i] = vpc
 	}
 
 	model.VPCs = vpcModels
-
-	return nil
 }


### PR DESCRIPTION
## 📝 Description

This PR is to apply the newly designed pattern of model data handling to taking care state consistent issue, which is that user configured values from the `plan` can be modified by provider code in `Update` and `Create` functions. Those can be modified are Unknown value in the model instance.

## ✔️ How to Test
`make testacc PKG_NAME="linode/vpcsubnets ./linode/vpc ./linode/vpcs ./linode/vpcsubnet"`

Sample TF config file for manual testing:

- `terraform apply --auto-approve` to apply the it to Linode cloud.
- `terraform refresh` to get the list of VPCs in the data source and you will see the output of the list.

```terraform
resource "linode_vpc" "test" {
    label = "test-vpc"
    region = "us-mia"
    description = "My first VPC."
}

data "linode_vpcs" "filtered-vpcs" {
    filter {
        name = "label"
        values = ["test-vpc"]
    }
}

output "vpcs" {
  value = data.linode_vpcs.filtered-vpcs.vpcs
}
```

