### PR TITLE
new: Add detailed logging on miscellaneous data sources 

### DIFF
--- a/linode/kernel/framework_datasource.go
+++ b/linode/kernel/framework_datasource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
@@ -27,6 +28,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_kernel")
+
 	client := d.Meta.Client
 
 	var data DataSourceModel
@@ -35,6 +38,9 @@ func (d *DataSource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	ctx = tflog.SetField(ctx, "kernel_id", data.ID.ValueString())
+	tflog.Trace(ctx, "client.GetKernel(...)")
 
 	kernel, err := client.GetKernel(ctx, data.ID.ValueString())
 	if err != nil {

--- a/linode/kernels/framework_datasource.go
+++ b/linode/kernels/framework_datasource.go
@@ -63,7 +63,7 @@ func listKernels(
 	filter string,
 ) ([]any, error) {
 	tflog.Debug(ctx, "client.ListKernels(...)", map[string]interface{}{
-		"body": filter,
+		"filter": filter,
 	})
 
 	kernels, err := client.ListKernels(ctx, &linodego.ListOptions{

--- a/linode/kernels/framework_datasource.go
+++ b/linode/kernels/framework_datasource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -28,6 +29,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_kernels")
+
 	var data KernelFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -59,6 +62,10 @@ func listKernels(
 	client *linodego.Client,
 	filter string,
 ) ([]any, error) {
+	tflog.Debug(ctx, "client.ListKernels(...)", map[string]interface{}{
+		"body": filter,
+	})
+
 	kernels, err := client.ListKernels(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})

--- a/linode/profile/framework_datasource.go
+++ b/linode/profile/framework_datasource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -83,6 +84,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_profile")
+
 	client := d.Meta.Client
 
 	var data DataSourceModel
@@ -92,6 +95,7 @@ func (d *DataSource) Read(
 		return
 	}
 
+	tflog.Trace(ctx, "client.GetProfile(...)")
 	profile, err := client.GetProfile(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/region/framework_datasource.go
+++ b/linode/region/framework_datasource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
@@ -28,6 +29,8 @@ func (r *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_region")
+
 	client := r.Meta.Client
 
 	var data RegionModel
@@ -38,6 +41,9 @@ func (r *DataSource) Read(
 	}
 
 	id := data.ID.ValueString()
+
+	ctx = tflog.SetField(ctx, "region_id", id)
+	tflog.Trace(ctx, "client.GetRegion(...)")
 
 	region, err := client.GetRegion(ctx, id)
 	if err != nil {

--- a/linode/regions/framework_datasource.go
+++ b/linode/regions/framework_datasource.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -29,6 +30,8 @@ func (r *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_regions")
+
 	var data RegionFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -59,6 +62,10 @@ func (r *DataSource) Read(
 }
 
 func listRegions(ctx context.Context, client *linodego.Client, filter string) ([]any, error) {
+	tflog.Debug(ctx, "client.ListRegions(...)", map[string]interface{}{
+		"body": filter,
+	})
+
 	regions, err := client.ListRegions(ctx, &linodego.ListOptions{
 		Filter: filter,
 	})

--- a/linode/vlan/framework_datasource.go
+++ b/linode/vlan/framework_datasource.go
@@ -69,7 +69,7 @@ func listVLANs(
 	filter string,
 ) ([]any, error) {
 	tflog.Debug(ctx, "client.ListVLANs(...)", map[string]interface{}{
-		"body": filter,
+		"filter": filter,
 	})
 
 	vlans, err := client.ListVLANs(

--- a/linode/vlan/framework_datasource.go
+++ b/linode/vlan/framework_datasource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -29,6 +30,8 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
+	tflog.Debug(ctx, "Read data.linode_vlans")
+
 	var data VLANsFilterModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -65,6 +68,10 @@ func listVLANs(
 	client *linodego.Client,
 	filter string,
 ) ([]any, error) {
+	tflog.Debug(ctx, "client.ListVLANs(...)", map[string]interface{}{
+		"body": filter,
+	})
+
 	vlans, err := client.ListVLANs(
 		ctx,
 		&linodego.ListOptions{Filter: filter},


### PR DESCRIPTION
## 📝 Description

This PR adds logging on the following data sources:

- linode_profile
- linode_kernel
- linode_kernels
- linode_region
- linode_regions
- linode_vlans

## ✔️ How to Test
1. Enable trace logging for the Linode provider:
```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```

2. Test `linode_profile` data source logging with the following config in a TF sandbox environment
```
data "linode_profile" "user" {}
```
Observe the new logging in the stderr output.

3. Test `linode_kernel` data source logging with the following config in a TF sandbox environment
```
data "linode_kernel" "foobar" {
    id = "linode/latest-64bit"
}
```
Observe the new logging in the stderr output.

4. Test `linode_kernels` data source logging with the following config in a TF sandbox environment
```
data "linode_kernels" "kernels" {}
```
Observe the new logging in the stderr output.

5. Test `linode_region` data source logging with the following config in a TF sandbox environment
```
data "linode_region" "foobar" {
    id = "us-east"
}
```
Observe the new logging in the stderr output.

6. Test `linode_regions` data source logging with the following config in a TF sandbox environment
```
data "linode_regions" "foobar" {}
```
Observe the new logging in the stderr output.

7. Test `linode_vlans` data source logging with the following config in a TF sandbox environment
```
data "linode_vlans" "foobar" {}
```
Observe the new logging in the stderr output.
