### PR TITLE
new: Add detailed logging to user-related resources

### DIFF
--- a/linode/user/resource.go
+++ b/linode/user/resource.go
@@ -61,10 +61,10 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_user")
 
 	client := meta.(*helper.ProviderMeta).Client
-	ctx = populateLogAttributes(ctx, d)
 
 	username := d.Get("username").(string)
 

--- a/linode/users/framework_datasource.go
+++ b/linode/users/framework_datasource.go
@@ -3,6 +3,8 @@ package users
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
@@ -28,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_users")
+
 	var data UserFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -60,6 +64,10 @@ func listUsers(
 	client *linodego.Client,
 	filter string,
 ) ([]any, error) {
+	tflog.Trace(ctx, "client.ListUsers(...)", map[string]any{
+		"filter": filter,
+	})
+
 	users, err := client.ListUsers(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})


### PR DESCRIPTION
## 📝 Description

This change adds detailed logging to the following resources and data sources:

- `linode_user`
- `linode_users`

## ✔️ How to Test

### Manual Testing

**NOTE: You can filter the output to only include Linode provider logs using the following: `terraform apply 2> >(grep '@module=linode' >&2)`**

1. Enable trace logging for the Linode provider:

```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```

2. Inside of a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
# ...

resource "random_string" "test" {
  length  = 10
  special = false
}

resource "linode_user" "test" {
  username   = random_string.test.result
  email      = "${random_string.test.result}@linode.com"
  restricted = true

  global_grants {
    add_linodes = true
    add_images  = true
  }
}

data "linode_user" "test" {
  depends_on = [linode_user.test]

  username = linode_user.test.username
}

data "linode_users" "test" {
  depends_on = [linode_user.test]

  filter {
    name   = "username"
    values = [linode_user.test.username]
  }
}
```

3. Observe the new log statements in the stderr output.
4. Make and apply arbitrary changes to the `linode_user.test` resource. 
5. Observe the new log statements in the stderr output.
