### PR TITLE
fix: Check for errors before setting log fields in `linode_nodebalancer_node`, `linode_nodebalancer_config`

### DIFF
--- a/linode/nbconfig/resource.go
+++ b/linode/nbconfig/resource.go
@@ -154,12 +154,12 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	})
 
 	config, err := client.CreateNodeBalancerConfig(ctx, nodebalancerID, createOpts)
-
-	ctx = tflog.SetField(ctx, "config_id", config.ID)
-
 	if err != nil {
 		return diag.Errorf("Error creating a Linode NodeBalancerConfig: %s", err)
 	}
+
+	ctx = tflog.SetField(ctx, "config_id", config.ID)
+
 	d.SetId(fmt.Sprintf("%d", config.ID))
 	d.Set("nodebalancer_id", nodebalancerID)
 

--- a/linode/nbnode/resource.go
+++ b/linode/nbnode/resource.go
@@ -129,12 +129,12 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	})
 
 	node, err := client.CreateNodeBalancerNode(ctx, nodebalancerID, configID, createOpts)
-
-	ctx = tflog.SetField(ctx, "node_id", node.ID)
-
 	if err != nil {
 		return diag.Errorf("Error creating a Linode NodeBalancerNode: %s", err)
 	}
+
+	ctx = tflog.SetField(ctx, "node_id", node.ID)
+
 	d.SetId(fmt.Sprintf("%d", node.ID))
 	d.Set("config_id", configID)
 	d.Set("nodebalancer_id", nodebalancerID)


### PR DESCRIPTION
## 📝 Description

Like PR #1344,  same potential issues exist in `linode_nodebalancer_node`, `linode_nodebalancer_config`. `tflog.SetField(...)` call was inserted before error check.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.
```
make PKG_NAME=linode/nbconfig int-test
make PKG_NAME=linode/nbnode int-test
```