### PR TITLE
Add notice for externally managed node pools

### DIFF
--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -6,13 +6,11 @@ description: |-
 
 # linode\_lke\_node\_pool
 
-~> **Notice** To prevent the node pools created by the `linode_lke_node_pool` resource
-from being managed by the `linode_lke_cluster` resource, you must configure the
-`external_pool_tags` attribute of the `linode_lke_cluster` resource and the `tags`
-attribute of the `linode_lke_node_pool` resource. Failure to configure these attributes
-may lead to recreation of the node pools in order to fix them. Please carefully review
-[Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools) before
-proceeding to create `linode_lke_node_pool` resources with a `linode_lke_cluster` resource.
+~> **Notice** To prevent LKE node pools managed by this resource from being
+recreated by the linode_lke_cluster resource, the cluster's external_pool_tags
+ attribute must match the tags attribute of this resource. Please review the
+[Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools)
+section for more information.
 
 Manages an LKE Node Pool.
 

--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -6,6 +6,14 @@ description: |-
 
 # linode\_lke\_node\_pool
 
+~> **Notice** To prevent the node pools created by the `linode_lke_node_pool` resource
+from being managed by the `linode_lke_cluster` resource, you must configure the
+`external_pool_tags` attribute of the `linode_lke_cluster` resource and the `tags`
+attribute of the `linode_lke_node_pool` resource. Failure to configure these attributes
+may lead to recreation of the node pools in order to fix them. Please carefully review
+[Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools) before
+proceeding to create `linode_lke_node_pool` resources with a `linode_lke_cluster` resource.
+
 Manages an LKE Node Pool.
 
 ## Example Usage


### PR DESCRIPTION
## 📝 Description

Add a clear notice for the requirement of configuring `external_pool_tags` in a cluster resource and `tags` in a node pool resource for externally managed node pools.