### PR TITLE
Add timeout block support to BaseResourceConfig and `linode_rdns` resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/hashicorp/terraform-json v0.18.0 h1:pCjgJEqqDESv4y0Tzdqfxr/edOIGkjs8k
 github.com/hashicorp/terraform-json v0.18.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-plugin-framework v1.5.0 h1:8kcvqJs/x6QyOFSdeAyEgsenVOUeC/IyKpi2ul4fjTg=
 github.com/hashicorp/terraform-plugin-framework v1.5.0/go.mod h1:6waavirukIlFpVpthbGd2PUNYaFedB0RwW3MDzJ/rtc=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
 github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.0 h1:egR4InfakWkgepZNUATWGwkrPhaAYOTEybPfEol+G/I=
 github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.0/go.mod h1:9vjvl36aY1p6KltaA5QCvGC5hdE/9t4YuhGftw6WOgE=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=

--- a/linode/helper/framework_data.go
+++ b/linode/helper/framework_data.go
@@ -17,6 +17,26 @@ func KeepOrUpdateBool(original types.Bool, updated bool, preserveKnown bool) typ
 	return KeepOrUpdateValue(original, types.BoolValue(updated), preserveKnown)
 }
 
+func KeepOrUpdateStringPointer(original types.String, updated *string, preserveKnown bool) types.String {
+	return KeepOrUpdateValue(original, types.StringPointerValue(updated), preserveKnown)
+}
+
+func KeepOrUpdateInt64Pointer(original types.Int64, updated *int64, preserveKnown bool) types.Int64 {
+	return KeepOrUpdateValue(original, types.Int64PointerValue(updated), preserveKnown)
+}
+
+func KeepOrUpdateIntPointer(original types.Int64, updated *int, preserveKnown bool) types.Int64 {
+	if updated == nil {
+		return KeepOrUpdateValue(original, types.Int64Null(), preserveKnown)
+
+	}
+	return KeepOrUpdateInt64(original, int64(*updated), preserveKnown)
+}
+
+func KeepOrUpdateBoolPointer(original types.Bool, updated *bool, preserveKnown bool) types.Bool {
+	return KeepOrUpdateValue(original, types.BoolPointerValue(updated), preserveKnown)
+}
+
 func KeepOrUpdateValue[T attr.Value](original T, updated T, preserveKnown bool) T {
 	if preserveKnown && !original.IsUnknown() {
 		return original

--- a/linode/helper/framework_data.go
+++ b/linode/helper/framework_data.go
@@ -26,9 +26,10 @@ func KeepOrUpdateInt64Pointer(original types.Int64, updated *int64, preserveKnow
 }
 
 func KeepOrUpdateIntPointer(original types.Int64, updated *int, preserveKnown bool) types.Int64 {
+	// There is not a built in function in `types` library of the framework.
+	// Manually handle it here
 	if updated == nil {
 		return KeepOrUpdateValue(original, types.Int64Null(), preserveKnown)
-
 	}
 	return KeepOrUpdateInt64(original, int64(*updated), preserveKnown)
 }

--- a/linode/helper/framework_resource_base.go
+++ b/linode/helper/framework_resource_base.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -28,6 +29,7 @@ type BaseResourceConfig struct {
 
 	// Optional
 	Schema        *schema.Schema
+	TimeoutOpts   *timeouts.Opts
 	IsEarlyAccess bool
 }
 
@@ -80,6 +82,13 @@ func (r *BaseResource) Schema(
 				"Please provide a Schema config attribute or implement, the Schema(...) function.",
 		)
 		return
+	}
+
+	if r.Config.TimeoutOpts != nil {
+		if r.Config.Schema.Blocks == nil {
+			r.Config.Schema.Blocks = make(map[string]schema.Block)
+		}
+		r.Config.Schema.Blocks["timeouts"] = timeouts.Block(ctx, *r.Config.TimeoutOpts)
 	}
 
 	resp.Schema = *r.Config.Schema

--- a/linode/rdns/framework_models.go
+++ b/linode/rdns/framework_models.go
@@ -1,6 +1,7 @@
 package rdns
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper/customtypes"
@@ -11,6 +12,7 @@ type ResourceModel struct {
 	RDNS             types.String                  `tfsdk:"rdns"`
 	WaitForAvailable types.Bool                    `tfsdk:"wait_for_available"`
 	ID               types.String                  `tfsdk:"id"`
+	Timeouts         timeouts.Value                `tfsdk:"timeouts"`
 }
 
 func (rm *ResourceModel) parseConfiguredAttributes(ip *linodego.InstanceIP) {

--- a/linode/rdns/tmpl/template.go
+++ b/linode/rdns/tmpl/template.go
@@ -9,6 +9,8 @@ import (
 type TemplateData struct {
 	Label            string
 	Region           string
+	CreateTimeout    string
+	UpdateTimeout    string
 	WaitForAvailable bool
 }
 
@@ -35,5 +37,25 @@ func Deleted(t *testing.T, label, region string) string {
 		"rdns_deleted", TemplateData{
 			Label:  label,
 			Region: region,
+		})
+}
+
+func WithTimeout(t *testing.T, label, region, createTimeout, updateTimeout string) string {
+	return acceptance.ExecuteTemplate(t,
+		"rdns_with_timeout", TemplateData{
+			Label:         label,
+			Region:        region,
+			CreateTimeout: createTimeout,
+			UpdateTimeout: updateTimeout,
+		})
+}
+
+func WithTimeoutUpdated(t *testing.T, label, region, createTimeout, updateTimeout string) string {
+	return acceptance.ExecuteTemplate(t,
+		"rdns_with_timeout_updated", TemplateData{
+			Label:         label,
+			Region:        region,
+			CreateTimeout: createTimeout,
+			UpdateTimeout: updateTimeout,
 		})
 }

--- a/linode/rdns/tmpl/with_timeout.gotf
+++ b/linode/rdns/tmpl/with_timeout.gotf
@@ -1,0 +1,21 @@
+{{ define "rdns_with_timeout" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    image = "linode/alpine3.19"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+}
+
+resource "linode_rdns" "foobar" {
+    address = "${linode_instance.foobar.ip_address}"
+    rdns    = "${linode_instance.foobar.ip_address}.nip.io"
+    wait_for_available = true
+
+    timeouts {
+        create = "{{ .CreateTimeout }}"
+        update = "{{ .UpdateTimeout }}"
+    }
+}
+
+{{ end }}

--- a/linode/rdns/tmpl/with_timeout_updated.gotf
+++ b/linode/rdns/tmpl/with_timeout_updated.gotf
@@ -1,0 +1,21 @@
+{{ define "rdns_with_timeout_updated" }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    image = "linode/alpine3.19"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+}
+
+resource "linode_rdns" "foobar" {
+    address = "${linode_instance.foobar.ip_address}"
+    rdns    = "${replace(linode_instance.foobar.ip_address, ".", "-")}.nip.io"
+    wait_for_available = true
+
+    timeouts {
+        create = "{{ .CreateTimeout }}"
+        update = "{{ .UpdateTimeout }}"
+    }
+}
+
+{{ end }}


### PR DESCRIPTION
## 📝 Description

This PR separates timeout logic from [the volume migration PR](https://github.com/linode/terraform-provider-linode/pull/1240) as the breaking change might delay the volume migration work.

This PR also implements multiple helper functions for handling pointer values.

## ✔️ How to Test

~~We currently don't have any resource which has time consuming operations, so we probably can't test it in this PR.~~

~~However, in [the volume migration PR](https://github.com/linode/terraform-provider-linode/pull/1240), many operations are time consuming like resizing or creation. And that PR contains basically same code for handling timeout, so you can pull it and test it there.~~

Thanks @lgarber-akamai's idea! I added timeout support to `linode_rdns` resource. So now it can be tested with `linode_rdns` resource.

## Automated Testing

`make int-test PKG_NAME="linode/rdns"` 

## Manual Testing

```terraform
resource "linode_instance" "foobar" {
    label = "mylinode"
    image = "linode/debian12"
    type = "g6-nanode-1"
    region = "us-mia"
}

resource "linode_rdns" "foobar" {
    address = "${linode_instance.foobar.ip_address}"
    rdns    = "${linode_instance.foobar.ip_address}.nip.io"
    wait_for_available = true

    timeouts {
        create = "15m"
        update = "15m"
    }
}
```

You can verify if this config is applied successfully with Terraform, and then you can change the timeout to be a very small value, such as `1ms`, to verify it can fail in the case of timeout.
