### PR TITLE
new: Add logging for nb related resource and data sources

### DIFF
--- a/linode/nb/framework_datasource.go
+++ b/linode/nb/framework_datasource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -28,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_nodebalancer")
+
 	var data NodeBalancerDataSourceModel
 	client := d.Meta.Client
 
@@ -44,6 +48,9 @@ func (d *DataSource) Read(
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "nodebalancer_id", nodeBalancerID)
+	tflog.Trace(ctx, "client.GetNodeBalancer(...)")
+
 	nodeBalancer, err := client.GetNodeBalancer(ctx, nodeBalancerID)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -51,6 +58,8 @@ func (d *DataSource) Read(
 			err.Error(),
 		)
 	}
+
+	tflog.Trace(ctx, "client.ListNodeBalancerFirewalls(...)")
 
 	firewalls, err := client.ListNodeBalancerFirewalls(ctx, nodeBalancerID, nil)
 	if err != nil {

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -132,7 +132,7 @@ func (r *Resource) Read(
 	}
 
 	ctx = populateLogAttributes(ctx, data)
-	tflog.Trace(ctx, "client.GetNodeBalancer(...)")
+	tflog.Debug(ctx, "client.GetNodeBalancer(...)")
 
 	nodeBalancer, err := client.GetNodeBalancer(ctx, id)
 	if err != nil {
@@ -214,7 +214,9 @@ func (r *Resource) Update(
 			return
 		}
 
-		tflog.Trace(ctx, "client.UpdateNodeBalancer(...)")
+		tflog.Debug(ctx, "client.UpdateNodeBalancer(...)", map[string]any{
+			"options": updateOpts,
+		})
 
 		nodeBalancer, err := client.UpdateNodeBalancer(ctx, id, updateOpts)
 		if err != nil {

--- a/linode/nbconfig/framework_datasource.go
+++ b/linode/nbconfig/framework_datasource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -28,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_nodebalancer_config")
+
 	client := d.Meta.Client
 	var data DataSourceModel
 
@@ -41,6 +45,11 @@ func (d *DataSource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	tflog.Debug(ctx, "client.GetNodeBalancerConfig(...)", map[string]any{
+		"nodebalancer_id": nodeBalancerID,
+		"config_id":       configID,
+	})
 
 	config, err := client.GetNodeBalancerConfig(ctx, nodeBalancerID, configID)
 	if err != nil {

--- a/linode/nbconfigs/framework_datasource.go
+++ b/linode/nbconfigs/framework_datasource.go
@@ -3,6 +3,8 @@ package nbconfigs
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -27,6 +29,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_nodebalancer_configs")
+
 	var data NodeBalancerConfigFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -64,6 +68,9 @@ func (data *NodeBalancerConfigFilterModel) listNodeBalancerConfigs(
 	if err != nil {
 		return nil, err
 	}
+
+	ctx = tflog.SetField(ctx, "nodebalancer_id", nbId)
+	tflog.Trace(ctx, "client.ListNodeBalancerConfigs(...)")
 
 	nbs, err := client.ListNodeBalancerConfigs(ctx, nbId, &linodego.ListOptions{
 		Filter: filter,

--- a/linode/nbnode/framework_datasource.go
+++ b/linode/nbnode/framework_datasource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -28,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.nb_node")
+
 	client := d.Meta.Client
 
 	var data DataSourceModel
@@ -46,6 +50,9 @@ func (d *DataSource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = tflog.SetField(ctx, "node_id", id)
+	tflog.Trace(ctx, "client.GetNodeBalancerNode(...)")
 
 	node, err := client.GetNodeBalancerNode(ctx, nodeBalancerID, configID, id)
 	if err != nil {

--- a/linode/nbs/framework_datasource.go
+++ b/linode/nbs/framework_datasource.go
@@ -3,6 +3,8 @@ package nbs
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
@@ -26,6 +28,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.nodebalancers")
+
 	var data NodeBalancerFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -57,6 +61,8 @@ func listNodeBalancers(
 	client *linodego.Client,
 	filter string,
 ) ([]any, error) {
+	tflog.Trace(ctx, "client.ListNodeBalancers(...)")
+
 	nbs, err := client.ListNodeBalancers(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})


### PR DESCRIPTION
## 📝 Description

Add logging for following resource and data source:
- nodebalancer (resource and data source)
- nodebalancer_config (resource and data source)
- nodebalancer_configs (data source)
- nodebalancer_node (resource and data source)
- nodebalancers (data source)

## ✔️ How to Test

1. Enable trace logging for the Linode provider:
```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```
2. Inside of a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:

Use filter `terraform apply 2> >(grep '@module=linode' >&2) `
```
# ...
terraform {
  required_providers {
    // Running sandbox targets will automatically
    // use the local provider in repos/terraform-provider-linode
    linode = {
      source  = "linode/linode"
      version = "2.6.0"
    }
  }
}

data "linode_nodebalancer_config" "my-config" {
  depends_on = [linode_nodebalancer_config.foofig]
  id              = linode_nodebalancer_config.foofig.id
  nodebalancer_id = linode_nodebalancer_config.foofig.nodebalancer_id
}

data "linode_nodebalancer_configs" "filter_nb_configs" {
  depends_on = [linode_nodebalancer_config.foofig]
  nodebalancer_id = linode_nodebalancer_config.foofig.nodebalancer_id
  filter {
    name   = "port"
    values = ["80"]
  }
}

data "linode_nodebalancer_node" "my-node" {
  count          = 3
  id             = linode_nodebalancer_node.foonode[count.index].id
  nodebalancer_id = linode_nodebalancer_node.foonode[count.index].nodebalancer_id
  config_id      = linode_nodebalancer_node.foonode[count.index].config_id
}


data "linode_nodebalancers" "specific-nodebalancers" {
  filter {
    name   = "label"
    values = ["my-nodebalancer"]
  }

  filter {
    name   = "region"
    values = ["us-east"]
  }
}

resource "linode_instance" "web" {
  count           = 3
  label           = "web-${count.index + 1}"
  image           = "linode/ubuntu20.04"
  region          = "us-east"
  type            = "g6-nanode-1"
  authorized_keys = ["ssh-rsa AAAA...Gw== user@example.local"]
  root_pass       = "terraform-test"
  private_ip      = true
}

resource "linode_nodebalancer" "foobar" {
  label                = "mynodebalancer"
  region               = "us-east"
  client_conn_throttle = 20
}

resource "linode_nodebalancer_config" "foofig" {
  nodebalancer_id = linode_nodebalancer.foobar.id
  port            = 80
  protocol        = "http"
  check           = "http"
  check_path      = "/foo"
  check_attempts  = 3
  check_timeout   = 30
  stickiness      = "http_cookie"
  algorithm       = "source"
}

resource "linode_nodebalancer_node" "foonode" {
  count          = 3
  nodebalancer_id = linode_nodebalancer.foobar.id
  config_id      = linode_nodebalancer_config.foofig.id
  address        = "${element(linode_instance.web.*.private_ip, count.index)}:80"
  label          = "mynodebalancernode"
  weight         = 50
}

```



## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**