### PR TITLE
ci: add back keep and stale labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,3 +36,9 @@
 - name: bug
   description: issues that report a bug
   color: ed8e21
+- name: keep
+  description: prevent github from closing issue
+  color: 9c5186
+- name: stale
+  description: github will close this issue soon
+  color: ab4f5c


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Initial PR removed keep and stale labels, this adds them back.
