### PR TITLE
fix: Revert Framework resource ID attributes to strings

### DIFF
--- a/linode/firewalldevice/framework_models.go
+++ b/linode/firewalldevice/framework_models.go
@@ -1,6 +1,7 @@
 package firewalldevice
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -9,7 +10,7 @@ import (
 )
 
 type FirewallDeviceModel struct {
-	ID         types.Int64  `tfsdk:"id"`
+	ID         types.String `tfsdk:"id"`
 	FirewallID types.Int64  `tfsdk:"firewall_id"`
 	EntityID   types.Int64  `tfsdk:"entity_id"`
 	EntityType types.String `tfsdk:"entity_type"`
@@ -24,7 +25,7 @@ func (fdm *FirewallDeviceModel) FlattenFirewallDevice(
 	// firewall_id is always configured by the user and
 	// never appear in linodego.FirewallDevice
 
-	fdm.ID = helper.KeepOrUpdateInt64(fdm.ID, int64(device.ID), preserveKnown)
+	fdm.ID = helper.KeepOrUpdateString(fdm.ID, strconv.Itoa(device.ID), preserveKnown)
 	fdm.EntityID = helper.KeepOrUpdateInt64(
 		fdm.EntityID,
 		int64(device.Entity.ID),

--- a/linode/firewalldevice/framework_resource.go
+++ b/linode/firewalldevice/framework_resource.go
@@ -16,7 +16,7 @@ func NewResource() resource.Resource {
 		BaseResource: helper.NewBaseResource(
 			helper.BaseResourceConfig{
 				Name:   "linode_firewall_device",
-				IDType: types.Int64Type,
+				IDType: types.StringType,
 				Schema: &frameworkResourceSchema,
 			},
 		),
@@ -93,15 +93,16 @@ func (r *Resource) Read(
 
 	ctx = helper.SetLogFieldBulk(ctx, map[string]any{
 		"firewall_id": state.FirewallID.ValueInt64(),
-		"device_id":   state.ID.ValueInt64(),
+		"device_id":   state.ID.ValueString(),
 	})
 
 	client := r.Meta.Client
 
-	id := helper.FrameworkSafeInt64ToInt(
-		state.ID.ValueInt64(),
-		&resp.Diagnostics,
-	)
+	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	firewallID := helper.FrameworkSafeInt64ToInt(
 		state.FirewallID.ValueInt64(),
 		&resp.Diagnostics,
@@ -118,8 +119,8 @@ func (r *Resource) Read(
 			resp.Diagnostics.AddWarning(
 				"Firewall Device No Longer Exists",
 				fmt.Sprintf(
-					"Removing firewall device %d from state because it no longer exists",
-					state.ID.ValueInt64(),
+					"Removing firewall device %s from state because it no longer exists",
+					state.ID.String(),
 				),
 			)
 			resp.State.RemoveResource(ctx)
@@ -173,10 +174,14 @@ func (r *Resource) Delete(
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	client := r.Meta.Client
 
-	id := helper.FrameworkSafeInt64ToInt(
-		state.ID.ValueInt64(),
-		&resp.Diagnostics,
+	id := helper.FrameworkSafeStringToInt(
+		state.ID.ValueString(),
+		resp.Diagnostics,
 	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	firewallID := helper.FrameworkSafeInt64ToInt(
 		state.FirewallID.ValueInt64(),
 		&resp.Diagnostics,
@@ -218,6 +223,18 @@ func (r *Resource) ImportState(
 	tflog.Debug(ctx, "Import linode_firewall_device")
 
 	helper.ImportStateWithMultipleIDs(
-		ctx, req, resp, "firewall_id", "id",
+		ctx,
+		req,
+		resp,
+		[]helper.ImportableID{
+			{
+				Name:          "firewall_id",
+				TypeConverter: helper.IDTypeConverterInt64,
+			},
+			{
+				Name:          "id",
+				TypeConverter: helper.IDTypeConverterString,
+			},
+		},
 	)
 }

--- a/linode/firewalldevice/framework_resource_schema.go
+++ b/linode/firewalldevice/framework_resource_schema.go
@@ -10,11 +10,11 @@ import (
 
 var frameworkResourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The unique ID that represents the firewall device in the Terraform state.",
 			Computed:    true,
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"firewall_id": schema.Int64Attribute{

--- a/linode/helper/conversion.go
+++ b/linode/helper/conversion.go
@@ -100,3 +100,16 @@ func StringValue(v *string) string {
 	}
 	return ""
 }
+
+func FrameworkSafeStringToInt(val string, d diag.Diagnostics) int {
+	result, err := strconv.Atoi(val)
+	if err != nil {
+		d = append(d, diag.NewErrorDiagnostic(
+			"Failed to convert string to int",
+			err.Error(),
+		))
+		return 0
+	}
+
+	return result
+}

--- a/linode/instancesharedips/framework_models.go
+++ b/linode/instancesharedips/framework_models.go
@@ -1,21 +1,23 @@
 package instancesharedips
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
 type ResourceModel struct {
-	ID        types.Int64 `tfsdk:"id"`
-	LinodeID  types.Int64 `tfsdk:"linode_id"`
-	Addresses types.Set   `tfsdk:"addresses"`
+	ID        types.String `tfsdk:"id"`
+	LinodeID  types.Int64  `tfsdk:"linode_id"`
+	Addresses types.Set    `tfsdk:"addresses"`
 }
 
 func (data *ResourceModel) FlattenSharedIPs(
 	linodeID int, sharedIPs []string, preserveKnown bool, diags *diag.Diagnostics,
 ) {
-	data.ID = helper.KeepOrUpdateInt64(data.ID, int64(linodeID), preserveKnown)
+	data.ID = helper.KeepOrUpdateString(data.ID, strconv.Itoa(linodeID), preserveKnown)
 	data.LinodeID = helper.KeepOrUpdateInt64(data.LinodeID, int64(linodeID), preserveKnown)
 	data.Addresses = helper.KeepOrUpdateStringSet(data.Addresses, sharedIPs, preserveKnown, diags)
 }

--- a/linode/instancesharedips/framework_resource.go
+++ b/linode/instancesharedips/framework_resource.go
@@ -218,6 +218,6 @@ func GetSharedIPsForLinode(ctx context.Context, client *linodego.Client, linodeI
 func populateLogAttributes(ctx context.Context, data ResourceModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
 		"linode_id": data.LinodeID.ValueInt64(),
-		"id":        data.ID.ValueInt64(),
+		"id":        data.ID.ValueString(),
 	})
 }

--- a/linode/instancesharedips/framework_resource_schema.go
+++ b/linode/instancesharedips/framework_resource_schema.go
@@ -2,18 +2,18 @@ package instancesharedips
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var frameworkResourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "linode_id is used as the ID of linode_instance_shared_ips",
 			Computed:    true,
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"linode_id": schema.Int64Attribute{

--- a/linode/volume/framework_models.go
+++ b/linode/volume/framework_models.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -66,7 +67,7 @@ func (data *VolumeDataSourceModel) ParseNonComputedAttributes(
 
 type VolumeResourceModel struct {
 	SourceVolumeID types.Int64    `tfsdk:"source_volume_id"`
-	ID             types.Int64    `tfsdk:"id"`
+	ID             types.String   `tfsdk:"id"`
 	Label          types.String   `tfsdk:"label"`
 	Region         types.String   `tfsdk:"region"`
 	Size           types.Int64    `tfsdk:"size"`
@@ -86,7 +87,7 @@ func (data *VolumeResourceModel) FlattenVolume(volume *linodego.Volume, preserve
 		)
 		return diags
 	}
-	data.ID = helper.KeepOrUpdateInt64(data.ID, int64(volume.ID), preserveKnown)
+	data.ID = helper.KeepOrUpdateString(data.ID, strconv.Itoa(volume.ID), preserveKnown)
 	data.Label = helper.KeepOrUpdateString(data.Label, volume.Label, preserveKnown)
 	data.Region = helper.KeepOrUpdateString(data.Region, volume.Region, preserveKnown)
 	data.Size = helper.KeepOrUpdateInt64(data.Size, int64(volume.Size), preserveKnown)

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -25,7 +25,7 @@ func NewResource() resource.Resource {
 		BaseResource: helper.NewBaseResource(
 			helper.BaseResourceConfig{
 				Name:   "linode_volume",
-				IDType: types.Int64Type,
+				IDType: types.StringType,
 				Schema: &frameworkResourceSchema,
 				TimeoutOpts: &timeouts.Opts{
 					Update: true,
@@ -311,7 +311,7 @@ func (r *Resource) Read(
 
 	client := r.Meta.Client
 
-	id := helper.FrameworkSafeInt64ToInt(state.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -400,7 +400,7 @@ func (r *Resource) Update(
 
 	client := r.Meta.Client
 
-	id := helper.FrameworkSafeInt64ToInt(plan.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), resp.Diagnostics)
 	size := helper.FrameworkSafeInt64ToInt(plan.Size.ValueInt64(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
@@ -586,7 +586,7 @@ func (r *Resource) Delete(
 
 	client := r.Meta.Client
 
-	id := helper.FrameworkSafeInt64ToInt(state.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/volume/framework_schema_resource.go
+++ b/linode/volume/framework_schema_resource.go
@@ -20,11 +20,11 @@ const RequireReplacementWhenNewSourceVolumeIDIsNotNull = "When source_volume_id 
 
 var frameworkResourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The id of the volume.",
 			Computed:    true,
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"source_volume_id": schema.Int64Attribute{

--- a/linode/vpc/framework_datasource.go
+++ b/linode/vpc/framework_datasource.go
@@ -37,7 +37,7 @@ func (d *DataSource) Read(
 		return
 	}
 
-	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(data.ID.ValueString(), resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/vpc/framework_models.go
+++ b/linode/vpc/framework_models.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -10,7 +11,7 @@ import (
 )
 
 type VPCModel struct {
-	ID          types.Int64       `tfsdk:"id"`
+	ID          types.String      `tfsdk:"id"`
 	Label       types.String      `tfsdk:"label"`
 	Description types.String      `tfsdk:"description"`
 	Region      types.String      `tfsdk:"region"`
@@ -19,7 +20,7 @@ type VPCModel struct {
 }
 
 func (m *VPCModel) FlattenVPC(ctx context.Context, vpc *linodego.VPC, preserveKnown bool) {
-	m.ID = helper.KeepOrUpdateInt64(m.ID, int64(vpc.ID), preserveKnown)
+	m.ID = helper.KeepOrUpdateString(m.ID, strconv.Itoa(vpc.ID), preserveKnown)
 	m.Description = helper.KeepOrUpdateString(m.Description, vpc.Description, preserveKnown)
 	m.Created = helper.KeepOrUpdateValue(
 		m.Created,

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -15,7 +15,7 @@ func NewResource() resource.Resource {
 		BaseResource: helper.NewBaseResource(
 			helper.BaseResourceConfig{
 				Name:   "linode_vpc",
-				IDType: types.Int64Type,
+				IDType: types.StringType,
 				Schema: &frameworkResourceSchema,
 			},
 		),
@@ -72,7 +72,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(data.ID.ValueString(), resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -130,7 +130,7 @@ func (r *Resource) Update(
 	}
 
 	if shouldUpdate {
-		id := helper.FrameworkSafeInt64ToInt(plan.ID.ValueInt64(), &resp.Diagnostics)
+		id := helper.FrameworkSafeStringToInt(plan.ID.ValueString(), resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -163,7 +163,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(data.ID.ValueString(), resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -172,7 +172,7 @@ func (r *Resource) Delete(
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); (ok && lerr.Code != 404) || !ok {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to delete the VPC (%d)", data.ID.ValueInt64()),
+				fmt.Sprintf("Failed to delete the VPC (%s)", data.ID.ValueString()),
 				err.Error(),
 			)
 		}

--- a/linode/vpc/framework_schema_datasource.go
+++ b/linode/vpc/framework_schema_datasource.go
@@ -6,7 +6,7 @@ import (
 )
 
 var VPCAttrs = map[string]schema.Attribute{
-	"id": schema.Int64Attribute{
+	"id": schema.StringAttribute{
 		Description: "The id of the VPC.",
 		Required:    true,
 	},

--- a/linode/vpc/framework_schema_resource.go
+++ b/linode/vpc/framework_schema_resource.go
@@ -3,18 +3,17 @@ package vpc
 import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 var frameworkResourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The id of the VPC.",
 			Computed:    true,
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"label": schema.StringAttribute{

--- a/linode/vpcsubnet/framework_datasource.go
+++ b/linode/vpcsubnet/framework_datasource.go
@@ -38,7 +38,7 @@ func (d *DataSource) Read(
 	}
 
 	vpcId := helper.FrameworkSafeInt64ToInt(data.VPCId.ValueInt64(), &resp.Diagnostics)
-	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(data.ID.ValueString(), resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -47,7 +47,7 @@ func (d *DataSource) Read(
 	vpcSubnet, err := client.GetVPCSubnet(ctx, vpcId, id)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to read VPC Subnet %v", data.ID.ValueInt64()),
+			fmt.Sprintf("Failed to read VPC Subnet %v", data.ID.ValueString()),
 			err.Error(),
 		)
 		return

--- a/linode/vpcsubnet/framework_models.go
+++ b/linode/vpcsubnet/framework_models.go
@@ -2,6 +2,7 @@ package vpcsubnet
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -12,7 +13,7 @@ import (
 )
 
 type VPCSubnetModel struct {
-	ID      types.Int64       `tfsdk:"id"`
+	ID      types.String      `tfsdk:"id"`
 	VPCId   types.Int64       `tfsdk:"vpc_id"`
 	Label   types.String      `tfsdk:"label"`
 	IPv4    types.String      `tfsdk:"ipv4"`
@@ -81,7 +82,7 @@ func (d *VPCSubnetModel) FlattenSubnet(
 	subnet *linodego.VPCSubnet,
 	preserveKnown bool,
 ) diag.Diagnostics {
-	d.ID = helper.KeepOrUpdateInt64(d.ID, int64(subnet.ID), preserveKnown)
+	d.ID = helper.KeepOrUpdateString(d.ID, strconv.Itoa(subnet.ID), preserveKnown)
 
 	linodesList, diags := FlattenSubnetLinodes(ctx, subnet.Linodes)
 	if diags.HasError() {

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -17,7 +17,7 @@ func NewResource() resource.Resource {
 		BaseResource: helper.NewBaseResource(
 			helper.BaseResourceConfig{
 				Name:   "linode_vpc_subnet",
-				IDType: types.Int64Type,
+				IDType: types.StringType,
 				Schema: &frameworkResourceSchema,
 			},
 		),

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -34,7 +34,20 @@ func (r *Resource) ImportState(
 	resp *resource.ImportStateResponse,
 ) {
 	tflog.Debug(ctx, "Import "+r.Config.Name)
-	helper.ImportStateWithMultipleIDs(ctx, req, resp, "vpc_id", "id")
+	helper.ImportStateWithMultipleIDs(
+		ctx,
+		req,
+		resp,
+		[]helper.ImportableID{
+			{
+				Name:          "vpc_id",
+				TypeConverter: helper.IDTypeConverterInt64,
+			},
+			{
+				Name:          "id",
+				TypeConverter: helper.IDTypeConverterString,
+			},
+		})
 }
 
 func (r *Resource) Create(
@@ -92,7 +105,7 @@ func (r *Resource) Read(
 	}
 
 	vpcId := helper.FrameworkSafeInt64ToInt(data.VPCId.ValueInt64(), &resp.Diagnostics)
-	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(data.ID.ValueString(), resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -154,7 +167,7 @@ func (r *Resource) Update(
 			plan.VPCId.ValueInt64(),
 			&resp.Diagnostics,
 		)
-		id := helper.FrameworkSafeInt64ToInt(plan.ID.ValueInt64(), &resp.Diagnostics)
+		id := helper.FrameworkSafeStringToInt(plan.ID.ValueString(), resp.Diagnostics)
 
 		if resp.Diagnostics.HasError() {
 			return
@@ -193,7 +206,7 @@ func (r *Resource) Delete(
 	}
 
 	vpcId := helper.FrameworkSafeInt64ToInt(data.VPCId.ValueInt64(), &resp.Diagnostics)
-	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
+	id := helper.FrameworkSafeStringToInt(data.ID.ValueString(), resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -203,7 +216,7 @@ func (r *Resource) Delete(
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); (ok && lerr.Code != 404) || !ok {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to delete the VPC subnet (%d)", data.ID.ValueInt64()),
+				fmt.Sprintf("Failed to delete the VPC subnet (%s)", data.ID.ValueString()),
 				err.Error(),
 			)
 		}

--- a/linode/vpcsubnet/framework_schema_datasource.go
+++ b/linode/vpcsubnet/framework_schema_datasource.go
@@ -7,7 +7,7 @@ import (
 
 var frameworkDatasourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The id of the VPC Subnet.",
 			Required:    true,
 		},

--- a/linode/vpcsubnet/framework_schema_resource.go
+++ b/linode/vpcsubnet/framework_schema_resource.go
@@ -29,11 +29,11 @@ var LinodeObjectType = types.ObjectType{
 
 var frameworkResourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"id": schema.Int64Attribute{
+		"id": schema.StringAttribute{
 			Description: "The id of the VPC Subnet.",
 			Computed:    true,
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"vpc_id": schema.Int64Attribute{


### PR DESCRIPTION
## 📝 Description

This change reverts the ID attributes to strings for resources and their associated data sources implemented using Framework. This should resolve various issues with downstream consumers of the Terraform provider, specifically Pulumi.

This PR also updates the shared ID import logic to support custom types per-ID rather than using a single custom type for all ID attributes.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally before running.

### Integration Tests

```bash
make PKG_NAME=linode/firewalldevice int-test
make PKG_NAME=linode/instancesharedips int-test
make PKG_NAME=linode/volume int-test
make PKG_NAME=linode/vpc int-test
make PKG_NAME=linode/vpcsubnet int-test
```

### Manual Testing

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**