### PR TITLE
docs: Improve documentation around legacy-style primary interfaces

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -238,9 +238,9 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
 Interface defines a network interfaces that is exposed to a Linode. See the official [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema) for more details.
 
-A Linode must have a public interface in the first/eth0 position to be reachable via the public internet 
-upon boot without additional system configuration. If no public interface is configured, the Linode 
-is not directly reachable via the public internet. In this case, access can only be established via 
+A Linode must have a public interface in the first/eth0 position to be reachable via the public internet
+upon boot without additional system configuration. If no public interface is configured, the Linode
+is not directly reachable via the public internet. In this case, access can only be established via
 LISH or other Linodes connected to the same VLAN.
 
 Only one public interface per Linode can be defined.

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -238,6 +238,15 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
 Interface defines a network interfaces that is exposed to a Linode. See the official [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema) for more details.
 
+A Linode must have a public interface in the first/eth0 position to be reachable via the public internet 
+upon boot without additional system configuration. If no public interface is configured, the Linode 
+is not directly reachable via the public internet. In this case, access can only be established via 
+LISH or other Linodes connected to the same VLAN.
+
+Only one public interface per Linode can be defined.
+
+The Linode’s default public IPv4 address is assigned to the public interface.
+
 Each interface exports the following attributes:
 
 * `purpose` - (Required) The type of interface. (`public`, `vlan`, `vpc`)

--- a/docs/resources/instance_config.md
+++ b/docs/resources/instance_config.md
@@ -218,6 +218,15 @@ The following attributes are available on helpers:
 
 ### interface
 
+A Linode must have a public interface in the first/eth0 position to be reachable via the public internet
+upon boot without additional system configuration. If no public interface is configured, the Linode
+is not directly reachable via the public internet. In this case, access can only be established via
+LISH or other Linodes connected to the same VLAN.
+
+Only one public interface per Linode can be defined.
+
+The Linode’s default public IPv4 address is assigned to the public interface.
+
 The following arguments are available in an interface:
 
 * `purpose` - (Required) The type of interface. (`public`, `vlan`, `vpc`)


### PR DESCRIPTION
## 📝 Description

This change improves the documentation around the ordered interface system. User needs to specify their public interface as eth0 to let Linode be reachable via public Internet. 

Addressed issue #1138. 
