### PR TITLE
new: Add detailed logging to Firewall-related resources

### DIFF
--- a/linode/firewall/framework_datasource.go
+++ b/linode/firewall/framework_datasource.go
@@ -3,9 +3,8 @@ package firewall
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 

--- a/linode/firewall/framework_datasource.go
+++ b/linode/firewall/framework_datasource.go
@@ -3,6 +3,8 @@ package firewall
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -27,6 +29,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_firewall")
+
 	var data FirewallModel
 	client := d.Meta.Client
 
@@ -40,6 +44,9 @@ func (d *DataSource) Read(
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "firewall_id", firewallID)
+
+	tflog.Trace(ctx, "client.GetFirewall(...)")
 	firewall, err := client.GetFirewall(ctx, firewallID)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -48,6 +55,8 @@ func (d *DataSource) Read(
 		)
 		return
 	}
+
+	tflog.Trace(ctx, "client.GetFirewallRules(...)")
 	rules, err := client.GetFirewallRules(ctx, firewallID)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -56,6 +65,8 @@ func (d *DataSource) Read(
 		)
 		return
 	}
+
+	tflog.Trace(ctx, "client.ListFirewallDevices(...)")
 	devices, err := client.ListFirewallDevices(ctx, firewallID, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -67,8 +78,10 @@ func (d *DataSource) Read(
 
 	resp.Diagnostics.Append(data.parseComputedAttributes(ctx, firewall, rules, devices)...)
 	resp.Diagnostics.Append(data.parseNonComputedAttributes(ctx, firewall, rules, devices)...)
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/linode/firewall/resource.go
+++ b/linode/firewall/resource.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"

--- a/linode/firewall/resource.go
+++ b/linode/firewall/resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
@@ -37,11 +39,16 @@ func Resource() *schema.Resource {
 }
 
 func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	ctx = populateLogAttributes(ctx, d)
+	tflog.Debug(ctx, "Read linode_firewall")
+
 	client := meta.(*helper.ProviderMeta).Client
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("failed to parse Firewall %s as int: %s", d.Id(), err)
 	}
+
+	tflog.Trace(ctx, "client.GetFirewall(...)")
 	firewall, err := client.GetFirewall(ctx, id)
 	if err != nil {
 		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code == 404 {
@@ -52,11 +59,13 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("failed to get firewall %d: %s", id, err)
 	}
 
+	tflog.Trace(ctx, "client.GetFirewallRules(...)")
 	rules, err := client.GetFirewallRules(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get rules for firewall %d: %s", id, err)
 	}
 
+	tflog.Trace(ctx, "client.ListFirewallDevices(...)")
 	devices, err := client.ListFirewallDevices(ctx, id, nil)
 	if err != nil {
 		return diag.Errorf("failed to get devices for firewall %d: %s", id, err)
@@ -93,16 +102,28 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	createOpts.Rules.Outbound = expandFirewallRules(d.Get("outbound").([]any))
 	createOpts.Rules.OutboundPolicy = d.Get("outbound_policy").(string)
 
+	tflog.Debug(ctx, "client.CreateFirewall(...)", map[string]any{
+		"options": createOpts,
+	})
+
 	firewall, err := client.CreateFirewall(ctx, createOpts)
 	if err != nil {
 		return diag.Errorf("failed to create Firewall: %s", err)
 	}
 	d.SetId(strconv.Itoa(firewall.ID))
 
+	ctx = populateLogAttributes(ctx, d)
+
 	if d.Get("disabled").(bool) {
-		if _, err := client.UpdateFirewall(ctx, firewall.ID, linodego.FirewallUpdateOptions{
+		updateOpts := linodego.FirewallUpdateOptions{
 			Status: linodego.FirewallDisabled,
-		}); err != nil {
+		}
+
+		tflog.Debug(ctx, "client.UpdateFirewall(...)", map[string]any{
+			"options": updateOpts,
+		})
+
+		if _, err := client.UpdateFirewall(ctx, firewall.ID, updateOpts); err != nil {
 			return diag.Errorf("failed to disable firewall %d: %s", firewall.ID, err)
 		}
 	}
@@ -111,6 +132,9 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	ctx = populateLogAttributes(ctx, d)
+	tflog.Debug(ctx, "Update linode_firewall")
+
 	client := meta.(*helper.ProviderMeta).Client
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -130,6 +154,10 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			updateOpts.Status = expandFirewallStatus(d.Get("disabled"))
 		}
 
+		tflog.Debug(ctx, "client.UpdateFirewall(...)", map[string]any{
+			"options": updateOpts,
+		})
+
 		if _, err := client.UpdateFirewall(ctx, id, updateOpts); err != nil {
 			return diag.Errorf("failed to update firewall %d: %s", id, err)
 		}
@@ -143,6 +171,10 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Outbound:       outboundRules,
 		OutboundPolicy: d.Get("outbound_policy").(string),
 	}
+
+	tflog.Debug(ctx, "client.UpdateFirewallRules(...)", map[string]any{
+		"rules": ruleSet,
+	})
 	if _, err := client.UpdateFirewallRules(ctx, id, ruleSet); err != nil {
 		return diag.Errorf("failed to update rules for firewall %d: %s", id, err)
 	}
@@ -167,6 +199,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			})
 		}
 
+		tflog.Debug(ctx, "Reconciling firewall device assignments")
 		if err := updateFirewallDevices(ctx, d, client, id, assignments); err != nil {
 			return diag.Errorf("failed to update firewall devices: %s", err)
 		}
@@ -176,12 +209,15 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	ctx = populateLogAttributes(ctx, d)
+
 	client := meta.(*helper.ProviderMeta).Client
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("failed to parse Firewall %s as int: %s", d.Id(), err)
 	}
 
+	tflog.Debug(ctx, "ctx.DeleteFirewall(...)")
 	if err := client.DeleteFirewall(ctx, id); err != nil {
 		return diag.Errorf("failed to delete Firewall %d: %s", id, err)
 	}

--- a/linode/firewalls/framework_datasource.go
+++ b/linode/firewalls/framework_datasource.go
@@ -3,6 +3,8 @@ package firewalls
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
@@ -28,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_firewalls")
+
 	var data FirewallFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -69,6 +73,10 @@ func listFirewalls(
 	client *linodego.Client,
 	filter string,
 ) ([]any, error) {
+	tflog.Trace(ctx, "client.ListFirewalls", map[string]any{
+		"filter": filter,
+	})
+
 	firewalls, err := client.ListFirewalls(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})

--- a/linode/firewalls/framework_datasource.go
+++ b/linode/firewalls/framework_datasource.go
@@ -3,9 +3,8 @@ package firewalls
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )


### PR DESCRIPTION
## 📝 Description

This PR implements detailed logging for Firewall-related resources, including:
- linode_firewall (resource and data source)
- linode_firewall_device (resource)
- linode_firewalls (data source)

**NOTE:** Logging before each API request was inspired by feedback in https://github.com/linode/terraform-provider-linode/pull/1248. This may be unnecessary because of opt-in API request logs but it does make logs a good bit more readable. Any feedback would be much appreciated!

## ✔️ How to Test

The following test steps assume you have pulled this code locally.

### Manual Testing

**NOTE: You can filter the output to only include Linode provider logs using the following: `terraform apply 2> >(grep '@module=linode' >&2)`**

1. Enable trace logging for the Linode provider:

```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```

2. Inside of a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
# ...

data "linode_firewall" "test" {
  depends_on = [linode_firewall.test]

  id = linode_firewall.test.id
}

data "linode_firewalls" "test" {
  depends_on = [linode_firewall.test]

  filter {
    name = "label"
    values = [linode_firewall.test.label]
  }
}

resource "linode_firewall" "test" {
  label = "test-firewall"

  inbound {
    label    = "allow-http"
    action   = "ACCEPT"
    protocol = "TCP"
    ports    = "80"
    ipv4     = ["0.0.0.0/0"]
    ipv6     = ["::/0"]
  }

  inbound_policy = "DROP"

  outbound {
    label    = "reject-http"
    action   = "DROP"
    protocol = "TCP"
    ports    = "80"
    ipv4     = ["0.0.0.0/0"]
    ipv6     = ["::/0"]
  }

  outbound_policy = "ACCEPT"
}

resource "linode_firewall_device" "test" {
  firewall_id = linode_firewall.test.id
  entity_id = linode_instance.test.id
  entity_type = "linode"
}

resource "linode_instance" "test" {
  label = "test-instance"
  type = "g6-nanode-1"
  region = "us-mia"
}
```

3. Observe the new log statements in the stderr output.
4. Make and apply arbitrary changes to the `linode_firewall.test` and `linode_firewall_device.test` resources. 
5. Observe the new log statements in the stderr output.

