### PR TITLE
fix: Restore `format` target to Makefile; make minor consistency improvements

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
       - run: go version
       - run: make deps
       - name: Check docs
-        run: make docscheck
+        run: make docs-check
       - name: Lint
         run: make lint
       - name: Unit tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,5 +18,8 @@ jobs:
 
       - run: go version
 
+      - name: Install deps
+        run: make deps
+
       - name: Run unit tests
         run: make unit-test

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ smoke-test: format
 	RUN_LONG_TESTS=$(RUN_LONG_TESTS) \
 	go test -v -run smoke ./linode/... -count $(COUNT) -timeout $(TIMEOUT) -parallel=$(PARALLEL) -ldflags="-X=github.com/linode/terraform-provider-linode/v2/version.ProviderVersion=acc"
 
-.PHONY: docscheck
-docscheck:
+.PHONY: docs-check
+docs-check:
 	# markdown linter for the documents
 	docker run --rm \
 		-v $$(pwd):/markdown:ro \

--- a/Makefile
+++ b/Makefile
@@ -54,21 +54,21 @@ vet:
 	golangci-lint run --disable-all --enable govet ./...
 
 .PHONY: test
-test: format smoke-test unit-test int-test
+test: fmt-check smoke-test unit-test int-test
 
 .PHONY: unit-test
-unit-test: format
+unit-test: fmt-check
 	go test -v --tags=unit ./$(PKG_NAME)
 
 .PHONY: int-test
-int-test: format
+int-test: fmt-check
 	TF_ACC=1 \
 	LINODE_API_VERSION="v4beta" \
 	RUN_LONG_TESTS=$(RUN_LONG_TESTS) \
 	go test --tags=integration -v ./$(PKG_NAME) -count $(COUNT) -timeout $(TIMEOUT) -parallel=$(PARALLEL) -ldflags="-X=github.com/linode/terraform-provider-linode/v2/version.ProviderVersion=acc" $(ARGS)
 
 .PHONY: smoke-test
-smoke-test: format
+smoke-test: fmt-check
 	TF_ACC=1 \
 	LINODE_API_VERSION="v4beta" \
 	RUN_LONG_TESTS=$(RUN_LONG_TESTS) \

--- a/Makefile
+++ b/Makefile
@@ -40,23 +40,24 @@ deps:
 	go generate -tags tools tools/tools.go
 
 .PHONY: format
-format: fmt vet errcheck imports
+format:
+	gofumpt -l -w .
 
-.PHONY: fmt vet errcheck imports
-fmt:
+.PHONY: fmt-check err-check imports-check vet
+fmt-check:
 	golangci-lint run --disable-all --enable gofumpt ./...
+err-check:
+	golangci-lint run --disable-all -E errcheck ./...
+imports-check:
+	golangci-lint run --disable-all --enable goimports ./...
 vet:
 	golangci-lint run --disable-all --enable govet ./...
-errcheck:
-	golangci-lint run --disable-all -E errcheck ./...
-imports:
-	golangci-lint run --disable-all --enable goimports ./...
 
 .PHONY: test
 test: format smoke-test unit-test int-test
 
 .PHONY: unit-test
-unit-test:
+unit-test: format
 	go test -v --tags=unit ./$(PKG_NAME)
 
 .PHONY: int-test


### PR DESCRIPTION
## 📝 Description

This change restores the `make format` target to the Makefile and makes a few other naming changes for consistency with other targets.

## ✔️ How to Test

1. Pull down this PR.
2. Run `make format`.
3. Observe the `gofumpt` has run.
