### PR TITLE
Only set linode_id in log; append unhandled diags

### DIFF
--- a/linode/instancesharedips/framework_resource.go
+++ b/linode/instancesharedips/framework_resource.go
@@ -41,7 +41,10 @@ func CreateOrUpdateSharedIPs(
 		LinodeID: linodeID,
 	}
 
-	plan.Addresses.ElementsAs(ctx, &createOpts.IPs, false)
+	diags.Append(plan.Addresses.ElementsAs(ctx, &createOpts.IPs, false)...)
+	if diags.HasError() {
+		return
+	}
 
 	tflog.Debug(ctx, "client.ShareIPAddresses(...)", map[string]interface{}{
 		"options": createOpts,
@@ -218,6 +221,5 @@ func GetSharedIPsForLinode(ctx context.Context, client *linodego.Client, linodeI
 func populateLogAttributes(ctx context.Context, data ResourceModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
 		"linode_id": data.LinodeID.ValueInt64(),
-		"id":        data.ID.ValueString(),
 	})
 }


### PR DESCRIPTION
## 📝 Description

2 small fixes to the shared IP resource.

- `id` and `linode_id` is the same thing in this resource, thus only one is needed in the logs.
- `diags` returned from `plan.Addresses.ElementsAs` wasn't handled, it should be appended into the `diags` and checked.

## ✔️ How to Test

```
make PKG_NAME=linode/instancesharedips int-test
```

```terraform
resource "linode_instance_shared_ips" "share-primary" {
  linode_id = linode_instance.secondary.id
  addresses = [linode_instance_ip.primary.address]
}

resource "linode_instance_ip" "primary" {
  linode_id = linode_instance.primary.id
}

resource "linode_instance" "primary" {
  label = "node-primary"
  type = "g6-nanode-1"
  region = "us-mia"
}

resource "linode_instance" "secondary" {
  label = "node-secondary"
  type = "g6-nanode-1"
  region = "us-mia"
}
```