### PR TITLE
Add logging for obj cluster, bucket, and key

### DIFF
--- a/linode/objcluster/framework_datasource.go
+++ b/linode/objcluster/framework_datasource.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -45,6 +46,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read linode_object_storage_cluster")
 	client := d.Meta.Client
 
 	var data DataSourceModel
@@ -54,7 +56,14 @@ func (d *DataSource) Read(
 		return
 	}
 
-	cluster, err := client.GetObjectStorageCluster(ctx, data.ID.ValueString())
+	cluster_id := data.ID.ValueString()
+
+	ctx = helper.SetLogFieldBulk(ctx, map[string]any{
+		"cluster_id": cluster_id,
+	})
+
+	tflog.Debug(ctx, "Fetching object storage cluster")
+	cluster, err := client.GetObjectStorageCluster(ctx, cluster_id)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to get LKE Versions: %s", err.Error(),


### PR DESCRIPTION
## 📝 Description

This is to improve logging for Object Storage related resources and data sources.

## ✔️ How to Test

### Automated tests

`make testacc PKG_NAME="linode/objbucket"`
`make testacc PKG_NAME="linode/objcluster"`
`make testacc PKG_NAME="linode/objkey"`

### Manual testing

- Enable log output to a file
```bash
export TF_LOG=DEBUG
export TF_LOG_PATH=$PWD/log.txt 
export TF_LOG_PROVIDER_LINODE_REQUESTS=DEBUG
```
- Build the provider in this branch
- Run `terraform apply` with a TF config file (see code snippet below as an example), and verify the newly added logs appear in the output file.
```terraform
resource "linode_object_storage_key" "my-key" {
  label = "test-access-key"
}

resource "linode_object_storage_bucket" "my-bucket" {
  access_key = linode_object_storage_key.my-key.access_key
  secret_key = linode_object_storage_key.my-key.secret_key

  cluster = "us-mia-1"
  label   = "my-bucket-zhiwei"
  versioning = false
}

resource "linode_object_storage_object" "object" {
    bucket  = linode_object_storage_bucket.my-bucket.label
    cluster = "us-mia-1"
    key     = "my-non-versioned-object"

    secret_key = linode_object_storage_key.my-key.secret_key
    access_key = linode_object_storage_key.my-key.access_key

    content          = "Some content"
    content_type     = "text/plain"
    content_language = "en"
    force_destroy    = true
}
```