### PR TITLE
linode_image upload: avoid buffering the image content in memory

### DIFF
--- a/linode/image/resource.go
+++ b/linode/image/resource.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"bytes"
 	"context"
 	"crypto/md5" // #nosec G501 -- endpoint expecting md5
 	"encoding/hex"
@@ -295,16 +294,10 @@ func uploadImageAndStoreHash(
 ) error {
 	client := meta.(*helper.ProviderMeta).Client
 
-	var buf bytes.Buffer
-	tee := io.TeeReader(image, &buf)
+	hash := md5.New() // #nosec G401 -- endpoint expecting md5
+	tee := io.TeeReader(image, hash)
 
 	if err := client.UploadImageToURL(ctx, uploadURL, tee); err != nil {
-		return err
-	}
-
-	hash := md5.New() // #nosec G401 -- endpoint expecting md5
-
-	if _, err := io.Copy(hash, &buf); err != nil {
 		return err
 	}
 

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -26,6 +26,9 @@ var testImageBytes = []byte{
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 }
 
+// MD5 digest of testImageBytes
+const testImageMD5 = "0cf442194905e7be019a11660df8164f"
+
 var testImageBytesNew = []byte{
 	0x1f, 0x8b, 0x08, 0x08, 0x53, 0x13, 0x94, 0x60,
 	0x00, 0x03, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x69, 0x6d, 0x67, 0x00, 0xcb, 0xc8,
@@ -183,7 +186,7 @@ func TestAccImage_uploadFile(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "type", "manual"),
 					resource.TestCheckResourceAttr(resName, "is_public", "false"),
 					resource.TestCheckResourceAttrSet(resName, "deprecated"),
-					resource.TestCheckResourceAttrSet(resName, "file_hash"),
+					resource.TestCheckResourceAttr(resName, "file_hash", testImageMD5),
 					resource.TestCheckResourceAttr(resName, "status", string(linodego.ImageStatusAvailable)),
 				),
 			},


### PR DESCRIPTION
## 📝 Description

The current implementation of creating a `linode_image` by uploading a local file involves accumulating the file's content in a `bytes.Buffer` during the upload, then computing the MD5 checksum of the buffer's content. I believe this buffer is unnecessary - the file's content can be streamed into the hasher as well as the uploader.

This drastically reduces memory consumption. Before this change I was unable to upload a ~800MB image without my computer (8GB total) running out of memory almost immediately; after this change I could successfully upload it (with about 4GB peak memory usage by terraform + terraform-provider-linode together).

## ✔️ How to Test

```
# Create an "image" to upload:
$ dd if=/dev/random of=img bs=1M count=200
$ gzip --fast img
$ du -hs img.gz
201M	img.gz

$ cat main.tf
terraform {
  required_providers {
    linode = {
      source = "linode/linode"
      version = "2.14.0"
    }
  }
}
resource "linode_image" "main" {
  label = "no-image-buffering-test"
  file_path = "./img.gz"
  file_hash = filemd5("./img.gz")
  region = "eu-west"
}

$ export LINODE_TOKEN=...
$ terraform init
$ terraform apply -auto-approve
$ terraform destroy -auto-approve
```

Observe the peak resident set size of the terraform-provider-linode process (e.g. by watching `top`/`htop`).

Without this patch => 1286M
With this patch => 973M