### PR TITLE
Migrate Parse Attrs Function to Flatten Function with Preserving Known Values Option for Token Resource

### DIFF
--- a/linode/token/framework_models_unit_test.go
+++ b/linode/token/framework_models_unit_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseToken(t *testing.T) {
+func TestFlattenToken(t *testing.T) {
 	createdTime := time.Date(2023, time.August, 17, 12, 0, 0, 0, time.UTC)
 	expiryDate := time.Date(2050, time.August, 17, 12, 0, 0, 0, time.UTC)
 
@@ -28,7 +28,7 @@ func TestParseToken(t *testing.T) {
 
 	model := &ResourceModel{}
 
-	model.parseToken(&sampleToken, false)
+	model.FlattenToken(&sampleToken, false, false)
 
 	assert.Equal(t, types.StringValue(sampleToken.Label), model.Label)
 	assert.Equal(t, customtypes.LinodeScopesStringValue{StringValue: types.StringValue(sampleToken.Scopes)}, model.Scopes)
@@ -36,7 +36,7 @@ func TestParseToken(t *testing.T) {
 	assert.Equal(t, types.StringValue(strconv.Itoa(sampleToken.ID)), model.ID)
 }
 
-func TestParseTokenRefreshTrue(t *testing.T) {
+func TestFlattenTokenRefreshTrue(t *testing.T) {
 	createdTime := time.Date(2023, time.August, 17, 12, 0, 0, 0, time.UTC)
 	expiryDate := time.Date(2050, time.August, 17, 12, 0, 0, 0, time.UTC)
 
@@ -51,7 +51,7 @@ func TestParseTokenRefreshTrue(t *testing.T) {
 
 	rm := &ResourceModel{}
 
-	rm.parseToken(&sampleToken, true)
+	rm.FlattenToken(&sampleToken, true, false)
 
 	assert.Empty(t, rm.Token)
 }

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -72,7 +72,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	data.parseToken(token, false)
+	data.FlattenToken(token, false, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -127,7 +127,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	data.parseToken(token, true)
+	data.FlattenToken(token, true, false)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -177,7 +177,10 @@ func (r *Resource) Update(
 			)
 			return
 		}
+		plan.FlattenToken(token, true, true)
 	}
+
+	plan.CopyFrom(state, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 


### PR DESCRIPTION
## 📝 Description

This PR migrates the legacy attributes parsing function to the newer flatten function to enabled support of preserving known value to better align with Terraform Framework's principles to void potential issues.

## ✔️ How to Test


### Automated Testing
`make PKG_NAME="linode/token" int-test`
`make PKG_NAME="linode/token" unit-test`

Note that **you may see an irrelevant API error during the test**, for example:
```
=== NAME  TestAccResourceToken_recreative_update
    resource_test.go:113: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        -       "created": "2024-02-13T01:47:45Z",
        +       "created": "2024-02-13T01:47:46Z",
          }
```
This is caused by inconsistent `created` date being returned from the API in GET and POST endpoints, and it's currently being fixed.

### Manual Testing
Here is a sample token resource definition you can play around with:
```terraform
resource "linode_token" "foo" {
  label  = "token"
  scopes = "linodes:read_only"
  expiry = "2100-01-02T03:04:05Z"
}
```

