### PR TITLE
new: Add logging for sshkey(s) resource and data source

### DIFF
--- a/linode/sshkey/framework_datasource.go
+++ b/linode/sshkey/framework_datasource.go
@@ -78,6 +78,7 @@ func (d *DataSource) Read(
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "sshkey_label", data.Label.ValueString())
 	tflog.Trace(ctx, "client.ListSSHKeys(...)")
 
 	keys, err := client.ListSSHKeys(ctx, nil)

--- a/linode/sshkey/framework_datasource.go
+++ b/linode/sshkey/framework_datasource.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -65,6 +67,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_sshkey")
+
 	client := d.Meta.Client
 
 	var data DataSourceModel
@@ -73,6 +77,8 @@ func (d *DataSource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	tflog.Trace(ctx, "client.ListSSHKeys(...)")
 
 	keys, err := client.ListSSHKeys(ctx, nil)
 	if err != nil {

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -76,8 +76,6 @@ func (r *Resource) Read(
 
 	var data ResourceModel
 
-	ctx = tflog.SetField(ctx, "sshkey_id", id)
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -92,6 +90,7 @@ func (r *Resource) Read(
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "sshkey_id", id)
 	tflog.Trace(ctx, "client.GetSSHKey(...)")
 
 	key, err := client.GetSSHKey(ctx, id)
@@ -188,7 +187,7 @@ func (r *Resource) Delete(
 
 	client := r.Meta.Client
 
-	populateLogAttributes(ctx, data)
+	ctx = tflog.SetField(ctx, "sshkey_id", id)
 	tflog.Trace(ctx, "client.DeleteSSHKey(...)")
 
 	err := client.DeleteSSHKey(ctx, id)
@@ -201,10 +200,4 @@ func (r *Resource) Delete(
 		}
 		return
 	}
-}
-
-func populateLogAttributes(ctx context.Context, model ResourceModel) context.Context {
-	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"sshkey_id": model.ID,
-	})
 }

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -31,6 +33,8 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
+	tflog.Debug(ctx, "Create linode_sshkey")
+
 	var data ResourceModel
 	client := r.Meta.Client
 
@@ -43,6 +47,10 @@ func (r *Resource) Create(
 		Label:  data.Label.ValueString(),
 		SSHKey: data.SSHKey.ValueString(),
 	}
+
+	tflog.Debug(ctx, "client.CreateSSHKey(...)", map[string]interface{}{
+		"options": createOpts,
+	})
 
 	key, err := client.CreateSSHKey(ctx, createOpts)
 	if err != nil {
@@ -62,9 +70,13 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Create linode_sshkey")
+
 	client := r.Meta.Client
 
 	var data ResourceModel
+
+	ctx = populateLogAttributes(ctx, data)
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -79,6 +91,8 @@ func (r *Resource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	tflog.Trace(ctx, "client.GetSSHKey(...)")
 
 	key, err := client.GetSSHKey(ctx, id)
 	if err != nil {
@@ -111,6 +125,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
+	tflog.Debug(ctx, "Update linode_sshkey")
+
 	var plan, state ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -130,6 +146,10 @@ func (r *Resource) Update(
 	}
 
 	if shouldUpdate {
+		tflog.Debug(ctx, "client.UpdateSSHKey(...)", map[string]any{
+			"options": updateOpts,
+		})
+
 		key, err := r.Meta.Client.UpdateSSHKey(
 			ctx,
 			id,
@@ -152,6 +172,8 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
+	tflog.Debug(ctx, "Delete linode_sshkey")
+
 	var data ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -165,6 +187,10 @@ func (r *Resource) Delete(
 	}
 
 	client := r.Meta.Client
+
+	populateLogAttributes(ctx, data)
+	tflog.Trace(ctx, "client.DeleteSSHKey(...)")
+
 	err := client.DeleteSSHKey(ctx, id)
 	if err != nil {
 		if lErr, ok := err.(*linodego.Error); (ok && lErr.Code != 404) || !ok {
@@ -175,4 +201,10 @@ func (r *Resource) Delete(
 		}
 		return
 	}
+}
+
+func populateLogAttributes(ctx context.Context, model ResourceModel) context.Context {
+	return helper.SetLogFieldBulk(ctx, map[string]any{
+		"sshkey_id": model.ID,
+	})
 }

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -76,7 +76,7 @@ func (r *Resource) Read(
 
 	var data ResourceModel
 
-	ctx = populateLogAttributes(ctx, data)
+	ctx = tflog.SetField(ctx, "sshkey_id", id)
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/sshkeys/framework_datasource.go
+++ b/linode/sshkeys/framework_datasource.go
@@ -46,6 +46,8 @@ func (d *DataSource) Read(
 	}
 	data.ID = id
 
+	ctx = tflog.SetField(ctx, "sshkey_filter_id", data.ID.ValueString())
+
 	result, diag := filterConfig.GetAndFilter(
 		ctx, d.Meta.Client, data.Filters, listSSHKeys,
 		data.Order, data.OrderBy)

--- a/linode/sshkeys/framework_datasource.go
+++ b/linode/sshkeys/framework_datasource.go
@@ -3,6 +3,8 @@ package sshkeys
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
@@ -28,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_sshkeys")
+
 	var data SSHKeyFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -59,6 +63,8 @@ func listSSHKeys(
 	client *linodego.Client,
 	filter string,
 ) ([]any, error) {
+	tflog.Trace(ctx, "client.ListSSHKeys(...)")
+
 	sshkeys, err := client.ListSSHKeys(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})


### PR DESCRIPTION
## 📝 Description

Add logging for following resource and data source:
- linode_sshkey (resource)
- linode_sshkeys (data source)

## ✔️ How to Test
1. Enable trace logging for the Linode provider:
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE

2. Inside of a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:
```
# ...
terraform {
  required_providers {
    // Running sandbox targets will automatically
    // use the local provider in repos/terraform-provider-linode
    linode = {
      source  = "linode/linode"
      version = "2.6.0"
    }
  }
}

resource "linode_sshkey" "foo" {
  label = "foo"
  ssh_key = chomp(file("~/.ssh/id_rsa.pub"))
}

resource "linode_instance" "foo" {
  image  = "linode/ubuntu22.04"
  label  = "foolinodeinstance"
  region = "us-east"
  type   = "g6-nanode-1"
  authorized_keys    = [linode_sshkey.foo.ssh_key]
  root_pass      = "RandomPAS!SWORDasdlkjfkljqouvi"
}

data "linode_sshkey" "foo" {
  depends_on = [linode_instance.foo]
  label = "foo"
}

data "linode_sshkeys" "filtered_ssh" {
  depends_on = [linode_instance.foo]
  filter {
    name = "label"
    values = ["foo"]
  }
  filter {
    name = "ssh_key"
    values = ["RSA-6522525"]
  }
}
```

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**