### PR TITLE
fix: `domains` integration test

### DIFF
--- a/linode/domains/datasource_test.go
+++ b/linode/domains/datasource_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceDomains_basic(t *testing.T) {
 			{
 				Config: tmpl.DataBasic(t, domainName),
 				Check: resource.ComposeTestCheckFunc(
-					acceptance.CheckResourceAttrGreaterThan(resourceName, "domains.#", "2"),
+					acceptance.CheckResourceAttrGreaterThan(resourceName, "domains.#", 1),
 					resource.TestCheckResourceAttrSet(resourceName, "domains.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "domains.0.domain"),
 					resource.TestCheckResourceAttrSet(resourceName, "domains.0.type"),
@@ -40,15 +40,15 @@ func TestAccDataSourceDomains_basic(t *testing.T) {
 			{
 				Config: tmpl.DataFilter(t, domainName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "domains.0.type", "master"),
+					resource.TestCheckResourceAttr(resourceName, "domains.0.description", "tf-testing-master"),
 				),
 			},
 			{
 				Config: tmpl.DataAPIFilter(t, domainName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "domains.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "domains.0.tags.0", "tf_test"),
+					resource.TestCheckResourceAttr(resourceName, "domains.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "domains.0.domain", domainName),
 				),
 			},

--- a/linode/domains/datasource_test.go
+++ b/linode/domains/datasource_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceDomains_basic(t *testing.T) {
 			{
 				Config: tmpl.DataBasic(t, domainName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "domains.#", "2"),
+					acceptance.CheckResourceAttrGreaterThan(resourceName, "domains.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "domains.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "domains.0.domain"),
 					resource.TestCheckResourceAttrSet(resourceName, "domains.0.type"),

--- a/linode/domains/tmpl/data_api_filter.gotf
+++ b/linode/domains/tmpl/data_api_filter.gotf
@@ -4,11 +4,9 @@
 
 data "linode_domains" "foo" {
     filter {
-        name = "tags"
-        values = ["tf_test"]
+        name = "domain"
+        values = ["{{.Domain}}"]
     }
-    order_by = "domain"
-    order = "desc"
 }
 
 {{ end }}

--- a/linode/domains/tmpl/data_base.gotf
+++ b/linode/domains/tmpl/data_base.gotf
@@ -5,15 +5,15 @@ resource "linode_domain" "foo" {
     type = "master"
     status = "active"
     soa_email = "example@{{.Domain}}"
-    description = "tf-testing"
-    tags = ["tf_test"]
+    description = "tf-testing-master"
+    tags = ["tf_test_master"]
 }
 
 resource "linode_domain" "bar" {
     domain = "slave-{{.Domain}}"
     type = "slave"
     soa_email = "example@{{.Domain}}"
-    description = "tf-testing"
+    description = "tf-testing-slave"
     tags = ["tf_test"]
     master_ips = ["12.34.56.78"]
 }

--- a/linode/domains/tmpl/data_filter.gotf
+++ b/linode/domains/tmpl/data_filter.gotf
@@ -4,9 +4,12 @@
 
 data "linode_domains" "foo" {
     filter {
-        name = "type"
-        values = ["master"]
+        name = "description"
+        values = ["tf-testing-"]
+        match_by = "substring"
     }
+    order_by = "domain"
+    order = "desc"
 }
 
 {{ end }}


### PR DESCRIPTION
## 📝 Description

A fix to `domains` integration tests. Although we create 2 new domains for this test case, there could be more than the 2 domains existing on the test account, because we're running concurrent tests. They're created by other test cases and haven't been cleared up yet, which may result in failures in the integration test.


## Test

`make PKG_NAME="linode/domains" int-test
`