### PR TITLE
changed region in example to us-iad in vpc.md

### DIFF
--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -17,7 +17,7 @@ Create a VPC:
 ```terraform
 resource "linode_vpc" "test" {
     label = "test-vpc"
-    region = "us-east"
+    region = "us-iad"
     description = "My first VPC."
 }
 ```


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Example region of `us-east` does not work because Linode's Newark region (`us-east`) does not support VPCs at this time, resulting in a 404 error when applying the example. I changed the example to `us-iad` (Washington, DC) as a viable example region to use, which does support VPCs.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

Use `us-east` as the region in the Terraform example, observe the error output when applying:

```
Error: Failed to create VPC.

   with linode_vpc.test,
   on vpc.tf line 14, in resource "linode_vpc" "test":
   14: resource "linode_vpc" "test" {

 [404] Not found
```

Note: an additional configuration of `api_version = "v4beta"` may be needed for the example to work with a valid region (like `us-iad`) while VPC is still in beta.