### PR TITLE
new: Add detailed logging to `linode_rdns` resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ There are a number of useful flags and variables to aid in debugging.
 - `TF_SCHEMA_PANIC_ON_ERROR` - This forces Terraform to panic if a Schema Set command failed.
 
 These values (along with `LINODE_TOKEN`) can be placed in a `.env` file in the repository root to avoid repeating them on the command line.
+
+To filter down to logs relevant to the Linode provider, the following command can be used:
+
+```bash
+terraform apply 2> >(grep '@module=linode' >&2)
+```

--- a/linode/rdns/framework_helper.go
+++ b/linode/rdns/framework_helper.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/linode/linodego"
 )
 

--- a/linode/rdns/framework_helper.go
+++ b/linode/rdns/framework_helper.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/linode/linodego"
 )
 
@@ -25,18 +27,27 @@ func updateIPAddress(
 		return updateIPAddressWithRetries(ctx, client, address, updateOpts, time.Second*5)
 	}
 
+	tflog.Debug(ctx, "client.UpdateIPAddress(...)", map[string]any{
+		"options": updateOpts,
+	})
+
 	return client.UpdateIPAddress(ctx, address, updateOpts)
 }
 
 func updateIPAddressWithRetries(ctx context.Context, client *linodego.Client, address string,
 	updateOpts linodego.IPAddressUpdateOptions, retryDuration time.Duration,
 ) (*linodego.InstanceIP, error) {
+	tflog.Debug(ctx, "Attempting to update IP address RDNS with retries")
+
 	ticker := time.NewTicker(retryDuration)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
+			tflog.Debug(ctx, "client.UpdateIPAddress(...)", map[string]any{
+				"options": updateOpts,
+			})
 			result, err := client.UpdateIPAddress(ctx, address, updateOpts)
 			if err != nil {
 				if lerr, ok := err.(*linodego.Error); ok && lerr.Code != 400 &&
@@ -44,6 +55,7 @@ func updateIPAddressWithRetries(ctx context.Context, client *linodego.Client, ad
 					return nil, fmt.Errorf("failed to update ip address: %s", err)
 				}
 
+				tflog.Debug(ctx, "IP is not yet ready for assignment")
 				continue
 			}
 

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -43,6 +45,8 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
+	tflog.Debug(ctx, "Create linode_rdns")
+
 	var plan ResourceModel
 	client := r.Meta.Client
 
@@ -50,6 +54,8 @@ func (r *Resource) Create(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = populateLogAttributes(ctx, plan)
 
 	createTimeout, diags := plan.Timeouts.Create(ctx, DefaultVolumeCreateTimeout)
 	resp.Diagnostics.Append(diags...)
@@ -60,7 +66,13 @@ func (r *Resource) Create(
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	ip, err := client.GetIPAddress(ctx, plan.Address.ValueString())
+	address := plan.Address.ValueString()
+
+	tflog.Trace(ctx, "client.GetIPAddress(...)", map[string]any{
+		"address": address,
+	})
+
+	ip, err := client.GetIPAddress(ctx, address)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to get the ip address associated with this RDNS",
@@ -107,6 +119,8 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read linode_rdns")
+
 	client := r.Meta.Client
 
 	var data ResourceModel
@@ -116,10 +130,13 @@ func (r *Resource) Read(
 		return
 	}
 
+	ctx = populateLogAttributes(ctx, data)
+
 	if helper.FrameworkAttemptRemoveResourceForEmptyID(ctx, data.ID, resp) {
 		return
 	}
 
+	tflog.Trace(ctx, "client.GetIPAddress(...)")
 	ip, err := client.GetIPAddress(ctx, data.ID.ValueString())
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -149,6 +166,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
+	tflog.Debug(ctx, "Update linode_rdns")
+
 	var state, plan ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -156,6 +175,8 @@ func (r *Resource) Update(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = populateLogAttributes(ctx, state)
 
 	updateTimeout, diags := plan.Timeouts.Update(ctx, DefaultVolumeUpdateTimeout)
 	resp.Diagnostics.Append(diags...)
@@ -203,6 +224,8 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
+	tflog.Debug(ctx, "Delete linode_rdns")
+
 	var data ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -216,6 +239,9 @@ func (r *Resource) Delete(
 		RDNS: nil,
 	}
 
+	tflog.Debug(ctx, "client.UpdateIPAddress(...)", map[string]any{
+		"options": updateOpts,
+	})
 	_, err := client.UpdateIPAddress(ctx, data.Address.ValueString(), updateOpts)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -237,4 +263,10 @@ func (r *Resource) Delete(
 			),
 		)
 	}
+}
+
+func populateLogAttributes(ctx context.Context, model ResourceModel) context.Context {
+	return helper.SetLogFieldBulk(ctx, map[string]any{
+		"address": model.Address.ValueString(),
+	})
 }


### PR DESCRIPTION
## 📝 Description

This change adds detailed logging to the `linode_rdns` resource and adds a small note to the README for filtering logs.

## ✔️ How to Test


### Manual Testing

**NOTE: You can filter the output to only include Linode provider logs using the following: `terraform apply 2> >(grep '@module=linode' >&2)`**

1. Enable trace logging for the Linode provider:

```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```

2. Inside of a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
# ...

resource "linode_instance" "test" {
    label = "test"
    image = "linode/alpine3.19"
    type = "g6-standard-1"
    region = "us-mia"
}

resource "linode_rdns" "test" {
    address = "${linode_instance.test.ip_address}"
    rdns    = "${replace(linode_instance.test.ip_address, ".", "-")}.nip.io"
    wait_for_available = true
}
```

3. Observe the new log statements in the stderr output.
4. Make and apply arbitrary changes to the `linode_rdns.test` resource. 
5. Observe the new log statements in the stderr output.
