### PR TITLE
Fix an example in instance config doc for vpc interface

### DIFF
--- a/docs/resources/instance_config.md
+++ b/docs/resources/instance_config.md
@@ -43,7 +43,7 @@ resource "linode_instance" "my-instance" {
 }
 ```
 
-Creating a complex bootable Instance Configuration Profile:
+Creating a complex bootable Instance Configuration Profile with a VPC:
 
 ```hcl
 resource "linode_instance_config" "my-config" {
@@ -77,10 +77,10 @@ resource "linode_instance_config" "my-config" {
     ipam_address = "10.0.0.2/24"
   }
 
-  # VPC networking on eth1
+  # VPC networking on eth2
   interface {
     purpose = "vpc"
-    subnet_id = 123
+    subnet_id = linode_vpc_subnet.foobar.id
     ipv4 {
       vpc = "10.0.4.250"
     }


### PR DESCRIPTION
## 📝 Description

This is to fix an example of instance config in the doc.

## ✔️ How to Test

You can test the example by applying it with Terraform.

```terraform
resource "linode_instance_config" "my-config" {
  linode_id = linode_instance.my-instance.id
  label = "my-config"

  device {
    device_name = "sda"
    disk_id = linode_instance_disk.boot.id
  }

  device {
    device_name = "sdb"
    disk_id = linode_instance_disk.swap.id
  }
  
  helpers {
    # Disable the updatedb helper
    updatedb_disabled = false
  }
  
  # Public networking on eth0
  interface {
    purpose = "public"
  }
  
  # VLAN networking on eth1
  interface {
    purpose = "vlan"
    label = "my-vlan"
    ipam_address = "10.0.0.2/24"
  }

  # VPC networking on eth2
  interface {
    purpose = "vpc"
    subnet_id = linode_vpc_subnet.foobar.id
    ipv4 {
      vpc = "10.0.4.250"
    }
  }
  
  booted = true

  // Run a remote-exec provisioner
  connection {
    host        = linode_instance.my-instance.ip_address
    user        = "root"
    password    = "myc00lpass!ciuw23asxbviwuc"
  }

  provisioner "remote-exec" {
    inline = [
      "echo 'Hello World!'"
    ]
  }
}

# Create a VPC and a subnet
resource "linode_vpc" "foobar" {
    label = "my-vpc"
    region = "us-mia"
    description = "test description"
}

resource "linode_vpc_subnet" "foobar" {
    vpc_id = linode_vpc.foobar.id
    label = "my-subnet"
    ipv4 = "10.0.4.0/24"
}

# Create a boot disk
resource "linode_instance_disk" "boot" {
  label = "boot"
  linode_id = linode_instance.my-instance.id
  size = linode_instance.my-instance.specs.0.disk - 512

  image = "linode/ubuntu22.04"
  root_pass = "myc00lpass!ciuw23asxbviwuc"
}

# Create a swap disk
resource "linode_instance_disk" "swap" {
  label = "swap"
  linode_id = linode_instance.my-instance.id
  size = 512
  filesystem = "swap"
}

resource "linode_instance" "my-instance" {
  label = "my-instance"
  type = "g6-standard-1"
  region = "us-mia"
}
```