### PR TITLE
Shutdown Linode for Updating VPC Interface when Required in `linode_instance_config` Resource

### DIFF
--- a/linode/helper/instance.go
+++ b/linode/helper/instance.go
@@ -251,7 +251,7 @@ func ExpandConfigInterface(ifaceMap map[string]interface{}) linodego.InstanceCon
 	return result
 }
 
-func ExpandInterfaces(ctx context.Context, ifaces []any) []linodego.InstanceConfigInterfaceCreateOptions {
+func ExpandConfigInterfaces(ctx context.Context, ifaces []any) []linodego.InstanceConfigInterfaceCreateOptions {
 	result := make([]linodego.InstanceConfigInterfaceCreateOptions, len(ifaces))
 
 	for i, iface := range ifaces {

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -694,28 +694,13 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	if d.HasChange("interface") {
 		interfaces := d.Get("interface").([]interface{})
 
-		powerOffRequired := false
-
-		expandedInterfaces := make([]linodego.InstanceConfigInterfaceCreateOptions, len(interfaces))
+		expandedInterfaces := helper.ExpandConfigInterfaces(ctx, interfaces)
 		config, err := client.GetInstanceConfig(ctx, id, bootConfig)
 		if err != nil {
-			return diag.Errorf("failed to get the boot config: %s", err)
+			return diag.Errorf("failed to get config %d: %s", bootConfig, err)
 		}
 
-		for i, ni := range interfaces {
-			expandedInterfaces[i] = helper.ExpandConfigInterface(ni.(map[string]interface{}))
-
-			newInterface := expandedInterfaces[i]
-			var oldInterface *linodego.InstanceConfigInterface
-			if len(config.Interfaces) > i {
-				oldInterface = &config.Interfaces[i]
-			}
-
-			vpcInterfaceInvolved := newInterface.Purpose == linodego.InterfacePurposeVPC ||
-				(oldInterface != nil && oldInterface.Purpose == linodego.InterfacePurposeVPC)
-
-			powerOffRequired = powerOffRequired || vpcInterfaceInvolved
-		}
+		powerOffRequired := VPCInterfaceIncluded(config.Interfaces, expandedInterfaces)
 
 		tflog.Debug(ctx, "Updating instance config for interface changes", map[string]any{
 			"config_id": bootConfig,
@@ -726,38 +711,19 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 			return diag.Errorf("Error fetching data about the current linode: %s", err)
 		}
 
-		if powerOffRequired {
-			if meta.(*helper.ProviderMeta).Config.SkipImplicitReboots {
-				return diag.Errorf(
-					"add, remove, and reorder a Linode VPC interface requires implicit " +
-						"reboot of the Linode, please consider setting 'skip_implicit_reboots' " +
-						"to true in the Linode provider config.",
-				)
-			}
-
-			tflog.Debug(ctx, "shutting down instance for applying VPC interface change")
-
-			if _, err := waitForRunningOrOfflineState(
-				ctx, instance.Status, &client, id,
-			); err != nil {
-				return diag.Errorf(
-					"failed waiting for instance %d to be in running or offline state: %s", id, err,
-				)
-			}
-			if instance.Status != linodego.InstanceOffline {
-				if err := shutDownInstanceSync(
-					ctx, client, instance.ID, helper.GetDeadlineSeconds(ctx, d),
-				); err != nil {
-					return diag.Errorf("failed to shutdown instance: %s", err)
-				}
-			}
-		}
-
 		// we should power on Linode after updating of the interfaces if
 		// it's currently on and booted attribute is unset by the user.
 		// Otherwise, it will stay off (if it's already off) or be handled by
 		// `handleBootedUpdate` (if booted is set to an explicit value)
 		shouldPowerOn := bootedNull && powerOffRequired && instance.Status == linodego.InstanceRunning
+
+		if powerOffRequired {
+			if diag := ShutdownInstanceForVPCInterfaceUpdate(
+				ctx, meta.(*helper.ProviderMeta), id, helper.GetDeadlineSeconds(ctx, d),
+			); diag != nil {
+				return diag
+			}
+		}
 
 		// reboot won't be needed if we power off the Linode during update
 		rebootInstance = !powerOffRequired
@@ -771,16 +737,11 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 			return diag.Errorf("failed to set boot config interfaces: %s", err)
 		}
 
-		instance, err = client.GetInstance(ctx, id)
-		if err != nil {
-			return diag.Errorf("Error fetching data about the current linode: %s", err)
-		}
 		if shouldPowerOn {
-			tflog.Debug(ctx, "booting instance after VPC interface change applied")
-			if err := bootInstanceSync(
-				ctx, client, instance.ID, bootConfig, helper.GetDeadlineSeconds(ctx, d),
-			); err != nil {
-				return diag.Errorf("failed to boot instance after VPC interface change applied: %s", err)
+			if diag := BootInstanceAfterVPCInterfaceUpdate(
+				ctx, meta.(*helper.ProviderMeta), id, bootConfig, helper.GetDeadlineSeconds(ctx, d),
+			); diag != nil {
+				return diag
 			}
 		}
 

--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
+	instancehelpers "github.com/linode/terraform-provider-linode/v2/linode/instance"
 )
 
 func Resource() *schema.Resource {
@@ -144,7 +145,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Label:       d.Get("label").(string),
 		Comments:    d.Get("comments").(string),
 		Helpers:     expandHelpers(d.Get("helpers")),
-		Interfaces:  helper.ExpandInterfaces(ctx, d.Get("interface").([]any)),
+		Interfaces:  helper.ExpandConfigInterfaces(ctx, d.Get("interface").([]any)),
 		MemoryLimit: d.Get("memory_limit").(int),
 		Kernel:      d.Get("kernel").(string),
 		RunLevel:    d.Get("run_level").(string),
@@ -271,22 +272,52 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		shouldUpdate = true
 	}
 
+	powerOffRequired := false
 	if d.HasChange("interface") {
-		putRequest.Interfaces = helper.ExpandInterfaces(ctx, d.Get("interface").([]any))
+		putRequest.Interfaces = helper.ExpandConfigInterfaces(ctx, d.Get("interface").([]any))
+		config, err := client.GetInstanceConfig(ctx, linodeID, id)
+		if err != nil {
+			return diag.Errorf("failed to get config %d: %s", id, err)
+		}
+
+		bootedConfigID, err := helper.GetCurrentBootedConfig(ctx, &client, linodeID)
+		if err != nil {
+			tflog.Warn(
+				ctx, fmt.Sprintf("failed to get current booted config of Linode %d", linodeID),
+			)
+		}
+
+		powerOffRequired = instancehelpers.VPCInterfaceIncluded(config.Interfaces, putRequest.Interfaces) && id == bootedConfigID
 		shouldUpdate = true
 	}
 
+	// We should not use `HasChange(...)` here because of possible mid-apply changes
+	managedBoot := !d.GetRawConfig().GetAttr("booted").IsNull()
+
+	shouldPowerBackOn := !managedBoot && powerOffRequired && inst.Status == linodego.InstanceRunning
+
 	if shouldUpdate {
+		if powerOffRequired {
+			instancehelpers.ShutdownInstanceForVPCInterfaceUpdate(
+				ctx, meta.(*helper.ProviderMeta), linodeID, helper.GetDeadlineSeconds(ctx, d),
+			)
+		}
+
 		tflog.Debug(ctx, "Update detected, sending config PUT request to API", map[string]any{
 			"body": putRequest,
 		})
-		if _, err := client.UpdateInstanceConfig(ctx, linodeID, int(id), putRequest); err != nil {
+		if _, err := client.UpdateInstanceConfig(ctx, linodeID, id, putRequest); err != nil {
 			return diag.Errorf("failed to update instance config: %s", err)
+		}
+
+		if shouldPowerBackOn {
+			instancehelpers.BootInstanceAfterVPCInterfaceUpdate(
+				ctx, meta.(*helper.ProviderMeta), linodeID, id, helper.GetDeadlineSeconds(ctx, d),
+			)
 		}
 	}
 
-	// We should not use `HasChange(...)` here because of possible mid-apply changes
-	if !d.GetRawConfig().GetAttr("booted").IsNull() {
+	if managedBoot {
 		if err := applyBootStatus(ctx, &client, inst, id, helper.GetDeadlineSeconds(ctx, d),
 			d.Get("booted").(bool)); err != nil {
 			return diag.Errorf("failed to update boot status: %s", err)

--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -375,7 +375,7 @@ func TestAccResourceInstanceConfig_vpcInterface(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.VPCInterfaceUpdates(t, instanceName, testRegion, rootPass),
+				Config: tmpl.VPCInterfaceUpdated(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resName, nil),
 					resource.TestCheckResourceAttr(resName, "interface.0.purpose", "public"),
@@ -385,6 +385,49 @@ func TestAccResourceInstanceConfig_vpcInterface(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "interface.1.ip_ranges.0", "10.0.4.100/32"),
 
 					resource.TestCheckResourceAttr(networkDSName, "ipv4.0.public.0.vpc_nat_1_1.#", "0"),
+				),
+			},
+			{
+				Config: tmpl.VPCInterfaceSwapped(t, instanceName, testRegion, rootPass),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resName, nil),
+					resource.TestCheckResourceAttr(resName, "interface.#", "2"),
+					resource.TestCheckResourceAttr(resName, "interface.1.purpose", "public"),
+					resource.TestCheckResourceAttr(resName, "interface.0.purpose", "vpc"),
+					resource.TestCheckResourceAttr(resName, "interface.0.ipv4.0.vpc", "10.0.4.249"),
+					resource.TestCheckResourceAttr(resName, "interface.0.active", "false"),
+					resource.TestCheckResourceAttr(resName, "interface.0.ip_ranges.0", "10.0.4.100/32"),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: resourceImportStateID,
+			},
+			{
+				Config: tmpl.VPCInterfaceOnly(t, instanceName, testRegion, rootPass),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resName, nil),
+					resource.TestCheckResourceAttr(resName, "interface.#", "1"),
+					resource.TestCheckResourceAttr(resName, "interface.0.purpose", "vpc"),
+					resource.TestCheckResourceAttr(resName, "interface.0.ipv4.0.vpc", "10.0.4.249"),
+					resource.TestCheckResourceAttr(resName, "interface.0.active", "false"),
+					resource.TestCheckResourceAttr(resName, "interface.0.ip_ranges.0", "10.0.4.100/32"),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: resourceImportStateID,
+			},
+			{
+				Config: tmpl.VPCInterfaceRemoved(t, instanceName, testRegion, rootPass),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resName, nil),
+					resource.TestCheckResourceAttr(resName, "interface.#", "1"),
+					resource.TestCheckResourceAttr(resName, "interface.0.purpose", "public"),
 				),
 			},
 			{

--- a/linode/instanceconfig/tmpl/template.go
+++ b/linode/instanceconfig/tmpl/template.go
@@ -102,10 +102,43 @@ func VPCInterface(t *testing.T, label, region string, rootPass string) string {
 	)
 }
 
-func VPCInterfaceUpdates(t *testing.T, label, region string, rootPass string) string {
+func VPCInterfaceUpdated(t *testing.T, label, region string, rootPass string) string {
 	return acceptance.ExecuteTemplate(
 		t,
 		"vpc_interface_update", TemplateData{
+			Label:    label,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+}
+
+func VPCInterfaceRemoved(t *testing.T, label, region string, rootPass string) string {
+	return acceptance.ExecuteTemplate(
+		t,
+		"vpc_interface_remove", TemplateData{
+			Label:    label,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+}
+
+func VPCInterfaceSwapped(t *testing.T, label, region string, rootPass string) string {
+	return acceptance.ExecuteTemplate(
+		t,
+		"vpc_interface_swap", TemplateData{
+			Label:    label,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+}
+
+func VPCInterfaceOnly(t *testing.T, label, region string, rootPass string) string {
+	return acceptance.ExecuteTemplate(
+		t,
+		"vpc_interface_only", TemplateData{
 			Label:    label,
 			Region:   region,
 			RootPass: rootPass,

--- a/linode/instanceconfig/tmpl/vpc_interface_only.gotf
+++ b/linode/instanceconfig/tmpl/vpc_interface_only.gotf
@@ -1,0 +1,37 @@
+{{ define "vpc_interface_only" }}
+
+{{ template "instance_config_empty_instance" . }}
+
+{{ template "instance_config_disk" . }}
+
+{{ template "vpc_for_instance_config" . }}
+
+resource "linode_instance_config" "foobar" {
+  linode_id = linode_instance.foobar.id
+  label = "my-config"
+
+  device {
+    device_name = "sda"
+    disk_id = linode_instance_disk.foobar.id
+  }
+
+  interface {
+    purpose = "vpc"
+    subnet_id = linode_vpc_subnet.foobar.id
+    ipv4 {
+      vpc = "10.0.4.249"
+      nat_1_1 = "any"
+    }
+    ip_ranges = ["10.0.4.100/32"]
+  }
+
+  kernel = "linode/grub2"
+  root_device = "/dev/sda"
+}
+
+data "linode_instance_networking" "foobar" {
+  depends_on = [linode_instance_config.foobar]
+  linode_id = linode_instance.foobar.id
+}
+
+{{ end }}

--- a/linode/instanceconfig/tmpl/vpc_interface_removed.gotf
+++ b/linode/instanceconfig/tmpl/vpc_interface_removed.gotf
@@ -1,0 +1,32 @@
+{{ define "vpc_interface_remove" }}
+
+{{ template "instance_config_empty_instance" . }}
+
+{{ template "instance_config_disk" . }}
+
+{{ template "vpc_for_instance_config" . }}
+
+resource "linode_instance_config" "foobar" {
+  linode_id = linode_instance.foobar.id
+  label = "my-config-removed"
+  comments = "cool-removed"
+
+  device {
+    device_name = "sda"
+    disk_id = linode_instance_disk.foobar.id
+  }
+
+  interface {
+    purpose = "public"
+  }
+
+  kernel = "linode/grub2"
+  root_device = "/dev/sda"
+}
+
+data "linode_instance_networking" "foobar" {
+  depends_on = [linode_instance_config.foobar]
+  linode_id = linode_instance.foobar.id
+}
+
+{{ end }}

--- a/linode/instanceconfig/tmpl/vpc_interface_swapped.gotf
+++ b/linode/instanceconfig/tmpl/vpc_interface_swapped.gotf
@@ -1,0 +1,41 @@
+{{ define "vpc_interface_swap" }}
+
+{{ template "instance_config_empty_instance" . }}
+
+{{ template "instance_config_disk" . }}
+
+{{ template "vpc_for_instance_config" . }}
+
+resource "linode_instance_config" "foobar" {
+  linode_id = linode_instance.foobar.id
+  label = "my-config-swapped"
+  comments = "cool-swapped"
+
+  device {
+    device_name = "sda"
+    disk_id = linode_instance_disk.foobar.id
+  }
+
+  interface {
+    purpose = "vpc"
+    subnet_id = linode_vpc_subnet.foobar.id
+    ipv4 {
+      vpc = "10.0.4.249"
+    }
+    ip_ranges = ["10.0.4.100/32"]
+  }
+
+  interface {
+    purpose = "public"
+  }
+
+  kernel = "linode/grub2"
+  root_device = "/dev/sda"
+}
+
+data "linode_instance_networking" "foobar" {
+  depends_on = [linode_instance_config.foobar]
+  linode_id = linode_instance.foobar.id
+}
+
+{{ end }}


### PR DESCRIPTION
## 📝 Description

The Terraform provider doesn't currently handle VPC interfaces update on a Linode which requires a shutting down of the instance before calling the PUT API endpoint. This PR implement the logic to handle it. Some refactors of the previous VPC interfaces update logic in `linode_instance` resource is also included, for reduced repeated code.

## ✔️ How to Test

### Automated Testing
`make PKG_NAME="linode/instanceconfig" int-test`

### Manual Testing

You can test the VPC interface by moving it around (add, remove, swap) in the following TF config.
```terraform
resource "linode_vpc" "foobar" {
    label = "test-vpc-tf"
    region = "us-mia"
}

resource "linode_vpc_subnet" "foobar" {
    vpc_id = linode_vpc.foobar.id
    label = "test-vpc-tf"
    ipv4 = "10.0.4.0/24"
}

resource "linode_instance_config" "my-config" {
  linode_id = linode_instance.my-instance.id
  label = "my-config"

  device {
    device_name = "sda"
    disk_id = linode_instance_disk.boot.id
  }

  device {
    device_name = "sdb"
    disk_id = linode_instance_disk.swap.id
  }

  interface {
    purpose = "public"
  }

  interface {
    purpose = "vlan"
    label = "my-vlan"
    ipam_address = "192.0.24.11/24"
  }
  
  booted = true
  kernel = "linode/grub2"
}

resource "linode_instance_disk" "boot" {
  label = "boot"
  linode_id = linode_instance.my-instance.id
  size = linode_instance.my-instance.specs.0.disk - 1024

  image = "linode/ubuntu22.04"
  root_pass = "myc00lpassegvbherhvgoewrgvol"
}

resource "linode_instance_disk" "swap" {
  label = "swap"
  linode_id = linode_instance.my-instance.id
  size = 1024
  filesystem = "swap"
}

resource "linode_instance" "my-instance" {
  label = "my-instance"
  type = "g6-nanode-1"
  region = "us-mia"
}
```