### PR TITLE
new: Add logging to `linode_volume` resource and data source

### DIFF
--- a/linode/volume/framework_datasource.go
+++ b/linode/volume/framework_datasource.go
@@ -2,10 +2,10 @@ package volume
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 

--- a/linode/volume/framework_datasource.go
+++ b/linode/volume/framework_datasource.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -47,6 +48,13 @@ func (r *DataSource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = tflog.SetField(ctx, "volume_id", volumeID)
+
+	tflog.Debug(ctx, "Read data.linode_volume")
+
+	tflog.Trace(ctx, "client.GetVolume(...)")
+
 	volume, err := client.GetVolume(ctx, volumeID)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get the volume.", err.Error())

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -102,7 +102,7 @@ func (r *Resource) CreateVolumeFromSource(
 		return nil
 	}
 
-	tflog.Trace(ctx, "client.CloneVolume(...)")
+	tflog.Debug(ctx, "client.CloneVolume(...)")
 
 	clonedVolume, err := client.CloneVolume(ctx, sourceVolumeID, data.Label.ValueString())
 	if err != nil {

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -3,13 +3,13 @@ package volume
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )


### PR DESCRIPTION
## 📝 Description

This PR adds logging to linode_volume resource and data source. Also removed an unused function from the volume resource.

## ✔️ How to Test

1. In a sandbox environment (i.e. dx-devenv), create a volume.

```
resource "linode_volume" "foo" {
  label  = "tf_test-volume"
  region = "us-mia"
  tags   = ["tf_test"]
}
```

2. Observe the new log statements in the stderr output. 