### PR TITLE
new: Allow importing linode_user; use ID in CRUD operations

### DIFF
--- a/linode/user/resource.go
+++ b/linode/user/resource.go
@@ -117,7 +117,8 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	client := meta.(*helper.ProviderMeta).Client
 
-	username := d.Id()
+	id := d.Id()
+	username := d.Get("username").(string)
 	restricted := d.Get("restricted").(bool)
 
 	updateOpts := linodego.UserUpdateOptions{
@@ -129,8 +130,8 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 		"options": updateOpts,
 	})
 
-	if _, err := client.UpdateUser(ctx, username, updateOpts); err != nil {
-		return diag.Errorf("failed to update user (%s): %s", username, err)
+	if _, err := client.UpdateUser(ctx, id, updateOpts); err != nil {
+		return diag.Errorf("failed to update user (%s): %s", id, err)
 	}
 
 	d.SetId(username)

--- a/linode/user/resource_test.go
+++ b/linode/user/resource_test.go
@@ -38,6 +38,11 @@ func TestAccResourceUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testUserResName, "tfa_enabled", "false"),
 				),
 			},
+			{
+				ResourceName:      testUserResName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -72,6 +77,11 @@ func TestAccResourceUser_updates(t *testing.T) {
 					resource.TestCheckResourceAttr(testUserResName, "ssh_keys.#", "0"),
 					resource.TestCheckResourceAttr(testUserResName, "tfa_enabled", "false"),
 				),
+			},
+			{
+				ResourceName:      testUserResName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -125,6 +135,11 @@ func TestAccResourceUser_grants(t *testing.T) {
 					resource.TestCheckResourceAttr(testUserResName, "linode_grant.#", "1"),
 					resource.TestCheckResourceAttr(testUserResName, "linode_grant.0.permissions", "read_write"),
 				),
+			},
+			{
+				ResourceName:      testUserResName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
## 📝 Description

This change adds support for importing instances of `linode_user` by username. Additionally this PR updates the `linode_user` CRUD functions to consume the resource ID rather than the `username` attribute, which is necessary for import state passthrough to work as expected.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Tests

```
make PKG_NAME=linode/user int-test
```

### Manual Testing

1. In a Terraform provider sandbox environment (e.g. dx-devenv), apply the following:

```terraform
# ...

resource "random_string" "random" {
  length = 10
  special = false
}

resource "linode_user" "test" {
  username = "tf-test-${random_string.random.result}"
  email = "tf-test-${random_string.random.result}@linode.com"
}
```

2. Ensure the apply succeeds as expected.
3. Open your `terraform.tfstate` file and take note of the user's ID attribute. 
4. In `terraform.tfstate`, drop the instance of the `linode_user` resource so the `linode_user` block looks something like this:

```json
    {
      "mode": "managed",
      "type": "linode_user",
      "name": "test",
      "provider": "provider[\"registry.terraform.io/linode/linode\"]",
      "instances": []
    }
```

5. Attempt to plan the configuration and ensure it wants to create a new user.
6. Run `terraform import linode_user.test {id}` where `{id}` is replaced with the ID you took note of in step 3.
7. Re-plan the configuration and ensure no changes are proposed.