### PR TITLE
new: Populate route_target in linode_ipv6_range

### DIFF
--- a/linode/ipv6range/framework_models.go
+++ b/linode/ipv6range/framework_models.go
@@ -82,4 +82,5 @@ func (r *ResourceModel) CopyFrom(other ResourceModel, preserveKnown bool) {
 	r.PrefixLength = helper.KeepOrUpdateValue(
 		r.PrefixLength, other.PrefixLength, preserveKnown,
 	)
+	r.RouteTarget = helper.KeepOrUpdateValue(r.RouteTarget, other.RouteTarget, preserveKnown)
 }

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -116,23 +116,9 @@ func (r *Resource) Create(
 		return
 	}
 
-	// when user configured linode_id, populate route_target implicitly
+	// If user configured linode_id, populate route_target implicitly.
 	if linodeIdConfigured {
-		ranges, err := client.ListIPv6Ranges(ctx, nil)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Failed to list ipv6 ranges when create.",
-				err.Error(),
-			)
-			return
-		}
-
-		for _, r := range ranges {
-			if r.Range == data.ID.ValueString() {
-				data.RouteTarget = types.StringValue(r.RouteTarget)
-				break
-			}
-		}
+		data.RouteTarget = types.StringValue(ipv6range.RouteTarget)
 	}
 
 	resp.Diagnostics.Append(data.FlattenIPv6Range(ctx, ipv6rangeR, true)...)

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -116,6 +116,25 @@ func (r *Resource) Create(
 		return
 	}
 
+	// when user configured linode_id, populate route_target implicitly
+	if linodeIdConfigured {
+		ranges, err := client.ListIPv6Ranges(ctx, nil)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Failed to list ipv6 ranges when create.",
+				err.Error(),
+			)
+			return
+		}
+
+		for _, r := range ranges {
+			if r.Range == data.ID.ValueString() {
+				data.RouteTarget = types.StringValue(r.RouteTarget)
+				break
+			}
+		}
+	}
+
 	resp.Diagnostics.Append(data.FlattenIPv6Range(ctx, ipv6rangeR, true)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/ipv6range/framework_schema_resource.go
+++ b/linode/ipv6range/framework_schema_resource.go
@@ -32,6 +32,7 @@ var frameworkResourceSchema = schema.Schema{
 		"route_target": schema.StringAttribute{
 			Description:   "The IPv6 SLAAC address to assign this range to.",
 			Optional:      true,
+			Computed:      true,
 			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			Validators: []validator.String{
 				stringvalidator.ConflictsWith(path.Expressions{

--- a/linode/ipv6range/resource_test.go
+++ b/linode/ipv6range/resource_test.go
@@ -44,6 +44,7 @@ func TestAccIPv6Range_basic(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resName, "range"),
 						resource.TestCheckResourceAttrSet(resName, "linode_id"),
 						resource.TestCheckResourceAttrSet(resName, "linodes.0"),
+						resource.TestCheckResourceAttrSet(resName, "route_target"),
 					),
 				},
 				{
@@ -141,6 +142,7 @@ func TestAccIPv6Range_reassignment(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resName, "range"),
 						resource.TestCheckResourceAttrSet(resName, "linode_id"),
 						resource.TestCheckResourceAttrSet(resName, "linodes.0"),
+						resource.TestCheckResourceAttrSet(resName, "route_target"),
 					),
 				},
 				{
@@ -157,6 +159,7 @@ func TestAccIPv6Range_reassignment(t *testing.T) {
 						resource.TestCheckResourceAttrSet(resName, "range"),
 						resource.TestCheckResourceAttrSet(resName, "linode_id"),
 						resource.TestCheckResourceAttrSet(resName, "linodes.0"),
+						resource.TestCheckResourceAttrSet(resName, "route_target"),
 					),
 				},
 				{


### PR DESCRIPTION
## 📝 Description

When user configured `linode_id` to create a ipv6 range, populate the value of `route_target` implicitly. 

## ✔️ How to Test

`make unit-test`

`make int-test PKG_NAME="linode/ipv6range"`

**Manual test:**
1. In a sandbox environment (i.e. dx-devenv), put the following configuration to create ipv6 range under a new Linode using linode_id:
```
resource "linode_instance" "foobar" {
    label = "tf-test-instance"
    type = "g6-nanode-1"
    region = "us-mia"
    booted = false
}

resource "linode_ipv6_range" "foobar" {
    linode_id = linode_instance.foobar.id
    prefix_length = 64
}

output "route_target" {
    value = linode_ipv6_range.foobar.route_target
}

output "linode_ipv6" {
    value = linode_instance.foobar.ipv6
}
```
2. Apply the configuration. Observe that the `route_target` is correctly populated. Its value without the prefix length equals to `linode_ipv6` the Linode’s IPv6 SLAAC address.
3. Destroy the resources for clean up.