### PR TITLE
Migrate Parse Attrs Function to Flatten Function with Preserving Known Values Option for RDNS Resource

### DIFF
--- a/linode/rdns/framework_models.go
+++ b/linode/rdns/framework_models.go
@@ -23,3 +23,9 @@ func (rm *ResourceModel) FlattenInstanceIP(ip *linodego.InstanceIP, preserveKnow
 	rm.ID = helper.KeepOrUpdateString(rm.ID, ip.Address, preserveKnown)
 	rm.RDNS = helper.KeepOrUpdateString(rm.RDNS, ip.RDNS, preserveKnown)
 }
+
+func (rm *ResourceModel) CopyFrom(other ResourceModel, preserveKnown bool) {
+	rm.Address = helper.KeepOrUpdateValue(rm.Address, other.Address, preserveKnown)
+	rm.ID = helper.KeepOrUpdateValue(rm.ID, other.ID, preserveKnown)
+	rm.RDNS = helper.KeepOrUpdateValue(rm.RDNS, other.RDNS, preserveKnown)
+}

--- a/linode/rdns/framework_models.go
+++ b/linode/rdns/framework_models.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper/customtypes"
 )
 
@@ -15,14 +16,10 @@ type ResourceModel struct {
 	Timeouts         timeouts.Value                `tfsdk:"timeouts"`
 }
 
-func (rm *ResourceModel) parseConfiguredAttributes(ip *linodego.InstanceIP) {
-	rm.Address = customtypes.IPAddrValue(ip.Address)
-
-	if !rm.RDNS.Equal(types.StringValue(ip.RDNS)) {
-		rm.RDNS = types.StringValue(ip.RDNS)
-	}
-}
-
-func (rm *ResourceModel) parseComputedAttributes(ip *linodego.InstanceIP) {
-	rm.ID = types.StringValue(ip.Address)
+func (rm *ResourceModel) FlattenInstanceIP(ip *linodego.InstanceIP, preserveKnown bool) {
+	rm.Address = helper.KeepOrUpdateValue(
+		rm.Address, customtypes.IPAddrValue(ip.Address), preserveKnown,
+	)
+	rm.ID = helper.KeepOrUpdateString(rm.ID, ip.Address, preserveKnown)
+	rm.RDNS = helper.KeepOrUpdateString(rm.RDNS, ip.RDNS, preserveKnown)
 }

--- a/linode/rdns/framework_models_unit_test.go
+++ b/linode/rdns/framework_models_unit_test.go
@@ -12,28 +12,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseConfiguredAttributes(t *testing.T) {
+func TestFlattenInstanceIP(t *testing.T) {
 	ip := &linodego.InstanceIP{
 		Address: "192.168.1.1",
 		RDNS:    "linode.example.com",
 	}
 
-	rm := &ResourceModel{}
+	rm := &ResourceModel{
+		RDNS: types.StringValue("linode2.example.com"),
+	}
 
-	rm.parseConfiguredAttributes(ip)
+	rm.FlattenInstanceIP(ip, false)
 
 	assert.Equal(t, customtypes.IPAddrValue("192.168.1.1"), rm.Address)
 	assert.Equal(t, types.StringValue("linode.example.com"), rm.RDNS)
 }
 
-func TestParseComputedAttributes(t *testing.T) {
+func TestFlattenInstanceIPPreserveKnown(t *testing.T) {
 	ip := &linodego.InstanceIP{
 		Address: "192.168.1.1",
 	}
 
-	rm := &ResourceModel{}
+	rm := &ResourceModel{
+		ID:      types.StringUnknown(),
+		Address: customtypes.IPAddrValue("192.168.1.2"),
+	}
 
-	rm.parseComputedAttributes(ip)
+	rm.FlattenInstanceIP(ip, true)
 
-	assert.Equal(t, types.StringValue("192.168.1.1"), rm.ID)
+	assert.True(t, customtypes.IPAddrValue("192.168.1.2").Equal(rm.Address))
+	assert.True(t, types.StringValue("192.168.1.1").Equal(rm.ID))
 }

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -213,7 +213,7 @@ func (r *Resource) Update(
 		}
 		plan.FlattenInstanceIP(ip, true)
 	}
-
+	plan.CopyFrom(state, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -109,7 +109,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	plan.parseComputedAttributes(ip)
+	plan.FlattenInstanceIP(ip, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -155,8 +155,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	data.parseComputedAttributes(ip)
-	data.parseConfiguredAttributes(ip)
+	data.FlattenInstanceIP(ip, false)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -212,7 +211,7 @@ func (r *Resource) Update(
 			)
 			return
 		}
-		plan.parseComputedAttributes(ip)
+		plan.FlattenInstanceIP(ip, true)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)


### PR DESCRIPTION
## 📝 Description

This PR migrates legacy attributes parsing function to the newer flatten function to enabled support of preserving known value to better align with Terraform Framework's principles to void potential issues.

## ✔️ How to Test

### Automated Testing
`make PKG_NAME="linode/rdns" int-test`
`make PKG_NAME="linode/rdns" unit-test`
 
### Manual Testing

A sample config file to play around with:
```terraform
resource "linode_rdns" "foo" {
  address = linode_instance.foo.ip_address
  rdns = "${linode_instance.foo.ip_address}.nip.io"
}

resource "linode_instance" "foo" {
   image = "linode/debian12"
   region = "us-mia"
   type = "g6-nanode-1"
}
```