### PR TITLE
Apply Import Helper Function for VPC Subnet Resource 

### DIFF
--- a/docs/resources/firewall_device.md
+++ b/docs/resources/firewall_device.md
@@ -58,3 +58,13 @@ In addition to all arguments above, the following attributes are exported:
 * `created` - When the Firewall Device was last created.
 
 * `updated` - When the Firewall Device was last updated.
+
+## Import
+
+Firewall Device can be imported using the `firewall_id` followed by the Firewall Device `id` separated by a comma, e.g.
+
+```sh
+terraform import linode_firewall_device.my_device_duplicated 1234567,7654321
+```
+
+The Linode Guide, [Import Existing Infrastructure to Terraform](https://www.linode.com/docs/applications/configuration-management/import-existing-infrastructure-to-terraform/), offers resource importing examples for various Linode resource types.

--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -41,3 +41,13 @@ In addition to all the arguments above, the following attributes are exported.
 * `created` - The date and time when the VPC was created.
 
 * `updated` - The date and time when the VPC was last updated.
+
+## Import
+
+Linode Virtual Private Cloud (VPC) Subnet can be imported using the `vpc_id` followed by the subnet `id` separated by a comma, e.g.
+
+```sh
+terraform import linode_vpc_subnet.my_subnet_duplicated 1234567,7654321
+```
+
+The Linode Guide, [Import Existing Infrastructure to Terraform](https://www.linode.com/docs/applications/configuration-management/import-existing-infrastructure-to-terraform/), offers resource importing examples for various Linode resource types.

--- a/linode/helper/framework_import.go
+++ b/linode/helper/framework_import.go
@@ -100,6 +100,8 @@ func ImportStateWithMultipleCustomTypedIDs(
 			return
 		}
 		convertedIDs = ids
+	} else {
+		convertedIDs = TypedSliceToAny(ids)
 	}
 
 	for i, id := range convertedIDs {

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -3,11 +3,11 @@ package vpcsubnet
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -33,25 +33,8 @@ func (r *Resource) ImportState(
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	idParts := strings.Split(req.ID, ",")
-
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: vpc_id,id. Got: %q", req.ID),
-		)
-		return
-	}
-
-	vpcID := helper.StringToInt64(idParts[0], &resp.Diagnostics)
-	id := helper.StringToInt64(idParts[1], &resp.Diagnostics)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vpc_id"), vpcID)...)
+	tflog.Debug(ctx, "Import "+r.Config.Name)
+	helper.ImportStateWithMultipleIDs(ctx, req, resp, "vpc_id", "id")
 }
 
 func (r *Resource) Create(


### PR DESCRIPTION
## 📝 Description

- Use the import helper function in VPC subnet resource.
- Updated docs for describing import support on Firewall Device and VPC Subnet.
- Fix a bug in the import helper function.

## ✔️ How to Test

### Automated Testing
`make PKG_NAME="linode/vpcsubnet" int-test `

### Manual Testing

Create the resources for testing first.

```terraform
resource "linode_vpc" "test" {
  label       = "test-vpc2"
  region      = "us-iad"
  description = "My first VPC."
}

resource "linode_vpc_subnet" "test" {
  vpc_id = linode_vpc.test.id
  label  = "test-subnet2"
  ipv4   = "10.0.0.0/24"
}
```

Add an empty `linode_vpc_subnet` resource in the config file.

``` terraform
resource "linode_vpc_subnet" "test_duplicated" {}
```

And then run the import command in the terminal to verify the import is success.
```bash
terraform import linode_vpc_subnet.test_duplicated 1234,4321
```

