### PR TITLE
Migrate Parse Attrs Function to Flatten Function with Preserving Known Values Option for SSH Key Resource

### DIFF
--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -61,7 +61,7 @@ func (r *Resource) Create(
 		return
 	}
 
-	data.parseComputedAttributes(key)
+	data.FlattenSSHKey(key, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -113,8 +113,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	data.parseComputedAttributes(key)
-	data.parseConfiguredAttributes(key)
+	data.FlattenSSHKey(key, false)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -160,9 +159,9 @@ func (r *Resource) Update(
 				err.Error())
 			return
 		}
-		plan.parseComputedAttributes(key)
+		plan.FlattenSSHKey(key, true)
 	}
-
+	plan.CopyFrom(state, true)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/sshkey/framework_resource_models_unit_test.go
+++ b/linode/sshkey/framework_resource_models_unit_test.go
@@ -7,22 +7,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestParseConfiguredAttributes(t *testing.T) {
+	created := time.Now()
 	key := linodego.SSHKey{
-		Label:  "Test Key",
-		SSHKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC...",
+		ID:      123,
+		Created: &created,
+		Label:   "Test Key",
+		SSHKey:  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC...",
 	}
 
 	rm := &ResourceModel{}
-	rm.parseConfiguredAttributes(&key)
+	rm.FlattenSSHKey(&key, false)
 
 	assert.Equal(t, types.StringValue(key.Label), rm.Label)
 	assert.Equal(t, types.StringValue(key.SSHKey), rm.SSHKey)
+	assert.Equal(t, types.StringValue(strconv.Itoa(key.ID)), rm.ID)
+	assert.Equal(t, types.StringValue(created.Format(time.RFC3339)), rm.Created.StringValue)
 }
 
 func TestParseComputedAttributes(t *testing.T) {
@@ -32,9 +38,12 @@ func TestParseComputedAttributes(t *testing.T) {
 		Created: &created,
 	}
 
-	rm := &ResourceModel{}
-	rm.parseComputedAttributes(&key)
+	rm := &ResourceModel{
+		ID:      types.StringUnknown(),
+		Created: timetypes.NewRFC3339TimeValue(created.Add(24 * time.Hour)),
+	}
+	rm.FlattenSSHKey(&key, true)
 
-	assert.Equal(t, types.StringValue(strconv.Itoa(key.ID)), rm.ID)
-	assert.Equal(t, types.StringValue(created.Format(time.RFC3339)), rm.Created.StringValue)
+	assert.True(t, types.StringValue("123").Equal(rm.ID))
+	assert.False(t, rm.Created.Equal(timetypes.NewRFC3339TimeValue(created)))
 }


### PR DESCRIPTION
## 📝 Description

This PR migrates legacy attributes parsing function to the newer flatten function to enabled support of preserving known value to better align with Terraform Framework's principles to void potential issues.

## ✔️ How to Test

### Automated Testing
`make PKG_NAME="linode/sshkey" int-test`
`make PKG_NAME="linode/sshkey" unit-test`
 
### Manual Testing

A sample config file to play around with:
```terraform
resource "linode_sshkey" "foo" {
  label = "foo"
  ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDCKUGi9jmryHdyqEVVoctxZvPr0ac2PcDRqqit2cyFvPyS9p7q2BIhJ3rMmEfPi/w9UPLGqiL8zjkTHOXrmoHMgj3UajSWM4i/8+Qe/ynigzKAXYmVKtqp+HhSvSIal5/NNlJOt5hSNIWhTv+FZRT2G6OyJF3AF0pQwsRrYnEVCXvhQpKXNJzLeoMfj/XIApSPOoD3m9K/pOMAdQOguAYmrsf+POHBs4/T2OOkoyyLuRxHTLmIvSbfnVt7wSrrNaSLdxMyBUCLSN3NjwyUH1K6BMb/5GP0sqIPpvZXVLrSYwNRUX3TwH3N6v1YyPTk15V5JtFx98o8GX3+tsUYS4pgktWIczBUSqjoTQeNOU97itr4EEnAZV8t5dHbbrFvYKHk/bcghA2NexC+CGCrQVtMa/BdzgvY0Dl2NIBjTUZVOYEiyCTAR3fHBWwtmcURc5FAFo4LiV2gyy8YVddAQbm+ALJO7pjCKOdIyYuHfh4Pm2PPD9EuulLknChJp9emOM="
}

resource "linode_instance" "foo" {
  image  = "linode/ubuntu22.04"
  label  = "foo"
  region = "us-mia"
  type   = "g6-nanode-1"
  authorized_keys    = [linode_sshkey.foo.ssh_key]
  root_pass      = "edfwgvwerbgdefwsbwwrdfebedfglvnweslkfqwasfwebfwnfbnwoebn"
}
```