### PR TITLE
doc: Improve documentation around managing external LKE node pools; add migration guide metadata

### DIFF
--- a/docs/guides/migrate_to_instance_config_and_disk_resources.md
+++ b/docs/guides/migrate_to_instance_config_and_disk_resources.md
@@ -1,3 +1,9 @@
+---
+page_title: "Linode: Migrating Away From Nested Configs and Disks"
+description: |-
+  Outlines the process of migrating an existing Terraform configuration away from nested Instance configs and disks.
+---
+
 # How to Migrate Embedded Attributes to Terraform-Managed Resources
 
 In this guide, we demonstrate how to migrate the `config` and `disk`

--- a/docs/resources/lke_cluster.md
+++ b/docs/resources/lke_cluster.md
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) An array of tags applied to the Kubernetes cluster. Tags are case-insensitive and are for organizational purposes only.
 
-* `external_pool_tags` - (Optional) An array of tags indicating that node pools having those tags are defined with a separate `linode_lke_node_pool` resource, rather than inside the current cluster resource.
+* `external_pool_tags` - (Optional) A set of node pool tags to ignore when planning and applying this cluster. This prevents externally managed node pools from being deleted or unintentionally updated on subsequent applies. See [Externally Managed Node Pools](#externally-managed-node-pools) for more details.
 
 ### pool
 
@@ -193,3 +193,45 @@ In this case, the first node pool from the original configuration will be update
 the second node pool's configuration.
 
 Although not ideal, this functionality guarantees that updates to nested node pools will be reliable and predictable.
+
+## Externally Managed Node Pools
+
+By default, the `linode_lke_cluster` resource will account for all node pools under the corresponding cluster, meaning
+any node pools created externally or managed by other resources will be removed on subsequent applies.
+
+To signal the provider to ignore externally managed node pools, the `external_pool_tags` attribute can be defined with
+tags matching a tag on an externally managed node pool.
+
+For example:
+
+```terraform
+locals {
+  external_pool_tag = "external"
+}
+
+resource "linode_lke_cluster" "my-cluster" {
+    label       = "my-cluster"
+    k8s_version = "1.28"
+    region      = "us-mia"
+    
+    # This tells the Linode provider to ignore 
+    # node pools with the tag `external`, preventing
+    # externally managed node pools from being deleted.
+    external_pool_tags = [local.external_pool_tag]
+    
+    # Due to Terraform/LkE limitations, the cluster must be
+    # defined with at least one node pool.
+    pool {
+        type  = "g6-standard-1"
+        count = 1
+    }
+}
+
+resource "linode_lke_node_pool" "my-pool" {
+  cluster_id  = linode_lke_cluster.my-cluster.id
+  type        = "g6-standard-2"
+  node_count  = 3
+
+  tags = [local.external_pool_tag]
+}
+```

--- a/docs/resources/lke_cluster.md
+++ b/docs/resources/lke_cluster.md
@@ -219,8 +219,8 @@ resource "linode_lke_cluster" "my-cluster" {
     # externally managed node pools from being deleted.
     external_pool_tags = [local.external_pool_tag]
     
-    # Due to Terraform/LkE limitations, the cluster must be
-    # defined with at least one node pool.
+    # Due to certain restrictions in Terraform and LKE, 
+    # the cluster must be defined with at least one node pool.
     pool {
         type  = "g6-standard-1"
         count = 1

--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `node_count` - (Required; Optional with `autoscaler`) The number of nodes in the Node Pool. If undefined with an autoscaler the initial node count will equal the autoscaler minimum.
 
-* `tags` - (Optional) An array of tags applied to the Node Pool. Tags can be used to flag node pools as externally managed, see [Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools).
+* `tags` - (Optional) An array of tags applied to the Node Pool. Tags can be used to flag node pools as externally managed, see [Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools) for more details.
 
 * [`autoscaler`](#autoscaler) - (Optional) If defined, an autoscaler will be enabled with the given configuration.
 

--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -58,9 +58,9 @@ resource "linode_lke_cluster" "my-cluster" {
     # node pools with the tag `external`, preventing
     # externally managed node pools from being deleted.
     external_pool_tags = [local.external_pool_tag]
-    
-    # Due to Terraform/LkE limitations, the cluster must be
-    # defined with at least one node pool.
+
+  # Due to certain restrictions in Terraform and LKE, 
+  # the cluster must be defined with at least one node pool.
     pool {
         type  = "g6-standard-1"
         count = 1
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `node_count` - (Required; Optional with `autoscaler`) The number of nodes in the Node Pool. If undefined with an autoscaler the initial node count will equal the autoscaler minimum.
 
-* `tags` - (Optional) An array of tags applied to the Node Pool. Tags are for organizational purposes only.
+* `tags` - (Optional) An array of tags applied to the Node Pool. Tags can be used to flag node pools as externally managed, see [Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools).
 
 * [`autoscaler`](#autoscaler) - (Optional) If defined, an autoscaler will be enabled with the given configuration.
 

--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -1,10 +1,10 @@
 ---
 page_title: "Linode: linode_lke_node_pool"
 description: |-
-  Manages a Linode Node Pool.
+  Manages an LKE Node Pool.
 ---
 
-# linode\_nodepool
+# linode\_lke\_node\_pool
 
 Manages an LKE Node Pool.
 
@@ -14,11 +14,9 @@ Creating a basic LKE Node Pool:
 
 ```terraform
 resource "linode_lke_node_pool" "my-pool" {
-  
     cluster_id  = 150003
     type  = "g6-standard-2"
     node_count = 3
-  
 }
 ```
 
@@ -26,7 +24,6 @@ Creating an LKE Node Pool with autoscaler:
 
 ```terraform
 resource "linode_lke_node_pool" "my-pool" {
-
     cluster_id  = 150003
     type  = "g6-standard-2"
   
@@ -37,13 +34,47 @@ resource "linode_lke_node_pool" "my-pool" {
 }
 ```
 
+Creating an LKE Node Pool for a Terraform-managed LKE cluster:
+
+```terraform
+locals {
+  external_pool_tag = "external"
+}
+
+resource "linode_lke_node_pool" "my-pool" {
+    cluster_id  = linode_lke_cluster.my-cluster.id
+    type        = "g6-standard-2"
+    node_count  = 3
+  
+    tags = [local.external_pool_tag]
+}
+
+resource "linode_lke_cluster" "my-cluster" {
+    label       = "my-cluster"
+    k8s_version = "1.28"
+    region      = "us-mia"
+    
+    # This tells the Linode provider to ignore 
+    # node pools with the tag `external`, preventing
+    # externally managed node pools from being deleted.
+    external_pool_tags = [local.external_pool_tag]
+    
+    # Due to Terraform/LkE limitations, the cluster must be
+    # defined with at least one node pool.
+    pool {
+        type  = "g6-standard-1"
+        count = 1
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `cluster_id` - ID of the LKE Cluster where to create the current Node Pool.
 
-* `type` - (Required) A Linode Type for all of the nodes in the Node Pool. See all node types [here](https://api.linode.com/v4/linode/types).
+* `type` - (Required) A Linode Type for all nodes in the Node Pool. See all node types [here](https://api.linode.com/v4/linode/types).
 
 * `node_count` - (Required; Optional with `autoscaler`) The number of nodes in the Node Pool. If undefined with an autoscaler the initial node count will equal the autoscaler minimum.
 


### PR DESCRIPTION
## 📝 Description

This change makes various improvements to the `linode_lke_cluster` and `linode_lke_node_pool` documentation to fix inconsistencies and to clarify the process for creating externally managed node pools.

Additionally, this PR adds metadata to the `How to Migrate Embedded Attributes to Terraform-Managed Resources` guide to make it display properly on the Terraform registry.

## ✔️ How to Test

N/A