### PR TITLE
docs: update go report card link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Release](https://img.shields.io/github/v/release/linode/terraform-provider-linode)](https://github.com/linode/terraform-provider-linode/releases/latest)
 [![GoDoc](https://godoc.org/github.com/linode/terraform-provider-linode?status.svg)](https://godoc.org/github.com/linode/terraform-provider-linode)
-[![Go Report Card](https://goreportcard.com/badge/github.com/linode/terraform-provider-linode)](https://goreportcard.com/report/github.com/linode/linodego)
+[![Go Report Card](https://goreportcard.com/badge/github.com/linode/terraform-provider-linode)](https://goreportcard.com/report/github.com/linode/terraform-provider-linode)
 [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 
 


### PR DESCRIPTION
Fix goreportcard.com link to point to the Terraform Linode provider rather than linodego

## 📝 Description

Fix the goreportcard link to point to the correct repo: https://goreportcard.com/report/github.com/linode/terraform-provider-linode

## ✔️ How to Test

The current link points to the linodego report card. To test this, click the link in the README.md. Check the link above. Both offer an A+ but the new link is the correct link.

I was tempted to pull the gitter.im link because that is a graveyard. Left it alone. You may want to steer users to the Linode community instead. 


