### PR TITLE
new: Add `linode_domains` data source 

### DIFF
--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -1,0 +1,104 @@
+---
+page_title: "Linode: linode_domains"
+description: |-
+Provides information about Linode Cloud Domains that match a set of filters.
+---
+
+# Data Source: linode\_domains
+
+Provides information about Linode Cloud Domains that match a set of filters.
+
+## Example Usage
+
+Get information about all Linode Cloud Domains with a specific tag:
+
+```hcl
+data "linode_domains" "specific" {
+  filter {
+    name = "tags"
+    values = ["test-tag"]
+  }
+}
+
+output "domain" {
+  value = data.linode_domains.specific.domains.0.domain
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* [`filter`](#filter) - (Optional) A set of filters used to select Linode Cloud Domains that meet certain requirements.
+
+* `order_by` - (Optional) The attribute to order the results by. See the [Filterable Fields section](#filterable-fields) for a list of valid fields.
+
+* `order` - (Optional) The order in which results should be returned. (`asc`, `desc`; default `asc`)
+
+### Filter
+
+* `name` - (Required) The name of the field to filter by. See the [Filterable Fields section](#filterable-fields) for a complete list of filterable fields.
+
+* `values` - (Required) A list of values for the filter to allow. These values should all be in string form.
+
+* `match_by` - (Optional) The method to match the field by. (`exact`, `regex`, `substring`; default `exact`)
+
+## Attributes Reference
+
+Each Linode Domain will be stored in the `domains` attribute and will export the following attributes:
+
+* `id` - The unique ID of this Domain.
+
+* `domain` - The domain this Domain represents. These must be unique in our system; you cannot have two Domains representing the same domain
+
+* `type` - If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave) (`master`, `slave`)
+
+* `group` - The group this Domain belongs to.
+
+* `status` - Used to control whether this Domain is currently being rendered. (`disabled`, `active`)
+
+* `description` - A description for this Domain.
+
+* `master_ips` - The IP addresses representing the master DNS for this Domain.
+
+* `axfr_ips` - The list of IPs that may perform a zone transfer for this Domain.
+
+* `ttl_sec` - 'Time to Live'-the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.
+
+* `retry_sec` - The interval, in seconds, at which a failed refresh should be retried.
+
+* `expire_sec` - The amount of time in seconds that may pass before this Domain is no longer authoritative.
+
+* `refresh_sec` - The amount of time in seconds before this Domain should be refreshed.
+
+* `soa_email` - Start of Authority email address.
+
+* `tags` - An array of tags applied to this object.
+
+## Filterable Fields
+
+* `group`
+
+* `tags`
+
+* `domain`
+
+* `type`
+
+* `status`
+
+* `description`
+
+* `master_ips`
+
+* `axfr_ips`
+
+* `ttl_sec`
+
+* `retry_sec`
+
+* `expire_sec`
+
+* `refresh_sec`
+
+* `soa_email`

--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -1,12 +1,12 @@
 ---
 page_title: "Linode: linode_domains"
 description: |-
-Provides information about Linode Cloud Domains that match a set of filters.
+  Provides information about Linode Cloud Domains that match a set of filters.
 ---
 
 # Data Source: linode\_domains
 
-Provides information about Linode Cloud Domains that match a set of filters.
+Provides information about Linode Domains that match a set of filters.
 
 ## Example Usage
 

--- a/linode/domain/framework_datasource.go
+++ b/linode/domain/framework_datasource.go
@@ -57,7 +57,7 @@ func (d *DataSource) Read(
 		return
 	}
 
-	data.parseDomain(domain)
+	data.ParseDomain(domain)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/linode/domain/framework_models.go
+++ b/linode/domain/framework_models.go
@@ -24,7 +24,7 @@ type DomainModel struct {
 	Tags        []types.String `tfsdk:"tags"`
 }
 
-func (m *DomainModel) parseDomain(domain *linodego.Domain) {
+func (m *DomainModel) ParseDomain(domain *linodego.Domain) {
 	m.ID = types.Int64Value(int64(domain.ID))
 	m.Domain = types.StringValue(domain.Domain)
 	m.Type = types.StringValue(string(domain.Type))

--- a/linode/domain/framework_models_unit_test.go
+++ b/linode/domain/framework_models_unit_test.go
@@ -30,7 +30,7 @@ func TestParseDomain(t *testing.T) {
 
 	domainModel := &DomainModel{}
 
-	domainModel.parseDomain(mockDomain)
+	domainModel.ParseDomain(mockDomain)
 
 	assert.Equal(t, types.Int64Value(1234), domainModel.ID)
 	assert.Equal(t, types.StringValue("example.org"), domainModel.Domain)

--- a/linode/domain/framework_schema_datasource.go
+++ b/linode/domain/framework_schema_datasource.go
@@ -8,78 +8,80 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var frameworkDataSourceSchema = schema.Schema{
-	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
-			Description: "The Domain's unique ID.",
-			Optional:    true,
-			Validators: []validator.Int64{
-				int64validator.ConflictsWith(path.Expressions{
-					path.MatchRoot("domain"),
-				}...),
-			},
-		},
-		"domain": schema.StringAttribute{
-			Description: "The domain this Domain represents. These must be unique in our system; you cannot have " +
-				"two Domains representing the same domain.",
-			Optional: true,
-		},
-		"type": schema.StringAttribute{
-			Description: "If this Domain represents the authoritative source of information for the domain it " +
-				"describes, or if it is a read-only copy of a master (also called a slave).",
-			Computed: true,
-		},
-		"group": schema.StringAttribute{
-			Description: "The group this Domain belongs to. This is for display purposes only.",
-			Computed:    true,
-		},
-		"status": schema.StringAttribute{
-			Description: "Used to control whether this Domain is currently being rendered.",
-			Computed:    true,
-		},
-		"description": schema.StringAttribute{
-			Description: "A description for this Domain. This is for display purposes only.",
-			Computed:    true,
-		},
-		"master_ips": schema.SetAttribute{
-			Description: "The IP addresses representing the master DNS for this Domain.",
-			ElementType: types.StringType,
-			Computed:    true,
-		},
-		"axfr_ips": schema.SetAttribute{
-			Description: "The list of IPs that may perform a zone transfer for this Domain. This is potentially " +
-				"dangerous, and should be set to an empty list unless you intend to use it.",
-			ElementType: types.StringType,
-			Computed:    true,
-		},
-		"ttl_sec": schema.Int64Attribute{
-			Description: "'Time to Live' - the amount of time in seconds that this Domain's records may be " +
-				"cached by resolvers or other domain servers. " + domainSecondsDescription,
-			Computed: true,
-		},
-		"retry_sec": schema.Int64Attribute{
-			Description: "The interval, in seconds, at which a failed refresh should be retried. " +
-				domainSecondsDescription,
-			Computed: true,
-		},
-		"expire_sec": schema.Int64Attribute{
-			Description: "The amount of time in seconds that may pass before this Domain is no longer " +
-				domainSecondsDescription,
-			Computed: true,
-		},
-		"refresh_sec": schema.Int64Attribute{
-			Description: "The amount of time in seconds before this Domain should be refreshed. " +
-				domainSecondsDescription,
-			Computed: true,
-		},
-		"soa_email": schema.StringAttribute{
-			Description: "Start of Authority email address. This is required for master Domains.",
-			Computed:    true,
-		},
-		"tags": schema.SetAttribute{
-			Description: "An array of tags applied to this object. Tags are for organizational purposes only.",
-			Computed:    true,
-			ElementType: types.StringType,
+var DomainAttributes = map[string]schema.Attribute{
+	"id": schema.Int64Attribute{
+		Description: "The Domain's unique ID.",
+		Optional:    true,
+		Validators: []validator.Int64{
+			int64validator.ConflictsWith(path.Expressions{
+				path.MatchRoot("domain"),
+			}...),
 		},
 	},
+	"domain": schema.StringAttribute{
+		Description: "The domain this Domain represents. These must be unique in our system; you cannot have " +
+			"two Domains representing the same domain.",
+		Optional: true,
+	},
+	"type": schema.StringAttribute{
+		Description: "If this Domain represents the authoritative source of information for the domain it " +
+			"describes, or if it is a read-only copy of a master (also called a slave).",
+		Computed: true,
+	},
+	"group": schema.StringAttribute{
+		Description: "The group this Domain belongs to. This is for display purposes only.",
+		Computed:    true,
+	},
+	"status": schema.StringAttribute{
+		Description: "Used to control whether this Domain is currently being rendered.",
+		Computed:    true,
+	},
+	"description": schema.StringAttribute{
+		Description: "A description for this Domain. This is for display purposes only.",
+		Computed:    true,
+	},
+	"master_ips": schema.SetAttribute{
+		Description: "The IP addresses representing the master DNS for this Domain.",
+		ElementType: types.StringType,
+		Computed:    true,
+	},
+	"axfr_ips": schema.SetAttribute{
+		Description: "The list of IPs that may perform a zone transfer for this Domain. This is potentially " +
+			"dangerous, and should be set to an empty list unless you intend to use it.",
+		ElementType: types.StringType,
+		Computed:    true,
+	},
+	"ttl_sec": schema.Int64Attribute{
+		Description: "'Time to Live' - the amount of time in seconds that this Domain's records may be " +
+			"cached by resolvers or other domain servers. " + domainSecondsDescription,
+		Computed: true,
+	},
+	"retry_sec": schema.Int64Attribute{
+		Description: "The interval, in seconds, at which a failed refresh should be retried. " +
+			domainSecondsDescription,
+		Computed: true,
+	},
+	"expire_sec": schema.Int64Attribute{
+		Description: "The amount of time in seconds that may pass before this Domain is no longer " +
+			domainSecondsDescription,
+		Computed: true,
+	},
+	"refresh_sec": schema.Int64Attribute{
+		Description: "The amount of time in seconds before this Domain should be refreshed. " +
+			domainSecondsDescription,
+		Computed: true,
+	},
+	"soa_email": schema.StringAttribute{
+		Description: "Start of Authority email address. This is required for master Domains.",
+		Computed:    true,
+	},
+	"tags": schema.SetAttribute{
+		Description: "An array of tags applied to this object. Tags are for organizational purposes only.",
+		Computed:    true,
+		ElementType: types.StringType,
+	},
+}
+
+var frameworkDataSourceSchema = schema.Schema{
+	Attributes: DomainAttributes,
 }

--- a/linode/domains/datasource_test.go
+++ b/linode/domains/datasource_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package domains_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/v2/linode/domains/tmpl"
+)
+
+func TestAccDataSourceDomains_basic(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_domains.foo"
+
+	domainName := acctest.RandomWithPrefix("tf-test") + ".example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.domain"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.type"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.description"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.status"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.tags.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.soa_email"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.retry_sec"),
+					resource.TestCheckResourceAttrSet(resourceName, "domains.0.expire_sec"),
+				),
+			},
+			{
+				Config: tmpl.DataFilter(t, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domains.0.type", "master"),
+				),
+			},
+		},
+	})
+}

--- a/linode/domains/datasource_test.go
+++ b/linode/domains/datasource_test.go
@@ -44,6 +44,14 @@ func TestAccDataSourceDomains_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domains.0.type", "master"),
 				),
 			},
+			{
+				Config: tmpl.DataAPIFilter(t, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "domains.0.tags.0", "tf_test"),
+					resource.TestCheckResourceAttr(resourceName, "domains.0.domain", domainName),
+				),
+			},
 		},
 	})
 }

--- a/linode/domains/framework_datasource.go
+++ b/linode/domains/framework_datasource.go
@@ -1,0 +1,68 @@
+package domains
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper"
+)
+
+type DataSource struct {
+	helper.BaseDataSource
+}
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{
+		BaseDataSource: helper.NewBaseDataSource(helper.BaseDataSourceConfig{
+			Name:   "linode_domains",
+			Schema: &frameworkDatasourceSchema,
+		}),
+	}
+}
+
+func (d *DataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var data DomainFilterModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, diag := filterConfig.GenerateID(data.Filters)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+	data.ID = id
+
+	result, diag := filterConfig.GetAndFilter(
+		ctx, d.Meta.Client, data.Filters, listDomains,
+		data.Order, data.OrderBy)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+
+	data.parseDomains(helper.AnySliceToTyped[linodego.Domain](result))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func listDomains(
+	ctx context.Context,
+	client *linodego.Client,
+	filter string,
+) ([]any, error) {
+	domains, err := client.ListDomains(ctx, &linodego.ListOptions{
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return helper.TypedSliceToAny(domains), nil
+}

--- a/linode/domains/framework_models.go
+++ b/linode/domains/framework_models.go
@@ -1,0 +1,31 @@
+package domains
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/domain"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
+)
+
+// DomainFilterModel describes the Terraform resource data model to match the
+// resource schema.
+type DomainFilterModel struct {
+	ID      types.String                     `tfsdk:"id"`
+	Filters frameworkfilter.FiltersModelType `tfsdk:"filter"`
+	Order   types.String                     `tfsdk:"order"`
+	OrderBy types.String                     `tfsdk:"order_by"`
+	Domains []domain.DomainModel             `tfsdk:"domains"`
+}
+
+func (data *DomainFilterModel) parseDomains(
+	domains []linodego.Domain,
+) {
+	result := make([]domain.DomainModel, len(domains))
+	for i := range domains {
+		var domainData domain.DomainModel
+		domainData.ParseDomain(&domains[i])
+		result[i] = domainData
+	}
+
+	data.Domains = result
+}

--- a/linode/domains/framework_schema.go
+++ b/linode/domains/framework_schema.go
@@ -1,0 +1,45 @@
+package domains
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/linode/terraform-provider-linode/v2/linode/domain"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
+)
+
+var filterConfig = frameworkfilter.Config{
+	"group": {APIFilterable: true, TypeFunc: helper.FilterTypeString},
+	"tags":  {APIFilterable: true, TypeFunc: helper.FilterTypeString},
+
+	"domain":      {APIFilterable: false, TypeFunc: helper.FilterTypeString},
+	"type":        {APIFilterable: false, TypeFunc: helper.FilterTypeString},
+	"status":      {APIFilterable: false, TypeFunc: helper.FilterTypeString},
+	"description": {APIFilterable: false, TypeFunc: helper.FilterTypeString},
+	"master_ips":  {APIFilterable: false, TypeFunc: helper.FilterTypeString},
+	"axfr_ips":    {APIFilterable: false, TypeFunc: helper.FilterTypeString},
+	"ttl_sec":     {APIFilterable: false, TypeFunc: helper.FilterTypeInt},
+	"retry_sec":   {APIFilterable: false, TypeFunc: helper.FilterTypeInt},
+	"expire_sec":  {APIFilterable: false, TypeFunc: helper.FilterTypeInt},
+	"refresh_sec": {APIFilterable: false, TypeFunc: helper.FilterTypeInt},
+	"soa_email":   {APIFilterable: false, TypeFunc: helper.FilterTypeString},
+}
+
+var frameworkDatasourceSchema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Description: "The data source's unique ID.",
+			Computed:    true,
+		},
+		"order":    filterConfig.OrderSchema(),
+		"order_by": filterConfig.OrderBySchema(),
+	},
+	Blocks: map[string]schema.Block{
+		"filter": filterConfig.Schema(),
+		"domains": schema.ListNestedBlock{
+			Description: "The returned list of Domains.",
+			NestedObject: schema.NestedBlockObject{
+				Attributes: domain.DomainAttributes,
+			},
+		},
+	},
+}

--- a/linode/domains/framework_schema.go
+++ b/linode/domains/framework_schema.go
@@ -8,10 +8,10 @@ import (
 )
 
 var filterConfig = frameworkfilter.Config{
-	"group": {APIFilterable: true, TypeFunc: helper.FilterTypeString},
-	"tags":  {APIFilterable: true, TypeFunc: helper.FilterTypeString},
+	"group":  {APIFilterable: true, TypeFunc: helper.FilterTypeString},
+	"tags":   {APIFilterable: true, TypeFunc: helper.FilterTypeString},
+	"domain": {APIFilterable: true, TypeFunc: helper.FilterTypeString},
 
-	"domain":      {APIFilterable: false, TypeFunc: helper.FilterTypeString},
 	"type":        {APIFilterable: false, TypeFunc: helper.FilterTypeString},
 	"status":      {APIFilterable: false, TypeFunc: helper.FilterTypeString},
 	"description": {APIFilterable: false, TypeFunc: helper.FilterTypeString},

--- a/linode/domains/tmpl/data_api_filter.gotf
+++ b/linode/domains/tmpl/data_api_filter.gotf
@@ -1,0 +1,14 @@
+{{ define "domains_data_api_filter" }}
+
+{{ template "domains_data_base" . }}
+
+data "linode_domains" "foo" {
+    filter {
+        name = "tags"
+        values = ["tf_test"]
+    }
+    order_by = "domain"
+    order = "desc"
+}
+
+{{ end }}

--- a/linode/domains/tmpl/data_base.gotf
+++ b/linode/domains/tmpl/data_base.gotf
@@ -1,0 +1,21 @@
+{{ define "domains_data_base" }}
+
+resource "linode_domain" "foo" {
+    domain = "{{.Domain}}"
+    type = "master"
+    status = "active"
+    soa_email = "example@{{.Domain}}"
+    description = "tf-testing"
+    tags = ["tf_test"]
+}
+
+resource "linode_domain" "bar" {
+    domain = "slave-{{.Domain}}"
+    type = "slave"
+    soa_email = "example@{{.Domain}}"
+    description = "tf-testing"
+    tags = ["tf_test"]
+    master_ips = ["12.34.56.78"]
+}
+
+{{ end }}

--- a/linode/domains/tmpl/data_basic.gotf
+++ b/linode/domains/tmpl/data_basic.gotf
@@ -1,0 +1,9 @@
+{{ define "domains_data_basic" }}
+
+{{ template "domains_data_base" . }}
+
+data "linode_domains" "foo" {
+    depends_on = [linode_domain.bar]
+}
+
+{{ end }}

--- a/linode/domains/tmpl/data_filter.gotf
+++ b/linode/domains/tmpl/data_filter.gotf
@@ -1,0 +1,12 @@
+{{ define "domains_data_filter" }}
+
+{{ template "domains_data_base" . }}
+
+data "linode_domains" "foo" {
+    filter {
+        name = "type"
+        values = ["master"]
+    }
+}
+
+{{ end }}

--- a/linode/domains/tmpl/template.go
+++ b/linode/domains/tmpl/template.go
@@ -1,0 +1,21 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
+)
+
+type TemplateData struct {
+	Domain string
+}
+
+func DataBasic(t *testing.T, domain string) string {
+	return acceptance.ExecuteTemplate(t,
+		"domains_data_basic", TemplateData{Domain: domain})
+}
+
+func DataFilter(t *testing.T, domain string) string {
+	return acceptance.ExecuteTemplate(t,
+		"domains_data_filter", TemplateData{Domain: domain})
+}

--- a/linode/domains/tmpl/template.go
+++ b/linode/domains/tmpl/template.go
@@ -19,3 +19,8 @@ func DataFilter(t *testing.T, domain string) string {
 	return acceptance.ExecuteTemplate(t,
 		"domains_data_filter", TemplateData{Domain: domain})
 }
+
+func DataAPIFilter(t *testing.T, domain string) string {
+	return acceptance.ExecuteTemplate(t,
+		"domains_data_api_filter", TemplateData{Domain: domain})
+}

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/databases"
 	"github.com/linode/terraform-provider-linode/v2/linode/domain"
 	"github.com/linode/terraform-provider-linode/v2/linode/domainrecord"
+	"github.com/linode/terraform-provider-linode/v2/linode/domains"
 	"github.com/linode/terraform-provider-linode/v2/linode/domainzonefile"
 	"github.com/linode/terraform-provider-linode/v2/linode/firewall"
 	"github.com/linode/terraform-provider-linode/v2/linode/firewalldevice"
@@ -223,5 +224,6 @@ func (p *FrameworkProvider) DataSources(ctx context.Context) []func() datasource
 		volumes.NewDataSource,
 		accountavailability.NewDataSource,
 		nbconfigs.NewDataSource,
+		domains.NewDataSource,
 	}
 }

--- a/linode/nbconfigs/tmpl/data_filter.gotf
+++ b/linode/nbconfigs/tmpl/data_filter.gotf
@@ -3,7 +3,6 @@
 {{ template "nb_configs_data_base" . }}
 
 data "linode_nodebalancer_configs" "foo" {
-    nodebalancer_id = "${linode_nodebalancer_config.bar.nodebalancer_id}"
     filter {
         name = "port"
         values = ["{{.Port}}"]

--- a/linode/nbconfigs/tmpl/data_filter.gotf
+++ b/linode/nbconfigs/tmpl/data_filter.gotf
@@ -3,6 +3,7 @@
 {{ template "nb_configs_data_base" . }}
 
 data "linode_nodebalancer_configs" "foo" {
+    nodebalancer_id = "${linode_nodebalancer_config.bar.nodebalancer_id}"
     filter {
         name = "port"
         values = ["{{.Port}}"]


### PR DESCRIPTION
## 📝 Description

Add a new data source `linode_domains` to allow listing and filtering on Domains. 

## ✔️ How to Test

`make testacc PKG_NAME="linode/domains"`

**Manual test:**

1. In a sandbox environment (i.e. dx-devenv), run the following terraform script to create two `linode_domain`
```
resource "linode_domain" "foo" {
    domain = "tf-test.example"
    type = "master"
    status = "active"
    soa_email = "example@tf-test.example"
    description = "tf-testing"
    tags = ["tf_test"]
}

resource "linode_domain" "bar" {
    domain = "slave-tf-test.example"
    type = "slave"
    soa_email = "example@tf-test.example"
    description = "tf-testing"
    tags = ["tf_test"]
    master_ips = ["12.34.56.78"]
}
```

2. Create a `linode_domains` data source to query the domain that we want. Assume that we want the master domain.
```
data "linode_domains" "master" {
    filter {
        name = "type"
        values = ["master"]
    }
}

output "linode_domains" {
  value = data.linode_domains.master.domains.0.id  
}
```

3. Observe that the output id equals to the id of `linode_domain.foo`