### PR TITLE
new: Add detailed logging to `linode_domain` and `linode_domain_record`

### DIFF
--- a/linode/domain/framework_datasource.go
+++ b/linode/domain/framework_datasource.go
@@ -32,7 +32,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	tflog.Debug(ctx, "Read data.linode_volume")
+	tflog.Debug(ctx, "Read data.linode_domain")
 
 	var data DomainModel
 

--- a/linode/domain/framework_datasource.go
+++ b/linode/domain/framework_datasource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -31,6 +32,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_volume")
+
 	var data DomainModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -47,6 +50,9 @@ func (d *DataSource) Read(
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		ctx = tflog.SetField(ctx, "domain_id", id)
+
 		domain, err = d.getDomainByID(ctx, id)
 	} else {
 		domain, err = d.getDomainByDomain(ctx, data.Domain.ValueString())
@@ -63,6 +69,8 @@ func (d *DataSource) Read(
 }
 
 func (d *DataSource) getDomainByID(ctx context.Context, id int) (*linodego.Domain, diag.Diagnostic) {
+	tflog.Trace(ctx, "client.GetDomain(...)")
+
 	domain, err := d.Meta.Client.GetDomain(ctx, id)
 	if err != nil {
 		return nil, diag.NewErrorDiagnostic(
@@ -75,7 +83,14 @@ func (d *DataSource) getDomainByID(ctx context.Context, id int) (*linodego.Domai
 }
 
 func (d *DataSource) getDomainByDomain(ctx context.Context, domain string) (*linodego.Domain, diag.Diagnostic) {
+	tflog.Debug(ctx, "Get domain by domain", map[string]interface{}{
+		"domain": domain,
+	})
+
 	filter, _ := json.Marshal(map[string]interface{}{"domain": domain})
+
+	tflog.Trace(ctx, "client.ListDomains(...)")
+
 	domains, err := d.Meta.Client.ListDomains(ctx, linodego.NewListOptions(0, string(filter)))
 	if err != nil {
 		return nil, diag.NewErrorDiagnostic(

--- a/linode/domainrecord/framework_datasource.go
+++ b/linode/domainrecord/framework_datasource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -60,6 +61,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_domain_record")
+
 	client := d.Meta.Client
 
 	var data DataSourceModel
@@ -89,6 +92,11 @@ func (d *DataSource) Read(
 			return
 		}
 
+		ctx = tflog.SetField(ctx, "domain_id", domainID)
+		ctx = tflog.SetField(ctx, "record_id", recordID)
+
+		tflog.Trace(ctx, "client.GetDomainRecord(...)")
+
 		rec, err := client.GetDomainRecord(ctx, domainID, recordID)
 		if err != nil {
 			resp.Diagnostics.AddError("Error fetching domain record: %v", err.Error())
@@ -104,6 +112,12 @@ func (d *DataSource) Read(
 		if resp.Diagnostics.HasError() {
 			return
 		}
+
+		ctx = tflog.SetField(ctx, "domain_id", domainID)
+		ctx = tflog.SetField(ctx, "record_name", data.Name.ValueString())
+
+		tflog.Trace(ctx, "client.ListDomainRecords(...)")
+
 		records, err := client.ListDomainRecords(ctx, domainID,
 			linodego.NewListOptions(0, string(filter)))
 		if err != nil {


### PR DESCRIPTION
## 📝 Description

Add tf logging to `linode_domain` and `linode_domain_record` data source and resource.

## ✔️ How to Test

Intergration tests:
`make PKG_NAME="linode/domainrecord" int-test`
`make PKG_NAME="linode/domain" int-test`

Manual test:
1. Enable trace level logging for the Linode provider:
```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```

2. In a sandbox environment (i.e. dx-devenv), create a domain resource.
```
resource "linode_domain" "foobar" {
    domain = "example.com"
    type = "master"
    status = "active"
    soa_email = "admin@example.com"
    description = "tf-testing"
    tags = ["tf_test"]
}
```

3. Observe the new log statements for domain in the stderr output.

4. Then create a domain record resource.
```
resource "linode_domain_record" "foobar" {
    domain_id = "${linode_domain.foobar.id}"
    name = "tf-test"
    record_type = "CNAME"
    target = "target.tf-test.example"
}
```

6. Observe the new log statements for domain record in the stderr output.