### PR TITLE
Migrate Parse Attrs Function to Flatten Function with Preserving Known Values Option for Object Storage Key Resource

### DIFF
--- a/linode/objkey/framework_model.go
+++ b/linode/objkey/framework_model.go
@@ -49,11 +49,13 @@ func (rm *ResourceModel) FlattenObjectStorageKey(key *linodego.ObjectStorageKey,
 		keyBucketAccess := *key.BucketAccess
 		bucketAccess := make([]BucketAccessModelEntry, len(keyBucketAccess))
 
-		for i := range keyBucketAccess {
+		for i := range bucketAccess {
 			var entry BucketAccessModelEntry
 			entry.FlattenBucketAccess(&keyBucketAccess[i], preserveKnown)
 			bucketAccess[i] = entry
 		}
+
+		rm.BucketAccess = bucketAccess
 	}
 }
 

--- a/linode/objkey/framework_models_unit_test.go
+++ b/linode/objkey/framework_models_unit_test.go
@@ -27,7 +27,7 @@ func TestParseConfiguredAttributes(t *testing.T) {
 	}
 
 	data := ResourceModel{}
-	data.parseConfiguredAttributes(&key)
+	data.FlattenObjectStorageKey(&key, false)
 	// assert.Equal(t, types.Int64Value(123), data.ID)
 	// assert.Equal(t, types.StringValue("my-key"), data.Label)
 	// assert.Equal(t, types.StringValue("KVAKUTGBA4WTR2NSJQ81"), data.AccessKey)
@@ -52,7 +52,7 @@ func TestParseComputedAttributes(t *testing.T) {
 	}
 
 	rm := ResourceModel{}
-	rm.parseComputedAttributes(&key)
+	rm.FlattenObjectStorageKey(&key, false)
 
 	//assert.Equal(t, types.Int64Value(123), rm.ID)
 	//assert.Equal(t, types.StringValue("KVAKUTGBA4WTR2NSJQ81"), rm.AccessKey)

--- a/linode/objkey/framework_models_unit_test.go
+++ b/linode/objkey/framework_models_unit_test.go
@@ -5,10 +5,12 @@ package objkey
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestParseConfiguredAttributes(t *testing.T) {
+func TestFlattenObjectStorageKey(t *testing.T) {
 	bucketAccessData := []linodego.ObjectStorageKeyBucketAccess{
 		{
 			Cluster:     "ap-south-1",
@@ -28,21 +30,21 @@ func TestParseConfiguredAttributes(t *testing.T) {
 
 	data := ResourceModel{}
 	data.FlattenObjectStorageKey(&key, false)
-	// assert.Equal(t, types.Int64Value(123), data.ID)
-	// assert.Equal(t, types.StringValue("my-key"), data.Label)
-	// assert.Equal(t, types.StringValue("KVAKUTGBA4WTR2NSJQ81"), data.AccessKey)
-	// assert.Equal(t, types.StringValue("OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw"), data.SecretKey)
-	// assert.Equal(t, types.BoolValue(true), data.Limited)
+	assert.True(t, types.StringValue("123").Equal(data.ID))
+	assert.Equal(t, types.StringValue("my-key"), data.Label)
+	assert.Equal(t, types.StringValue("KVAKUTGBA4WTR2NSJQ81"), data.AccessKey)
+	assert.Equal(t, types.StringValue("OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw"), data.SecretKey)
+	assert.Equal(t, types.BoolValue(true), data.Limited)
 
-	//assert.NotNil(t, data.BucketAccess)
-	//
-	//bucketAccessEntry := data.BucketAccess[0]
-	//assert.Equal(t, types.StringValue("ap-south-1"), bucketAccessEntry.Cluster)
-	//assert.Equal(t, types.StringValue("example-bucket"), bucketAccessEntry.BucketName)
-	//assert.Equal(t, types.StringValue("read_only"), bucketAccessEntry.Permissions)
+	assert.NotNil(t, data.BucketAccess)
+
+	bucketAccessEntry := data.BucketAccess[0]
+	assert.Equal(t, types.StringValue("ap-south-1"), bucketAccessEntry.Cluster)
+	assert.Equal(t, types.StringValue("example-bucket"), bucketAccessEntry.BucketName)
+	assert.Equal(t, types.StringValue("read_only"), bucketAccessEntry.Permissions)
 }
 
-func TestParseComputedAttributes(t *testing.T) {
+func TestFlattenObjectStorageKeyPreserveKnown(t *testing.T) {
 	key := linodego.ObjectStorageKey{
 		ID:           123,
 		AccessKey:    "KVAKUTGBA4WTR2NSJQ81",
@@ -51,12 +53,15 @@ func TestParseComputedAttributes(t *testing.T) {
 		BucketAccess: nil,
 	}
 
-	rm := ResourceModel{}
-	rm.FlattenObjectStorageKey(&key, false)
+	expectedID := types.StringValue("123")
+	expectedSecretKey := types.StringValue("OiA6F5r0niLs3QA2stbyq7mY5VCV7KqOzcmitmHw")
 
-	//assert.Equal(t, types.Int64Value(123), rm.ID)
-	//assert.Equal(t, types.StringValue("KVAKUTGBA4WTR2NSJQ81"), rm.AccessKey)
-	//assert.Equal(t, rm.Limited, types.BoolValue(true))
-	//
-	//assert.Equal(t, types.StringValue(""), rm.SecretKey)
+	rm := ResourceModel{
+		ID:        types.StringUnknown(),
+		SecretKey: expectedSecretKey,
+	}
+
+	rm.FlattenObjectStorageKey(&key, true)
+	assert.True(t, expectedID.Equal(rm.ID))
+	assert.True(t, expectedSecretKey.Equal(rm.SecretKey))
 }

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -77,7 +77,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	data.parseComputedAttributes(key)
+	data.FlattenObjectStorageKey(key, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -131,9 +131,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	data.parseComputedAttributes(key)
-	data.parseConfiguredAttributes(key)
-
+	data.FlattenObjectStorageKey(key, false)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -181,9 +179,10 @@ func (r *Resource) Update(
 			return
 		}
 
-		plan.parseComputedAttributes(key)
+		plan.FlattenObjectStorageKey(key, true)
 	}
 
+	plan.CopyFrom(state, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 


### PR DESCRIPTION
## 📝 Description

This PR migrates legacy attributes parsing function to the newer flatten function to enabled support of preserving known value to better align with Terraform Framework's principles to void potential issues.

## ✔️ How to Test

### Automated Testing
`make PKG_NAME="linode/objkey" int-test`
`make PKG_NAME="linode/objkey" unit-test`
 
### Manual Testing

A sample config file to play around with:
```terraform
resource "linode_object_storage_key" "foo" {
    label = "image-access"
}
```