### PR TITLE
fix: Update context when populating log attributes with correct types

### DIFF
--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -471,7 +471,7 @@ func (r *Resource) ImportState(
 
 func populateLogAttributes(ctx context.Context, model ResourceModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"linode_id": model.LinodeID,
-		"disk_id":   model.ID,
+		"linode_id": model.LinodeID.ValueInt64(),
+		"disk_id":   model.ID.ValueString(),
 	})
 }

--- a/linode/instanceip/framework_resource.go
+++ b/linode/instanceip/framework_resource.go
@@ -280,7 +280,7 @@ func (r *Resource) Delete(
 
 func populateLogAttributes(ctx context.Context, data *InstanceIPModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"linode_id": data.LinodeID,
-		"id":        data.ID,
+		"linode_id": data.LinodeID.ValueInt64(),
+		"id":        data.ID.ValueString(),
 	})
 }

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -285,7 +285,7 @@ func (r *Resource) Delete(
 
 func populateLogAttributes(ctx context.Context, model ResourceModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"ipv6_id": model.ID,
-		"range:":  model.Range,
+		"ipv6_id": model.ID.ValueString(),
+		"range:":  model.Range.ValueString(),
 	})
 }

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -264,7 +264,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	populateLogAttributes(ctx, data)
+	ctx = populateLogAttributes(ctx, data)
 	tflog.Debug(ctx, "client.DeleteIPv6Range(...)")
 
 	if err := client.DeleteIPv6Range(ctx, data.ID.ValueString()); err != nil {

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -368,6 +368,6 @@ func upgradeNodebalancerResourceStateV0toV1(
 
 func populateLogAttributes(ctx context.Context, model NodeBalancerModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"nodebalancer_id": model.ID,
+		"nodebalancer_id": model.ID.ValueString(),
 	})
 }

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -51,7 +51,7 @@ func Resource() *schema.Resource {
 func readResource(
 	ctx context.Context, d *schema.ResourceData, meta any,
 ) diag.Diagnostics {
-	populateLogAttributes(ctx, d)
+	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "reading linode_object_storage_bucket")
 	client := meta.(*helper.ProviderMeta).Client
 	config := meta.(*helper.ProviderMeta).Config
@@ -143,7 +143,7 @@ func readResource(
 func createResource(
 	ctx context.Context, d *schema.ResourceData, meta any,
 ) diag.Diagnostics {
-	populateLogAttributes(ctx, d)
+	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "creating linode_object_storage_bucket")
 	client := meta.(*helper.ProviderMeta).Client
 
@@ -174,7 +174,7 @@ func createResource(
 func updateResource(
 	ctx context.Context, d *schema.ResourceData, meta any,
 ) diag.Diagnostics {
-	populateLogAttributes(ctx, d)
+	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "updating linode_object_storage_bucket")
 	client := meta.(*helper.ProviderMeta).Client
 
@@ -227,7 +227,7 @@ func updateResource(
 func deleteResource(
 	ctx context.Context, d *schema.ResourceData, meta any,
 ) diag.Diagnostics {
-	populateLogAttributes(ctx, d)
+	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "deleting linode_object_storage_bucket")
 
 	client := meta.(*helper.ProviderMeta).Client

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -233,6 +233,6 @@ func (r *Resource) Delete(
 
 func populateLogAttributes(ctx context.Context, model ResourceModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"token_id": model.ID,
+		"token_id": model.ID.ValueString(),
 	})
 }

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -258,7 +258,7 @@ func (r *Resource) Delete(
 
 func populateLogAttributes(ctx context.Context, data VPCSubnetModel) context.Context {
 	return helper.SetLogFieldBulk(ctx, map[string]any{
-		"vpc_id": data.VPCId,
-		"id":     data.ID,
+		"vpc_id": data.VPCId.ValueInt64(),
+		"id":     data.ID.ValueString(),
 	})
 }


### PR DESCRIPTION
## 📝 Description

Some of our code is missing updating the context when populating log attributes. Update `ctx` variable for these.

Also fix the type issue in `populateLogAttribute` in several resources.

## ✔️ How to Test

1. Enable trace logging for the Linode provider:
```
export TF_LOG=TRACE
export TF_LOG_PROVIDER_LINODE=TRACE
```

2. In a sandbox environment, i.e. dx-devenv, run the following configuration to create a objbucket:
```
resource "linode_object_storage_bucket" "test" {
    cluster = "us-mia-1"
    label = "test-obj-bucket"
}
```

3. Make sure that log attributes (`bucket`, `cluster`) are populated correctly. Destroy the resource for clean up.

4. Run the configuration to create a ipv6range:
```
resource "linode_instance" "foobar" {
  label = "my-linode"
  image = "linode/alpine3.19"
  type = "g6-nanode-1"
  region = "us-southeast"
}

resource "linode_ipv6_range" "foobar" {
  linode_id = linode_instance.foobar.id

  prefix_length = 64
}
```
5. Destroy the resource, and make sure that log attributes (`ipv6_id`, `range`) for deleting it are populated correctly. 