### PR TITLE
 Migrate Parse Attrs Function to Flatten Function with Preserving Known Values Option for Account Settings Resource

### DIFF
--- a/linode/accountsettings/framework_datasource.go
+++ b/linode/accountsettings/framework_datasource.go
@@ -59,10 +59,6 @@ func (r *DataSource) Read(
 		return
 	}
 
-	data.parseAccountSettings(
-		account.Email,
-		settings,
-	)
-
+	data.FlattenAccountSettings(account.Email, settings, false)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/linode/accountsettings/framework_model.go
+++ b/linode/accountsettings/framework_model.go
@@ -12,23 +12,53 @@ type AccountSettingsModel struct {
 	ID                   types.String `tfsdk:"id"`
 	LongviewSubscription types.String `tfsdk:"longview_subscription"`
 	ObjectStorage        types.String `tfsdk:"object_storage"`
-	BackupsEnabed        types.Bool   `tfsdk:"backups_enabled"`
+	BackupsEnabled       types.Bool   `tfsdk:"backups_enabled"`
 	Managed              types.Bool   `tfsdk:"managed"`
 	NetworkHelper        types.Bool   `tfsdk:"network_helper"`
 }
 
-func (data *AccountSettingsModel) parseAccountSettings(
+func (data *AccountSettingsModel) FlattenAccountSettings(
 	email string,
 	settings *linodego.AccountSettings,
+	preserveKnown bool,
 ) {
-	data.ID = types.StringValue(email)
+	data.ID = helper.KeepOrUpdateString(data.ID, email, preserveKnown)
 
 	// These use empty strings ("") rather than StringNull to maintain backwards compatibility
 	// with the SDKv2 version of this resource.
-	data.LongviewSubscription = helper.GetStringPtrWithDefault(settings.LongviewSubscription, "")
-	data.ObjectStorage = helper.GetStringPtrWithDefault(settings.ObjectStorage, "")
+	data.LongviewSubscription = helper.KeepOrUpdateValue(
+		data.LongviewSubscription,
+		helper.GetStringPtrWithDefault(settings.LongviewSubscription, ""),
+		preserveKnown,
+	)
+	data.ObjectStorage = helper.KeepOrUpdateValue(
+		data.ObjectStorage,
+		helper.GetStringPtrWithDefault(settings.ObjectStorage, ""),
+		preserveKnown,
+	)
 
-	data.Managed = types.BoolValue(settings.Managed)
-	data.BackupsEnabed = types.BoolValue(settings.BackupsEnabled)
-	data.NetworkHelper = types.BoolValue(settings.NetworkHelper)
+	data.Managed = helper.KeepOrUpdateBool(data.Managed, settings.Managed, preserveKnown)
+	data.BackupsEnabled = helper.KeepOrUpdateBool(
+		data.BackupsEnabled, settings.BackupsEnabled, preserveKnown,
+	)
+	data.NetworkHelper = helper.KeepOrUpdateBool(
+		data.NetworkHelper, settings.NetworkHelper, preserveKnown,
+	)
+}
+
+func (data *AccountSettingsModel) CopyFrom(other AccountSettingsModel, preserveKnown bool) {
+	data.ID = helper.KeepOrUpdateValue(data.ID, other.ID, preserveKnown)
+	data.LongviewSubscription = helper.KeepOrUpdateValue(
+		data.LongviewSubscription, other.LongviewSubscription, preserveKnown,
+	)
+	data.ObjectStorage = helper.KeepOrUpdateValue(
+		data.ObjectStorage, other.ObjectStorage, preserveKnown,
+	)
+	data.BackupsEnabled = helper.KeepOrUpdateValue(
+		data.BackupsEnabled, other.BackupsEnabled, preserveKnown,
+	)
+	data.Managed = helper.KeepOrUpdateValue(data.Managed, other.Managed, preserveKnown)
+	data.NetworkHelper = helper.KeepOrUpdateValue(
+		data.NetworkHelper, other.NetworkHelper, preserveKnown,
+	)
 }

--- a/linode/accountsettings/framework_model_unit_test.go
+++ b/linode/accountsettings/framework_model_unit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func TestParseAccountSettings(t *testing.T) {
+func TestFlattenAccountSettings(t *testing.T) {
 	// Create mock AccountSettings data
 	mockEmail := "test@example.com"
 	longviewSubscriptionValue := "longview-3"
@@ -31,7 +31,7 @@ func TestParseAccountSettings(t *testing.T) {
 	model := &AccountSettingsModel{}
 
 	// Call the parseAccountSettings function
-	model.parseAccountSettings(mockEmail, mockSettings)
+	model.FlattenAccountSettings(mockEmail, mockSettings, false)
 
 	// Check if the fields in the model have been populated correctly
 	if model.ID != types.StringValue(mockEmail) {
@@ -46,8 +46,8 @@ func TestParseAccountSettings(t *testing.T) {
 		t.Errorf("Expected ObjectStorage to be %s, but got %s", "active", model.ObjectStorage)
 	}
 
-	if model.BackupsEnabed != types.BoolValue(true) {
-		t.Errorf("Expected BackupsEnabed to be %v, but got %v", true, model.BackupsEnabed)
+	if model.BackupsEnabled != types.BoolValue(true) {
+		t.Errorf("Expected BackupsEnabed to be %v, but got %v", true, model.BackupsEnabled)
 	}
 
 	if model.Managed != types.BoolValue(true) {


### PR DESCRIPTION
## 📝 Description

This PR migrates legacy attributes parsing function to the newer flatten function to enabled support of preserving known value to better align with Terraform Framework's principles to void potential issues.

## ✔️ How to Test

### Automated Testing
`ACC_OPT_IN_TESTS=TestAccDataSourceLinodeAccountSettings_basic make PKG_NAME="linode/accountsettings" int-test`
`ACC_OPT_IN_TESTS=TestAccResourceAccountSettings_basic make PKG_NAME="linode/accountsettings" int-test`
`ACC_OPT_IN_TESTS=TestAccResourceAccountSettings_update make PKG_NAME="linode/accountsettings" int-test`
`make PKG_NAME="linode/accountsettings" unit-test`

Tests may change your Linode testing account settings. Please review all settings after running the tests.

For example, you may want to turn the network helper back on after running the tests.
<img width="1092" alt="image" src="https://github.com/linode/terraform-provider-linode/assets/121905282/0946cf6d-f595-4de9-a0c6-2d8f7f53c598">
 
### Manual Testing

A sample config file to play around with:
```terraform
resource "linode_account_settings" "myaccount" {
    longview_subscription = null
    network_helper = true
}
```