### PR TITLE
new: Add detailed logging to VPC-related resources

### DIFF
--- a/linode/vpc/framework_datasource.go
+++ b/linode/vpc/framework_datasource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -28,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_vpc")
+
 	client := d.Meta.Client
 
 	var data VPCModel
@@ -37,11 +41,14 @@ func (d *DataSource) Read(
 		return
 	}
 
+	ctx = populateLogAttributes(ctx, data)
+
 	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	tflog.Trace(ctx, "client.GetVPC(...)")
 	vpc, err := client.GetVPC(ctx, id)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/vpcs/framework_datasource.go
+++ b/linode/vpcs/framework_datasource.go
@@ -3,6 +3,8 @@ package vpcs
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
@@ -29,6 +31,8 @@ func (r *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_vpcs")
+
 	var data VPCFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -62,6 +66,9 @@ func (r *DataSource) Read(
 }
 
 func ListVPCs(ctx context.Context, client *linodego.Client, filter string) ([]any, error) {
+	tflog.Trace(ctx, "client.ListVPCs(...)", map[string]any{
+		"filter": filter,
+	})
 	vpcs, err := client.ListVPCs(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})

--- a/linode/vpcsubnet/framework_datasource.go
+++ b/linode/vpcsubnet/framework_datasource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -28,6 +30,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Trace(ctx, "Read data.linode_vpc_subnet")
 	client := d.Meta.Client
 
 	var data VPCSubnetModel
@@ -37,6 +40,8 @@ func (d *DataSource) Read(
 		return
 	}
 
+	ctx = populateLogAttributes(ctx, data)
+
 	vpcId := helper.FrameworkSafeInt64ToInt(data.VPCId.ValueInt64(), &resp.Diagnostics)
 	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
 
@@ -44,6 +49,7 @@ func (d *DataSource) Read(
 		return
 	}
 
+	tflog.Trace(ctx, "client.GetVPCSubnet(...)")
 	vpcSubnet, err := client.GetVPCSubnet(ctx, vpcId, id)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -42,6 +42,8 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
+	tflog.Debug(ctx, "Read linode_vpc_subnet")
+
 	var data VPCSubnetModel
 	client := r.Meta.Client
 
@@ -49,6 +51,8 @@ func (r *Resource) Create(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = populateLogAttributes(ctx, data)
 
 	createOpts := linodego.VPCSubnetCreateOptions{
 		Label: data.Label.ValueString(),
@@ -61,6 +65,9 @@ func (r *Resource) Create(
 		return
 	}
 
+	tflog.Debug(ctx, "client.CreateVPCSubnet(...)", map[string]any{
+		"options": createOpts,
+	})
 	subnet, err := client.CreateVPCSubnet(ctx, createOpts, vpcId)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -83,6 +90,8 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read linode_vpc_subnet")
+
 	client := r.Meta.Client
 	var data VPCSubnetModel
 
@@ -91,6 +100,8 @@ func (r *Resource) Read(
 		return
 	}
 
+	ctx = populateLogAttributes(ctx, data)
+
 	vpcId := helper.FrameworkSafeInt64ToInt(data.VPCId.ValueInt64(), &resp.Diagnostics)
 	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
 
@@ -98,6 +109,7 @@ func (r *Resource) Read(
 		return
 	}
 
+	tflog.Trace(ctx, "client.GetVPCSubnet(...)")
 	subnet, err := client.GetVPCSubnet(ctx, vpcId, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -131,6 +143,8 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
+	tflog.Debug(ctx, "Update linode_vpc_subnet")
+
 	var plan, state VPCSubnetModel
 	client := r.Meta.Client
 
@@ -140,6 +154,8 @@ func (r *Resource) Update(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = populateLogAttributes(ctx, state)
 
 	var updateOpts linodego.VPCSubnetUpdateOptions
 	shouldUpdate := false
@@ -160,6 +176,9 @@ func (r *Resource) Update(
 			return
 		}
 
+		tflog.Debug(ctx, "client.UpdateVPCSubnet(...)", map[string]any{
+			"options": updateOpts,
+		})
 		subnet, err := client.UpdateVPCSubnet(ctx, vpcId, id, updateOpts)
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -184,6 +203,8 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
+	tflog.Debug(ctx, "Delete linode_vpc_subnet")
+
 	var data VPCSubnetModel
 	client := r.Meta.Client
 
@@ -192,6 +213,8 @@ func (r *Resource) Delete(
 		return
 	}
 
+	ctx = populateLogAttributes(ctx, data)
+
 	vpcId := helper.FrameworkSafeInt64ToInt(data.VPCId.ValueInt64(), &resp.Diagnostics)
 	id := helper.FrameworkSafeInt64ToInt(data.ID.ValueInt64(), &resp.Diagnostics)
 
@@ -199,6 +222,7 @@ func (r *Resource) Delete(
 		return
 	}
 
+	tflog.Debug(ctx, "client.DeleteVPCSubnet(...)")
 	err := client.DeleteVPCSubnet(ctx, vpcId, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); (ok && lerr.Code != 404) || !ok {
@@ -209,4 +233,11 @@ func (r *Resource) Delete(
 		}
 		return
 	}
+}
+
+func populateLogAttributes(ctx context.Context, data VPCSubnetModel) context.Context {
+	return helper.SetLogFieldBulk(ctx, map[string]any{
+		"vpc_id": data.VPCId,
+		"id":     data.ID,
+	})
 }

--- a/linode/vpcsubnets/framework_datasource.go
+++ b/linode/vpcsubnets/framework_datasource.go
@@ -41,7 +41,7 @@ func (r *DataSource) Read(
 		return
 	}
 
-	ctx = populateLogAttributes(ctx, data)
+	ctx = tflog.SetField(ctx, "vpc_id", data.VPCId)
 
 	id, d := filterConfig.GenerateID(data.Filters)
 	if d != nil {
@@ -81,7 +81,9 @@ func (data *VPCSubnetFilterModel) ListVPCSubnets(
 		}
 	}
 
-	tflog.Trace(ctx, "client.ListVPCSubnets(...)")
+	tflog.Trace(ctx, "client.ListVPCSubnets(...)", map[string]any{
+		"filter": filter,
+	})
 	vpcs, err := client.ListVPCSubnets(ctx, vpcId, &linodego.ListOptions{
 		Filter: filter,
 	})
@@ -90,11 +92,4 @@ func (data *VPCSubnetFilterModel) ListVPCSubnets(
 	}
 
 	return helper.TypedSliceToAny(vpcs), nil
-}
-
-func populateLogAttributes(ctx context.Context, model VPCSubnetFilterModel) context.Context {
-	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"vpc_id":  model.VPCId,
-		"filters": model.Filters,
-	})
 }

--- a/linode/vpcsubnets/framework_datasource.go
+++ b/linode/vpcsubnets/framework_datasource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -31,12 +33,15 @@ func (r *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_vpc_subnets")
 	var data VPCSubnetFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = populateLogAttributes(ctx, data)
 
 	id, d := filterConfig.GenerateID(data.Filters)
 	if d != nil {
@@ -76,6 +81,7 @@ func (data *VPCSubnetFilterModel) ListVPCSubnets(
 		}
 	}
 
+	tflog.Trace(ctx, "client.ListVPCSubnets(...)")
 	vpcs, err := client.ListVPCSubnets(ctx, vpcId, &linodego.ListOptions{
 		Filter: filter,
 	})
@@ -84,4 +90,11 @@ func (data *VPCSubnetFilterModel) ListVPCSubnets(
 	}
 
 	return helper.TypedSliceToAny(vpcs), nil
+}
+
+func populateLogAttributes(ctx context.Context, model VPCSubnetFilterModel) context.Context {
+	return helper.SetLogFieldBulk(ctx, map[string]any{
+		"vpc_id":  model.VPCId,
+		"filters": model.Filters,
+	})
 }


### PR DESCRIPTION
## 📝 Description

This change adds detailed logging to the following resources and data sources:

- `linode_vpc`
- `linode_vpc_subnet`
- `data.linode_vpc`
- `data.linode_vpc_subnet`
- `data.linode_vpcs`
- `data.linode_vpc_subnets`

## ✔️ How to Test

### Manual Testing

**NOTE: You can filter the output to only include Linode provider logs using the following: `terraform apply 2> >(grep '@module=linode' >&2)`**

1. Enable trace logging for the Linode provider:

```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```

2. Inside of a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
# ...

resource "linode_vpc" "test" {
  label = "test-vpc"
  region = "us-mia"
}

data "linode_vpc" "test" {
  depends_on = [linode_vpc.test]

  id = linode_vpc.test.id
}

data "linode_vpcs" "test" {
  depends_on = [linode_vpc.test]

  filter {
    name = "region"
    values = [linode_vpc.test.region]
  }
}

resource "linode_vpc_subnet" "test" {
  vpc_id = linode_vpc.test.id
  label = "test-subnet"
  ipv4 = "10.0.0.0/24"
}

data "linode_vpc_subnet" "test" {
  depends_on = [linode_vpc_subnet.test]

  vpc_id = linode_vpc.test.id
  id = linode_vpc_subnet.test.id
}

data "linode_vpc_subnets" "test" {
  depends_on = [linode_vpc_subnet.test]
  vpc_id = linode_vpc.test.id

  filter {
    name = "label"
    values = ["test-subnet"]
  }
}
```

3. Observe the new log statements in the stderr output.
4. Make and apply arbitrary changes to the resources in this configuration. 
5. Observe the new log statements in the stderr output.
