### PR TITLE
Migrate Parse Attrs Function to Flatten Function with Preserving Known Values Option for IPv6 Range Resource

### DIFF
--- a/linode/ipv6range/framework_models_unit_test.go
+++ b/linode/ipv6range/framework_models_unit_test.go
@@ -32,7 +32,7 @@ func TestParseIPv6RangeDataSource(t *testing.T) {
 	assert.NotEmpty(t, dataSourceModel.ID)
 }
 
-func TestParseIPv6RangeResourceDataComputedAttrs(t *testing.T) {
+func TestFlattenIPv6Range(t *testing.T) {
 	ipRange := linodego.IPv6Range{
 		Range:       "2600:3c01::",
 		Region:      "us-east",
@@ -43,7 +43,7 @@ func TestParseIPv6RangeResourceDataComputedAttrs(t *testing.T) {
 	}
 
 	resourceModel := ResourceModel{}
-	diags := resourceModel.parseIPv6RangeResourceDataComputedAttrs(context.Background(), &ipRange)
+	diags := resourceModel.FlattenIPv6Range(context.Background(), &ipRange, false)
 
 	assert.Nil(t, diags)
 	assert.Equal(t, types.StringValue("2600:3c01::"), resourceModel.Range)

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -107,7 +106,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseIPv6RangeResourceDataComputedAttrs(ctx, ipv6rangeR)...)
+	resp.Diagnostics.Append(data.FlattenIPv6Range(ctx, ipv6rangeR, true)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -148,8 +147,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	data.parseIPv6RangeResourceDataNonComputedAttrs(ipv6range)
-	resp.Diagnostics.Append(data.parseIPv6RangeResourceDataComputedAttrs(ctx, ipv6range)...)
+	resp.Diagnostics.Append(data.FlattenIPv6Range(ctx, ipv6range, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -204,14 +202,13 @@ func (r *Resource) Update(
 			return
 		}
 
-		resp.Diagnostics.Append(plan.parseIPv6RangeResourceDataComputedAttrs(ctx, ipv6range)...)
+		resp.Diagnostics.Append(plan.FlattenIPv6Range(ctx, ipv6range, true)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-	} else {
-		req.State.GetAttribute(ctx, path.Root("is_bgp"), &plan.IsBGP)
-		req.State.GetAttribute(ctx, path.Root("linodes"), &plan.Linodes)
 	}
+
+	plan.CopyFrom(state, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 


### PR DESCRIPTION
## 📝 Description

This PR migrates legacy attributes parsing function to the newer flatten function to enabled support of preserving known value to better align with Terraform Framework's principles to void potential issues.

## ✔️ How to Test

### Automated Testing
`make PKG_NAME="linode/ipv6range" int-test`
`make PKG_NAME="linode/ipv6range" unit-test`

### Manual Testing

A sample config file to play around with:
```terraform
resource "linode_instance" "foobar" {
  label = "my-linode"
  image = "linode/debian12"
  type = "g6-nanode-1"
  region = "us-mia"
}

resource "linode_ipv6_range" "foobar" {
  linode_id = linode_instance.foobar.id
  prefix_length = 64
}
```