### PR TITLE
new: Provider-level Object Storage Keys

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,12 @@ The following keys can be used to configure the provider.
 
 * `max_retry_delay_ms` - (Optional) Maximum delay in milliseconds before retrying a request.
 
+* `obj_access_key` - (Optional) The access key to be used in [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) and [linode_object_storage_object](/docs/resources/object_storage_object.md).
+  The Object Access Key can also be specified using the `LINODE_OBJ_ACCESS_KEY` shell environment variable.
+
+* `obj_secret_key` - (Optional) The secret key to be used in [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) and [linode_object_storage_object](/docs/resources/object_storage_object.md).
+  The Object Secret Key can also be specified using the `LINODE_OBJ_SECRET_KEY` shell environment variable.
+
 ## Early Access
 
 Some resources are made available before the feature reaches general availability. These resources are subject to change, and may not be available to all customers in all regions. Early access features can be accessed by configuring the provider to use a different version of the API.

--- a/docs/resources/object_storage_bucket.md
+++ b/docs/resources/object_storage_bucket.md
@@ -62,9 +62,9 @@ The following arguments are supported:
 
 * `acl` - (Optional) The Access Control Level of the bucket using a canned ACL string. See all ACL strings [in the Linode API v4 documentation](https://linode.com/docs/api/object-storage/#object-storage-bucket-access-update__request-body-schema).
 
-* `access_key` - (Optional) The access key to authenticate with.
+* `access_key` - (Optional) The access key to authenticate with. If not specified with the resource, the value of [`obj_access_key`](../index.md#configuration-reference) from provider-level will be used.
 
-* `secret_key` - (Optional) The secret key to authenticate with.
+* `secret_key` - (Optional) The secret key to authenticate with. If not specified with the resource, the value of [`obj_secret_key`](../index.md#configuration-reference) from provider-level will be used.
 
 * `cors_enabled` - (Optional) If true, the bucket will have CORS enabled for all origins.
 

--- a/docs/resources/object_storage_bucket.md
+++ b/docs/resources/object_storage_bucket.md
@@ -53,6 +53,7 @@ resource "linode_object_storage_bucket" "mybucket" {
 ```
 
 Creating an Object Storage Bucket with Lifecycle rules using provider-level object credentials
+
 ```hcl
 provider "linode" {
     obj_access_key = ${your-access-key}

--- a/docs/resources/object_storage_bucket.md
+++ b/docs/resources/object_storage_bucket.md
@@ -52,6 +52,24 @@ resource "linode_object_storage_bucket" "mybucket" {
 }
 ```
 
+Creating an Object Storage Bucket with Lifecycle rules using provider-level object credentials
+```hcl
+provider "linode" {
+    obj_access_key = ${your-access-key}
+    obj_secret_key = ${your-secret-key}
+}
+
+resource "linode_object_storage_bucket" "mybucket" {
+  # no need to specify the keys with the resource
+  cluster = "us-east-1"
+  label   = "mybucket"
+
+  lifecycle_rule {
+    # ... details of the lifecycle
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/object_storage_object.md
+++ b/docs/resources/object_storage_object.md
@@ -45,6 +45,7 @@ resource "linode_object_storage_object" "object" {
 ```
 
 ### Creating an object using provider-level object credentials
+
 ```hcl
 provider "linode" {
     obj_access_key = ${your-access-key}

--- a/docs/resources/object_storage_object.md
+++ b/docs/resources/object_storage_object.md
@@ -44,6 +44,22 @@ resource "linode_object_storage_object" "object" {
 
 ```
 
+### Creating an object using provider-level object credentials
+```hcl
+provider "linode" {
+    obj_access_key = ${your-access-key}
+    obj_secret_key = ${your-secret-key}
+}
+
+resource "linode_object_storage_object" "object" {
+    # no need to specify the keys with the resource
+    bucket  = "my-bucket"
+    cluster = "us-east-1"
+    key     = "my-object"
+    source = pathexpand("~/files/log.txt")
+}
+```
+
 ## Argument Reference
 
 -> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
@@ -56,9 +72,9 @@ The following arguments are supported:
 
 * `key` - (Required) They name of the object once it is in the bucket.
 
-* `secret_key` - (Required) The secret key to authenitcate with.
+* `secret_key` - (Required) The secret key to authenticate with. You can also specify the value at provider-level using [`obj_secret_key`](../index.md#configuration-reference).
 
-* `access_key` - (Required) The access key to authenticate with.
+* `access_key` - (Required) The access key to authenticate with. You can also specify the value at provider-level using [`obj_access_key`](../index.md#configuration-reference).
 
 * `source` - (Optional, conflicts with `content` and `content_base64`) The path to a file that will be read and uploaded as raw bytes for the object content. The path must either be relative to the root module or absolute.
 

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -165,6 +165,14 @@ func (p *FrameworkProvider) Schema(
 				Optional:    true,
 				Description: "The rate in milliseconds to poll for an LKE node to be ready.",
 			},
+			"obj_access_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "The access key to be used in linode_object_storage_bucket and linode_object_storage_object.",
+			},
+			"obj_secret_key": schema.StringAttribute{
+				Optional:    true,
+				Description: "The secret key to be used in linode_object_storage_bucket and linode_object_storage_object.",
+			},
 		},
 	}
 }

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -172,6 +172,7 @@ func (p *FrameworkProvider) Schema(
 			"obj_secret_key": schema.StringAttribute{
 				Optional:    true,
 				Description: "The secret key to be used in linode_object_storage_bucket and linode_object_storage_object.",
+				Sensitive:   true,
 			},
 		},
 	}

--- a/linode/framework_provider_config.go
+++ b/linode/framework_provider_config.go
@@ -188,6 +188,20 @@ func (fp *FrameworkProvider) HandleDefaults(
 	if lpm.LKENodeReadyPollMilliseconds.IsNull() {
 		lpm.LKENodeReadyPollMilliseconds = types.Int64Value(3000)
 	}
+
+	if lpm.ObjAccessKey.IsNull() {
+		lpm.ObjAccessKey = GetStringFromEnv(
+			"LINODE_OBJ_ACCESS_KEY",
+			types.StringNull(),
+		)
+	}
+
+	if lpm.ObjSecretKey.IsNull() {
+		lpm.ObjSecretKey = GetStringFromEnv(
+			"LINODE_OBJ_SECRET_KEY",
+			types.StringNull(),
+		)
+	}
 }
 
 func (fp *FrameworkProvider) InitProvider(

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	EventPollMilliseconds        int
 	LKEEventPollMilliseconds     int
 	LKENodeReadyPollMilliseconds int
+
+	ObjAccessKey string
+	ObjSecretKey string
 }
 
 // Client returns a fully initialized Linode client.

--- a/linode/helper/framework_provider_model.go
+++ b/linode/helper/framework_provider_model.go
@@ -23,6 +23,8 @@ func GetFrameworkProviderModelFromSDKv2ProviderConfig(config *Config) *Framework
 		EventPollMilliseconds:        types.Int64Value(int64(config.EventPollMilliseconds)),
 		LKEEventPollMilliseconds:     types.Int64Value(int64(config.LKEEventPollMilliseconds)),
 		LKENodeReadyPollMilliseconds: types.Int64Value(int64(config.LKENodeReadyPollMilliseconds)),
+		ObjAccessKey:                 types.StringValue(config.ObjAccessKey),
+		ObjSecretKey:                 types.StringValue(config.ObjSecretKey),
 	}
 }
 
@@ -49,6 +51,9 @@ type FrameworkProviderModel struct {
 	LKEEventPollMilliseconds types.Int64 `tfsdk:"lke_event_poll_ms"`
 
 	LKENodeReadyPollMilliseconds types.Int64 `tfsdk:"lke_node_ready_poll_ms"`
+
+	ObjAccessKey types.String `tfsdk:"obj_access_key"`
+	ObjSecretKey types.String `tfsdk:"obj_secret_key"`
 }
 
 type FrameworkProviderMeta struct {

--- a/linode/helper/objects.go
+++ b/linode/helper/objects.go
@@ -53,8 +53,25 @@ func S3ConnectionFromData(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	accessKey := d.Get("access_key").(string)
-	secretKey := d.Get("secret_key").(string)
+	config := meta.(*ProviderMeta).Config
+
+	var accessKey, secretKey string
+
+	if v, ok := d.GetOk("access_key"); ok {
+		accessKey = v.(string)
+	} else {
+		accessKey = config.ObjAccessKey
+	}
+
+	if v, ok := d.GetOk("secret_key"); ok {
+		secretKey = v.(string)
+	} else {
+		secretKey = config.ObjSecretKey
+	}
+
+	if accessKey == "" || secretKey == "" {
+		return nil, errors.New("access_key and secret_key are required to establish S3 connection")
+	}
 
 	return S3Connection(ctx, endpoint, accessKey, secretKey)
 }

--- a/linode/obj/resource.go
+++ b/linode/obj/resource.go
@@ -91,16 +91,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		d.Set("endpoint", endpoint)
 	}
 
-	// Compute object access credentials from provider metadata when they're not configured explicitly
-	config := meta.(*helper.ProviderMeta).Config
-	if _, ok := d.GetOk("access_key"); !ok {
-		d.Set("access_key", config.ObjAccessKey)
-	}
-
-	if _, ok := d.GetOk("secret_key"); !ok {
-		d.Set("secret_key", config.ObjSecretKey)
-	}
-
 	return nil
 }
 

--- a/linode/obj/resource.go
+++ b/linode/obj/resource.go
@@ -91,6 +91,16 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		d.Set("endpoint", endpoint)
 	}
 
+	// Compute object access credentials from provider metadata when they're not configured explicitly
+	config := meta.(*helper.ProviderMeta).Config
+	if _, ok := d.GetOk("access_key"); !ok {
+		d.Set("access_key", config.ObjAccessKey)
+	}
+
+	if _, ok := d.GetOk("secret_key"); !ok {
+		d.Set("secret_key", config.ObjSecretKey)
+	}
+
 	return nil
 }
 

--- a/linode/obj/schema_resource.go
+++ b/linode/obj/schema_resource.go
@@ -26,14 +26,18 @@ var resourceSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"secret_key": {
-		Type:        schema.TypeString,
-		Description: "The S3 secret key with access to the target bucket.",
-		Required:    true,
+		Type: schema.TypeString,
+		Description: "The required S3 secret key with access to the target bucket. " +
+			"If not specified with the resource, the value of obj_secret_key from provider-level will be used.",
+		Optional: true,
+		Computed: true,
 	},
 	"access_key": {
-		Type:        schema.TypeString,
-		Description: "The S3 access key with access to the target bucket.",
-		Required:    true,
+		Type: schema.TypeString,
+		Description: "The required S3 access key with access to the target bucket. " +
+			"If not specified with the resource, the value of obj_access_key from provider-level will be used.",
+		Optional: true,
+		Computed: true,
 	},
 	"content": {
 		Type:         schema.TypeString,

--- a/linode/obj/schema_resource.go
+++ b/linode/obj/schema_resource.go
@@ -29,8 +29,9 @@ var resourceSchema = map[string]*schema.Schema{
 		Type: schema.TypeString,
 		Description: "The required S3 secret key with access to the target bucket. " +
 			"If not specified with the resource, the value of obj_secret_key from provider-level will be used.",
-		Optional: true,
-		Computed: true,
+		Optional:  true,
+		Computed:  true,
+		Sensitive: true,
 	},
 	"access_key": {
 		Type: schema.TypeString,

--- a/linode/obj/schema_resource.go
+++ b/linode/obj/schema_resource.go
@@ -30,7 +30,6 @@ var resourceSchema = map[string]*schema.Schema{
 		Description: "The required S3 secret key with access to the target bucket. " +
 			"If not specified with the resource, the value of obj_secret_key from provider-level will be used.",
 		Optional:  true,
-		Computed:  true,
 		Sensitive: true,
 	},
 	"access_key": {
@@ -38,7 +37,6 @@ var resourceSchema = map[string]*schema.Schema{
 		Description: "The required S3 access key with access to the target bucket. " +
 			"If not specified with the resource, the value of obj_access_key from provider-level will be used.",
 		Optional: true,
-		Computed: true,
 	},
 	"content": {
 		Type:         schema.TypeString,

--- a/linode/obj/tmpl/creds_configed.gotf
+++ b/linode/obj/tmpl/creds_configed.gotf
@@ -1,0 +1,21 @@
+{{ define "object_object_creds_configed" }}
+
+{{ template "object_bucket_basic" .Bucket }}
+{{ template "object_key_basic" .Key }}
+
+provider "linode" {
+    alias = "creds_configed"
+    obj_access_key = linode_object_storage_key.foobar.access_key
+    obj_secret_key = linode_object_storage_key.foobar.secret_key
+}
+
+resource "linode_object_storage_object" "creds_configed" {
+    provider = linode.creds_configed
+
+    bucket     = linode_object_storage_bucket.foobar.label
+    cluster    = "{{ .Cluster }}"
+    key        = "test_creds_configed"
+    content    = "{{.Content}}"
+}
+
+{{ end }}

--- a/linode/obj/tmpl/template.go
+++ b/linode/obj/tmpl/template.go
@@ -38,3 +38,13 @@ func Updates(t *testing.T, name, cluster, keyName, content, source string) strin
 			Cluster: cluster,
 		})
 }
+
+func CredsConfiged(t *testing.T, name, cluster, keyName, content string) string {
+	return acceptance.ExecuteTemplate(t,
+		"object_object_creds_configed", TemplateData{
+			Bucket:  objectbucket.TemplateData{Label: name, Cluster: cluster},
+			Key:     objectkey.TemplateData{Label: keyName},
+			Content: content,
+			Cluster: cluster,
+		})
+}

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -136,8 +136,6 @@ func readResource(
 	d.Set("acl", access.ACL)
 	d.Set("cors_enabled", access.CorsEnabled)
 	d.Set("endpoint", endpoint)
-	d.Set("access_key", accessKey)
-	d.Set("secret_key", secretKey)
 
 	return nil
 }

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -488,6 +488,8 @@ func TestAccResourceBucket_credsConfiged(t *testing.T) {
 						resource.TestCheckResourceAttr(resName, "label", objectStorageBucketName),
 						resource.TestCheckResourceAttr(resName, "cluster", testCluster),
 						resource.TestCheckResourceAttr(resName, "lifecycle_rule.#", "1"),
+						resource.TestCheckResourceAttrSet(resName, "access_key"),
+						resource.TestCheckResourceAttrSet(resName, "secret_key"),
 					),
 				},
 			},

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -469,6 +469,32 @@ func TestAccResourceBucket_update(t *testing.T) {
 	})
 }
 
+func TestAccResourceBucket_credsConfiged(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_object_storage_bucket.foobar"
+	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
+	objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
+
+	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
+		resource.Test(retryT, resource.TestCase{
+			PreCheck:                 func() { acceptance.PreCheck(t) },
+			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+			CheckDestroy:             checkBucketDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: tmpl.CredsConfiged(t, objectStorageBucketName, testCluster, objectStorageKeyName),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resName, "label", objectStorageBucketName),
+						resource.TestCheckResourceAttr(resName, "cluster", testCluster),
+						resource.TestCheckResourceAttr(resName, "lifecycle_rule.#", "1"),
+					),
+				},
+			},
+		})
+	})
+}
+
 func checkBucketExists(s *terraform.State) error {
 	client := acceptance.TestAccProvider.Meta().(*helper.ProviderMeta).Client
 

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -488,8 +488,6 @@ func TestAccResourceBucket_credsConfiged(t *testing.T) {
 						resource.TestCheckResourceAttr(resName, "label", objectStorageBucketName),
 						resource.TestCheckResourceAttr(resName, "cluster", testCluster),
 						resource.TestCheckResourceAttr(resName, "lifecycle_rule.#", "1"),
-						resource.TestCheckResourceAttrSet(resName, "access_key"),
-						resource.TestCheckResourceAttrSet(resName, "secret_key"),
 					),
 				},
 			},

--- a/linode/objbucket/schema_resource.go
+++ b/linode/objbucket/schema_resource.go
@@ -8,7 +8,6 @@ var resourceSchema = map[string]*schema.Schema{
 		Description: "The S3 secret key to use for this resource. (Required for lifecycle_rule and versioning). " +
 			"If not specified with the resource, the value will be read from provider-level obj_secret_key.",
 		Optional:  true,
-		Computed:  true,
 		Sensitive: true,
 	},
 	"access_key": {
@@ -16,7 +15,6 @@ var resourceSchema = map[string]*schema.Schema{
 		Description: "The S3 access key to use for this resource. (Required for lifecycle_rule and versioning). " +
 			"If not specified with the resource, the value will be read from provider-level obj_access_key.",
 		Optional: true,
-		Computed: true,
 	},
 	"cluster": {
 		Type:        schema.TypeString,

--- a/linode/objbucket/schema_resource.go
+++ b/linode/objbucket/schema_resource.go
@@ -4,14 +4,18 @@ import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 var resourceSchema = map[string]*schema.Schema{
 	"secret_key": {
-		Type:        schema.TypeString,
-		Description: "The S3 secret key to use for this resource. (Required for lifecycle_rule and versioning)",
-		Optional:    true,
+		Type: schema.TypeString,
+		Description: "The S3 secret key to use for this resource. (Required for lifecycle_rule and versioning). " +
+			"If not specified with the resource, the value will be read from provider-level obj_secret_key.",
+		Optional: true,
+		Computed: true,
 	},
 	"access_key": {
-		Type:        schema.TypeString,
-		Description: "The S3 access key to use for this resource. (Required for lifecycle_rule and versioning)",
-		Optional:    true,
+		Type: schema.TypeString,
+		Description: "The S3 access key to use for this resource. (Required for lifecycle_rule and versioning). " +
+			"If not specified with the resource, the value will be read from provider-level obj_access_key.",
+		Optional: true,
+		Computed: true,
 	},
 	"cluster": {
 		Type:        schema.TypeString,
@@ -43,11 +47,10 @@ var resourceSchema = map[string]*schema.Schema{
 		Default:     true,
 	},
 	"lifecycle_rule": {
-		Type:         schema.TypeList,
-		Description:  "Lifecycle rules to be applied to the bucket.",
-		Optional:     true,
-		RequiredWith: []string{"access_key", "secret_key"},
-		Elem:         resourceLifeCycle(),
+		Type:        schema.TypeList,
+		Description: "Lifecycle rules to be applied to the bucket.",
+		Optional:    true,
+		Elem:        resourceLifeCycle(),
 	},
 	"hostname": {
 		Type: schema.TypeString,
@@ -56,11 +59,10 @@ var resourceSchema = map[string]*schema.Schema{
 		Computed: true,
 	},
 	"versioning": {
-		Type:         schema.TypeBool,
-		Description:  "Whether to enable versioning.",
-		Optional:     true,
-		RequiredWith: []string{"access_key", "secret_key"},
-		Computed:     true,
+		Type:        schema.TypeBool,
+		Description: "Whether to enable versioning.",
+		Optional:    true,
+		Computed:    true,
 	},
 	"cert": {
 		Type:        schema.TypeList,

--- a/linode/objbucket/schema_resource.go
+++ b/linode/objbucket/schema_resource.go
@@ -7,8 +7,9 @@ var resourceSchema = map[string]*schema.Schema{
 		Type: schema.TypeString,
 		Description: "The S3 secret key to use for this resource. (Required for lifecycle_rule and versioning). " +
 			"If not specified with the resource, the value will be read from provider-level obj_secret_key.",
-		Optional: true,
-		Computed: true,
+		Optional:  true,
+		Computed:  true,
+		Sensitive: true,
 	},
 	"access_key": {
 		Type: schema.TypeString,

--- a/linode/objbucket/tmpl/creds_configed.gotf
+++ b/linode/objbucket/tmpl/creds_configed.gotf
@@ -1,0 +1,29 @@
+{{ define "object_bucket_creds_configed" }}
+
+{{ template "object_key_basic" .Key }}
+
+provider "linode" {
+    alias = "creds_configed"
+    obj_access_key = linode_object_storage_key.foobar.access_key
+    obj_secret_key = linode_object_storage_key.foobar.secret_key
+}
+
+resource "linode_object_storage_bucket" "foobar" {
+    provider = linode.creds_configed
+
+    cluster = "{{ .Cluster }}"
+    label = "{{.Label}}"
+
+    lifecycle_rule {
+        prefix = "tf"
+        enabled = true
+
+        abort_incomplete_multipart_upload_days = 5
+
+        expiration {
+            date = "2021-06-21"
+        }
+    }
+}
+
+{{ end }}

--- a/linode/objbucket/tmpl/template.go
+++ b/linode/objbucket/tmpl/template.go
@@ -104,6 +104,15 @@ func ClusterDataBasic(t *testing.T, label, cluster string) string {
 		})
 }
 
+func CredsConfiged(t *testing.T, label, cluster, keyName string) string {
+	return acceptance.ExecuteTemplate(t,
+		"object_bucket_creds_configed", TemplateData{
+			Key:     objkey.TemplateData{Label: keyName},
+			Label:   label,
+			Cluster: cluster,
+		})
+}
+
 func DataBasic(t *testing.T, label, cluster string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_bucket_data_basic", TemplateData{

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -124,6 +124,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The secret key to be used in linode_object_storage_bucket and linode_object_storage_object.",
+				Sensitive:   true,
 			},
 		},
 

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -115,6 +115,16 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "The rate in milliseconds to poll for an LKE node to be ready.",
 			},
+			"obj_access_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The access key to be used in linode_object_storage_bucket and linode_object_storage_object.",
+			},
+			"obj_secret_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The secret key to be used in linode_object_storage_bucket and linode_object_storage_object.",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -218,6 +228,18 @@ func handleDefault(config *helper.Config, d *schema.ResourceData) diag.Diagnosti
 		config.LKENodeReadyPollMilliseconds = v.(int)
 	} else {
 		config.LKENodeReadyPollMilliseconds = 3000
+	}
+
+	if v, ok := d.GetOk("obj_access_key"); ok {
+		config.ObjAccessKey = v.(string)
+	} else {
+		config.ObjAccessKey = os.Getenv("LINODE_OBJ_ACCESS_KEY")
+	}
+
+	if v, ok := d.GetOk("obj_secret_key"); ok {
+		config.ObjSecretKey = v.(string)
+	} else {
+		config.ObjSecretKey = os.Getenv("LINODE_OBJ_SECRET_KEY")
 	}
 
 	return nil

--- a/linode/provider_test.go
+++ b/linode/provider_test.go
@@ -34,7 +34,7 @@ api_version = v4beta
 		SkipInstanceReadyPoll: false,
 		ConfigPath:            file.Name(),
 		ObjAccessKey:          "abcd",
-		ObjSecretKey:          "edfs",
+		ObjSecretKey:          "efgh",
 	}
 
 	client, err := config.Client(context.Background())

--- a/linode/provider_test.go
+++ b/linode/provider_test.go
@@ -33,6 +33,8 @@ api_version = v4beta
 		APIVersion:            "v4beta",
 		SkipInstanceReadyPoll: false,
 		ConfigPath:            file.Name(),
+		ObjAccessKey:          "abcd",
+		ObjSecretKey:          "edfs",
 	}
 
 	client, err := config.Client(context.Background())


### PR DESCRIPTION
## 📝 Description

This change allows user to specify object storage keys at provider-level. The access and secret keys can be used in `linode_object_storage_bucket` and `linode_object_storage_object` resource. We aim to simplify the object key management and avoid issue like circular dependency. The keys then can be specified in the provider configuration, or can be exported as an environment variable. 

Addressed issue #1172.

## ✔️ How to Test

`make int-test PKG_NAME="linode/obj"`
`make int-test PKG_NAME="linode/objbucket"`

**Manual Test:**
1. In a sandbox environment, i.e. dx-devenv, use the following configuration to create an object bucket with lifecycle policy:
```
provider "linode" {
    obj_access_key = ${your-access-key}
    obj_secret_key = ${your-secret-key}
}

resource "linode_object_storage_bucket" "test" {
    cluster = "us-mia-1"
    label = "test-obj-bucket"

    lifecycle_rule {
        prefix = "tf"
        enabled = true

        abort_incomplete_multipart_upload_days = 5

        expiration {
            date = "2024-03-21"
        }
    }
}
```
2. Observe that object bucket is created successfully without any error raised.
3. Destroy the resource to clean up.
4. Test that object credentials by exporting from environment
`export LINODE_OBJ_ACCESS_KEY=$YOUR_ACCESS_KEY`
`export LINODE_OBJ_SECRET_KEY=$YOUR_SECRET_KEY`
5. Put the configuration without provider metadata
```
resource "linode_object_storage_bucket" "test" {
    cluster = "us-mia-1"
    label = "test-obj-bucket"

    lifecycle_rule {
        prefix = "tf"
        enabled = true

        abort_incomplete_multipart_upload_days = 5

        expiration {
            date = "2024-03-21"
        }
    }
}
```
6. Observe that object bucket is created successfully without any error raised.
7. Destroy the resource to clean up.
