### PR TITLE
Implement Flatten Functions with Preserving Known Option for VPC Subnet

### DIFF
--- a/linode/vpcsubnet/framework_datasource.go
+++ b/linode/vpcsubnet/framework_datasource.go
@@ -53,7 +53,7 @@ func (d *DataSource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseVPCSubnet(ctx, vpcSubnet)...)
+	resp.Diagnostics.Append(data.FlattenSubnet(ctx, vpcSubnet, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/vpcsubnet/framework_models.go
+++ b/linode/vpcsubnet/framework_models.go
@@ -32,7 +32,6 @@ func FlattenSubnetLinode(
 	ctx context.Context,
 	linode linodego.VPCSubnetLinode,
 ) (*types.Object, diag.Diagnostics) {
-
 	result := map[string]attr.Value{
 		"id": types.Int64Value(int64(linode.ID)),
 	}
@@ -63,7 +62,6 @@ func FlattenSubnetLinodes(
 	ctx context.Context,
 	subnetLinodes []linodego.VPCSubnetLinode,
 ) (*types.List, diag.Diagnostics) {
-
 	result := make([]types.Object, len(subnetLinodes))
 
 	for i, inst := range subnetLinodes {

--- a/linode/vpcsubnet/framework_models.go
+++ b/linode/vpcsubnet/framework_models.go
@@ -28,7 +28,11 @@ func FlattenSubnetLinodeInterface(iface linodego.VPCSubnetLinodeInterface) (type
 	})
 }
 
-func FlattenSubnetLinode(ctx context.Context, linode linodego.VPCSubnetLinode) (*types.Object, diag.Diagnostics) {
+func FlattenSubnetLinode(
+	ctx context.Context,
+	linode linodego.VPCSubnetLinode,
+) (*types.Object, diag.Diagnostics) {
+
 	result := map[string]attr.Value{
 		"id": types.Int64Value(int64(linode.ID)),
 	}
@@ -55,7 +59,11 @@ func FlattenSubnetLinode(ctx context.Context, linode linodego.VPCSubnetLinode) (
 	return &resultObject, d
 }
 
-func FlattenSubnetLinodes(ctx context.Context, subnetLinodes []linodego.VPCSubnetLinode) (*types.List, diag.Diagnostics) {
+func FlattenSubnetLinodes(
+	ctx context.Context,
+	subnetLinodes []linodego.VPCSubnetLinode,
+) (*types.List, diag.Diagnostics) {
+
 	result := make([]types.Object, len(subnetLinodes))
 
 	for i, inst := range subnetLinodes {

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -87,7 +87,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseComputedAttributes(ctx, subnet)...)
+	resp.Diagnostics.Append(data.FlattenSubnet(ctx, subnet, true)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -135,7 +135,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseVPCSubnet(ctx, subnet)...)
+	resp.Diagnostics.Append(data.FlattenSubnet(ctx, subnet, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -185,7 +185,7 @@ func (r *Resource) Update(
 			)
 			return
 		}
-		resp.Diagnostics.Append(plan.parseComputedAttributes(ctx, subnet)...)
+		resp.Diagnostics.Append(plan.FlattenSubnet(ctx, subnet, true)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/linode/vpcsubnets/framework_datasource.go
+++ b/linode/vpcsubnets/framework_datasource.go
@@ -55,7 +55,7 @@ func (r *DataSource) Read(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseVPCSubnets(ctx, helper.AnySliceToTyped[linodego.VPCSubnet](result))...)
+	resp.Diagnostics.Append(data.FlattenSubnets(ctx, helper.AnySliceToTyped[linodego.VPCSubnet](result), false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
## 📝 Description

This is for replacing the old parsing attributes pattern to be newer pattern of flatten functions with `preserveKnown` option. This is a more reliable way to handle the data model with Terraform Framework.

## ✔️ How to Test

### Automated testing
`make testacc PKG_NAME="linode/vpcsubnets ./linode/vpcsubnet"`

### Manual testing

Here is a sample TF config file you can try for manual testing.

- `terraform apply` for deploying the VPC and subnets.
- `terraform fresh` for fetching latest data via data source.
- Observe if the output is correct

```terraform
resource "linode_vpc" "test-vpc" {
    label = "test-vpc"
    region = "us-mia"
    description = "My first VPC."
}

resource "linode_vpc_subnet" "test-subnet" {
    vpc_id = linode_vpc.test-vpc.id
    label = "test-subnet"
    ipv4 = "10.0.0.0/24"
}

data "linode_vpc_subnet" "foo" {
    vpc_id = linode_vpc.test-vpc.id
    id = linode_vpc_subnet.test-subnet.id
}

data "linode_vpc_subnets" "test-subnets" {
    vpc_id = linode_vpc.test-vpc.id
}

output "vpc_subnet" {
  value = data.linode_vpc_subnet.foo
}

output "vpc_subnets" {
  value = data.linode_vpc_subnets.test-subnets.vpc_subnets
}

```