### PR TITLE
Fix State Upgrader of NodeBalancer Resource

### DIFF
--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -319,6 +319,7 @@ func upgradeNodebalancerResourceStateV0toV1(
 		Created:            timetypes.RFC3339{StringValue: nbDataV0.Created},
 		Updated:            timetypes.RFC3339{StringValue: nbDataV0.Updated},
 		Tags:               nbDataV0.Tags,
+		Firewalls:          types.ListNull(firewallObjType),
 	}
 
 	var transferMap map[string]string

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -94,7 +94,7 @@ func (r *Resource) Create(
 	firewalls, err := client.ListNodeBalancerFirewalls(ctx, nodebalancer.ID, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to list firewalls assgiend to nodebalancer %d", nodebalancer.ID),
+			fmt.Sprintf("Failed to list firewalls assigned to NodeBalancer %d", nodebalancer.ID),
 			err.Error(),
 		)
 	}
@@ -142,16 +142,17 @@ func (r *Resource) Read(
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			resp.Diagnostics.AddWarning(
-				"Nodebalancer",
-				fmt.Sprintf("removing Linode NodeBalancer ID %v from state because it no longer exists", id),
+				"NodeBalancer No Longer Exists",
+				fmt.Sprintf("Removing Linode NodeBalancer ID %v from state because it no longer exists", id),
 			)
 			resp.State.RemoveResource(ctx)
 			return
 		}
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to get nodebalancer %v", id),
+			fmt.Sprintf("Failed to Get NodeBalancer %v", id),
 			err.Error(),
 		)
+		return
 	}
 
 	tflog.Trace(ctx, "client.ListNodeBalancerFirewalls(...)")
@@ -159,7 +160,7 @@ func (r *Resource) Read(
 	firewalls, err := client.ListNodeBalancerFirewalls(ctx, id, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to list firewalls assgiend to nodebalancer %d", id),
+			fmt.Sprintf("Failed to list firewalls assigned to NodeBalancer %d", id),
 			err.Error(),
 		)
 	}
@@ -224,7 +225,7 @@ func (r *Resource) Update(
 		nodeBalancer, err := client.UpdateNodeBalancer(ctx, id, updateOpts)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to update Nodebalancer %v", id),
+				fmt.Sprintf("Failed to Update NodeBalancer %v", id),
 				err.Error(),
 			)
 			return
@@ -235,7 +236,7 @@ func (r *Resource) Update(
 		firewalls, err := client.ListNodeBalancerFirewalls(ctx, id, nil)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to list firewalls assgiend to nodebalancer %d", id),
+				fmt.Sprintf("Failed to list firewalls assigned to NodeBalancer %d", id),
 				err.Error(),
 			)
 		}
@@ -273,14 +274,14 @@ func (r *Resource) Delete(
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
 			resp.Diagnostics.AddWarning(
-				"Nodebalancer does not exist.",
-				fmt.Sprintf("Nodebalancer %v does not exist, removing from state.", id),
+				"NodeBalancer No Longer Exists",
+				fmt.Sprintf("NodeBalancer %v does not exist, removing it from state.", id),
 			)
 			resp.State.RemoveResource(ctx)
 			return
 		}
 		resp.Diagnostics.AddError(
-			"Failed to delete Nodebalancer",
+			"Failed to Delete NodeBalancer",
 			err.Error(),
 		)
 		return


### PR DESCRIPTION
## 📝 Description

The state upgrader was broken by the introduction of `firewall` attribute. Fixing it up in this PR.

Error messages of NodeBalancer resource are also improved a little bit in this PR.

## ✔️ How to Test

### Automated Testing

```bash
make PKG_NAME="linode/nb" unit-test
```

```bash
make PKG_NAME="linode/nb" int-test
```

### Manual Testing

- Create a NodeBalancer with Linode provider `v1.13.4`, which uses the v0 schema of the NodeBalancer resource.
  - Note that Linode provider `v1.13.4` doesn't support Mac in ARM architecture, so you may have to test it in a Linode if your computer is a Mac with a M series chip. 
  - Also note that you will have to delete `~/.terraformrc` file in order to remove provider override for using a provider (e.g. Linode provider `v1.13.4`) downloaded from the Terraform registry.
    - Make sure you back it up so you can bring it back later for testing the provider in dev mode.
    - Reference: https://developer.hashicorp.com/terraform/plugin/debugging#terraform-cli-development-overrides
  - `terraform init --upgrade` command can help you to switch or fix the provider version.

```terraform
terraform {
  required_providers {
    linode = {
      source = "linode/linode"
      version = "1.13.4"
    }
  }
}
provider "linode" {
}

resource "linode_nodebalancer" "foobar" {
    label = "mynodebalancer"
    region = "us-mia"
    client_conn_throttle = 20
}
```

- Verify the failure on the latest Linode provider (dev branch) by doing `terraform refresh`
  - Don't forget bringing back `~/.terraformrc` when trying to use the provider from the `dev` branch or this feature branch.
```
╷
│ Error: Value Conversion Error
│ 
│   with linode_nodebalancer.foobar,
│   on main.tf line 11, in resource "linode_nodebalancer" "foobar":
│   11: resource "linode_nodebalancer" "foobar" {
│ 
│ An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or
│ panics. This is always an error in the provider. Please report the following to the provider developer:
│ 
│ Expected framework type from provider logic: types.ListType[types.ObjectType["created":basetypes.StringType,
│ "id":basetypes.Int64Type, "inbound":types.ListType[types.ObjectType["action":basetypes.StringType,
│ "ipv4":types.ListType[basetypes.StringType], "ipv6":types.ListType[basetypes.StringType], "label":basetypes.StringType,
│ "ports":basetypes.StringType, "protocol":basetypes.StringType]], "inbound_policy":basetypes.StringType,
│ "label":basetypes.StringType, "outbound":types.ListType[types.ObjectType["action":basetypes.StringType,
│ "ipv4":types.ListType[basetypes.StringType], "ipv6":types.ListType[basetypes.StringType], "label":basetypes.StringType,
│ "ports":basetypes.StringType, "protocol":basetypes.StringType]], "outbound_policy":basetypes.StringType,
│ "status":basetypes.StringType, "tags":types.SetType[basetypes.StringType], "updated":basetypes.StringType]] / underlying type:
│ tftypes.List[tftypes.Object["created":tftypes.String, "id":tftypes.Number,
│ "inbound":tftypes.List[tftypes.Object["action":tftypes.String, "ipv4":tftypes.List[tftypes.String],
│ "ipv6":tftypes.List[tftypes.String], "label":tftypes.String, "ports":tftypes.String, "protocol":tftypes.String]],
│ "inbound_policy":tftypes.String, "label":tftypes.String, "outbound":tftypes.List[tftypes.Object["action":tftypes.String,
│ "ipv4":tftypes.List[tftypes.String], "ipv6":tftypes.List[tftypes.String], "label":tftypes.String, "ports":tftypes.String,
│ "protocol":tftypes.String]], "outbound_policy":tftypes.String, "status":tftypes.String, "tags":tftypes.Set[tftypes.String],
│ "updated":tftypes.String]]
│ Received framework type from provider logic: types.ListType[!!! MISSING TYPE !!!] / underlying type:
│ tftypes.List[tftypes.DynamicPseudoType]
│ Path: firewalls
╵
```
- Verify that the error is gone with provider in this branch.
