### PR TITLE
fix: Check for errors before setting log fields in `linode_object_storage_key`

### DIFF
--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -64,12 +64,6 @@ func (r *Resource) Create(
 		"createOpts": createOpts,
 	})
 	key, err := client.CreateObjectStorageKey(ctx, createOpts)
-
-	ctx = helper.SetLogFieldBulk(ctx, map[string]any{
-		"key_id": key.ID,
-		"label":  key.Label,
-	})
-
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to create Object Storage Key",
@@ -77,6 +71,11 @@ func (r *Resource) Create(
 		)
 		return
 	}
+
+	ctx = helper.SetLogFieldBulk(ctx, map[string]any{
+		"key_id": key.ID,
+		"label":  key.Label,
+	})
 
 	data.FlattenObjectStorageKey(key, true)
 


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that would result in a panic when attempting to provision a `linode_object_storage_key` resource with invalid options. This is because a `helper.SetLogFieldBulk(...)` call was accidentally inserted before the OBJ key creation error check.

Resolves #1334 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make PKG_NAME=linode/objkey int-test
```

### Manual Testing

1. In a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
# ...

resource "linode_object_storage_key" "test" {
  label = "extremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabelextremelylonglabel"
}
```

2. Ensure the provider does not panic and instead a human-readable error is raised.
