### PR TITLE
Migrate Parse Attrs Function to Flatten Function with Preserving Known Values Option for NodeBalancer Resource

### DIFF
--- a/linode/nb/framework_models_unit_test.go
+++ b/linode/nb/framework_models_unit_test.go
@@ -24,7 +24,7 @@ func TestParseNonComputedAttrs(t *testing.T) {
 
 	nodeBalancerModel := &NodeBalancerModel{}
 
-	diags := nodeBalancerModel.ParseNonComputedAttrs(context.Background(), nodeBalancer)
+	diags := nodeBalancerModel.FlattenNodeBalancer(context.Background(), nodeBalancer, nil, false)
 
 	assert.False(t, diags.HasError(), "Errors should be returned due to custom context error")
 	assert.Equal(t, types.StringValue("test-nodebalancer"), nodeBalancerModel.Label)
@@ -62,7 +62,7 @@ func TestParseComputedAttrs(t *testing.T) {
 
 	nodeBalancerModel := &NodeBalancerModel{}
 
-	diags := nodeBalancerModel.ParseComputedAttrs(context.Background(), nodeBalancer, nil)
+	diags := nodeBalancerModel.FlattenNodeBalancer(context.Background(), nodeBalancer, nil, false)
 
 	assert.False(t, diags.HasError())
 
@@ -70,8 +70,8 @@ func TestParseComputedAttrs(t *testing.T) {
 	assert.Equal(t, types.StringValue("us-east"), nodeBalancerModel.Region)
 	assert.Equal(t, types.Int64Value(10), nodeBalancerModel.ClientConnThrottle)
 	assert.Equal(t, types.StringPointerValue(&hostname), nodeBalancerModel.Hostname)
-	assert.Equal(t, types.StringPointerValue(&IPv4), nodeBalancerModel.Ipv4)
-	assert.Equal(t, types.StringPointerValue(&IPv6), nodeBalancerModel.Ipv6)
+	assert.Equal(t, types.StringPointerValue(&IPv4), nodeBalancerModel.IPv4)
+	assert.Equal(t, types.StringPointerValue(&IPv6), nodeBalancerModel.IPv6)
 
 	assert.NotNil(t, nodeBalancerModel.Created)
 	assert.NotNil(t, nodeBalancerModel.Updated)

--- a/linode/nb/framework_models_unit_test.go
+++ b/linode/nb/framework_models_unit_test.go
@@ -13,26 +13,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseNonComputedAttrs(t *testing.T) {
+func TestFlattenNodeBalancerPreserveKnown(t *testing.T) {
 	label := "test-nodebalancer"
 
 	nodeBalancer := &linodego.NodeBalancer{
 		ID:    123,
 		Label: &label,
-		Tags:  []string{"tag1", "tag2"},
 	}
 
-	nodeBalancerModel := &NodeBalancerModel{}
+	nodeBalancerModel := &NodeBalancerModel{
+		ID:    types.StringUnknown(),
+		Label: types.StringValue("another" + label),
+	}
 
-	diags := nodeBalancerModel.FlattenNodeBalancer(context.Background(), nodeBalancer, nil, false)
+	diags := nodeBalancerModel.FlattenNodeBalancer(context.Background(), nodeBalancer, nil, true)
 
 	assert.False(t, diags.HasError(), "Errors should be returned due to custom context error")
-	assert.Equal(t, types.StringValue("test-nodebalancer"), nodeBalancerModel.Label)
-	assert.Contains(t, nodeBalancer.Tags, "tag1")
-	assert.Contains(t, nodeBalancer.Tags, "tag2")
+	assert.False(t, types.StringValue(label).Equal(nodeBalancerModel.Label))
+	assert.True(t, types.StringValue("123").Equal(nodeBalancerModel.ID))
 }
 
-func TestParseComputedAttrs(t *testing.T) {
+func TestFlattenNodeBalancer(t *testing.T) {
 	hostname := "example.nodebalancer.linode.com"
 	IPv4 := "192.168.1.1"
 	IPv6 := "2001:db8::1"
@@ -44,8 +45,11 @@ func TestParseComputedAttrs(t *testing.T) {
 	transferOut := float64(200.0)
 	transferTotal := float64(300.0)
 
+	label := "test-nodebalancer"
+
 	nodeBalancer := &linodego.NodeBalancer{
 		ID:                 123,
+		Label:              &label,
 		Region:             "us-east",
 		ClientConnThrottle: 10,
 		Hostname:           &hostname,
@@ -79,6 +83,8 @@ func TestParseComputedAttrs(t *testing.T) {
 	assert.Contains(t, nodeBalancerModel.Transfer.String(), "100.0")
 	assert.Contains(t, nodeBalancerModel.Transfer.String(), "200.0")
 	assert.Contains(t, nodeBalancerModel.Transfer.String(), "300.0")
+
+	assert.True(t, types.StringValue(label).Equal(nodeBalancerModel.Label))
 }
 
 func TestUpgradeResourceStateValue(t *testing.T) {

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -99,7 +98,7 @@ func (r *Resource) Create(
 		)
 	}
 
-	resp.Diagnostics.Append(data.ParseComputedAttrs(ctx, nodebalancer, firewalls)...)
+	resp.Diagnostics.Append(data.FlattenNodeBalancer(ctx, nodebalancer, firewalls, true)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -160,8 +159,7 @@ func (r *Resource) Read(
 		)
 	}
 
-	resp.Diagnostics.Append(data.ParseComputedAttrs(ctx, nodeBalancer, firewalls)...)
-	resp.Diagnostics.Append(data.ParseNonComputedAttrs(ctx, nodeBalancer)...)
+	resp.Diagnostics.Append(data.FlattenNodeBalancer(ctx, nodeBalancer, firewalls, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -237,11 +235,9 @@ func (r *Resource) Update(
 			)
 		}
 
-		resp.Diagnostics.Append(plan.ParseComputedAttrs(ctx, nodeBalancer, firewalls)...)
-	} else {
-		req.State.GetAttribute(ctx, path.Root("updated"), &plan.Updated)
-		req.State.GetAttribute(ctx, path.Root("transfer"), &plan.Transfer)
+		resp.Diagnostics.Append(plan.FlattenNodeBalancer(ctx, nodeBalancer, firewalls, true)...)
 	}
+	plan.CopyFrom(state, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -313,8 +309,8 @@ func upgradeNodebalancerResourceStateV0toV1(
 		Region:             nbDataV0.Region,
 		ClientConnThrottle: nbDataV0.ClientConnThrottle,
 		Hostname:           nbDataV0.Hostname,
-		Ipv4:               nbDataV0.Ipv4,
-		Ipv6:               nbDataV0.Ipv6,
+		IPv4:               nbDataV0.IPv4,
+		IPv6:               nbDataV0.IPv6,
 		Created:            timetypes.RFC3339{StringValue: nbDataV0.Created},
 		Updated:            timetypes.RFC3339{StringValue: nbDataV0.Updated},
 		Tags:               nbDataV0.Tags,

--- a/linode/nbs/framework_models.go
+++ b/linode/nbs/framework_models.go
@@ -65,7 +65,7 @@ func (data *NodeBalancerModel) flattenNodeBalancer(
 	data.Created = timetypes.NewRFC3339TimePointerValue(nodebalancer.Created)
 	data.Updated = timetypes.NewRFC3339TimePointerValue(nodebalancer.Updated)
 
-	transfer, diags := nb.ParseTransfer(ctx, nodebalancer.Transfer)
+	transfer, diags := nb.FlattenTransfer(ctx, nodebalancer.Transfer)
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
## 📝 Description

This PR migrates the legacy attributes parsing function to the newer flatten function to enabled support of preserving known value to better align with Terraform Framework's principles to void potential issues.

## ✔️ How to Test


### Automated Testing
`make PKG_NAME="linode/nb" int-test`
`make PKG_NAME="linode/nb" unit-test`

Note that **you may see an irrelevant API error during the test**, for example:
```
=== NAME  TestAccResourceToken_recreative_update
    resource_test.go:113: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        -       "created": "2024-02-13T01:47:45Z",
        +       "created": "2024-02-13T01:47:46Z",
          }
```
This is caused by inconsistent dates being returned from the API in GET and POST endpoints, and it's currently being fixed.

### Manual Testing
Here is a sample token resource definition you can play around with:
```terraform
resource "linode_nodebalancer" "foobar" {
    label = "mynodebalancer"
    region = "us-mia"
    client_conn_throttle = 20
}
```

