### PR TITLE
Fix Sent to Closed Channel Panic in `helper.RunBatch`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.22.0
 	golang.org/x/net v0.24.0
+	golang.org/x/sync v0.6.0
 )
 
 require (

--- a/linode/helper/batch.go
+++ b/linode/helper/batch.go
@@ -35,7 +35,7 @@ func RunBatch(toExecute ...BatchFunction) error {
 		close(errCh)
 	}()
 
-	allErrors := []error{}
+	allErrors := make([]error, 0)
 
 	for {
 		select {

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -90,7 +90,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	)
 	if err != nil {
 		// We can assume a 404 from any of these endpoints implies a deleted instance
-		if linodego.ErrHasStatus(err, 404) {
+		if linodego.IsNotFound(err) {
 			tflog.Warn(ctx, "removing Linode Instance ID %q from state because it no longer exists")
 			d.SetId("")
 			return nil

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -58,29 +58,29 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	var instanceDisks []linodego.InstanceDisk
 	var instanceConfigs []linodego.InstanceConfig
 
-	err = helper.RunBatch(
-		func() (err error) {
+	err = helper.RunBatch(ctx,
+		func(ctx context.Context) (err error) {
 			instance, err = client.GetInstance(ctx, id)
 			if err != nil {
 				err = fmt.Errorf("failed to get instance: %w", err)
 			}
 			return
 		},
-		func() (err error) {
+		func(ctx context.Context) (err error) {
 			instanceNetwork, err = client.GetInstanceIPAddresses(ctx, id)
 			if err != nil {
 				err = fmt.Errorf("failed to get instance networking: %w", err)
 			}
 			return
 		},
-		func() (err error) {
+		func(ctx context.Context) (err error) {
 			instanceDisks, err = client.ListInstanceDisks(ctx, id, nil)
 			if err != nil {
 				err = fmt.Errorf("failed to get instance disks: %w", err)
 			}
 			return
 		},
-		func() (err error) {
+		func(ctx context.Context) (err error) {
 			instanceConfigs, err = client.ListInstanceConfigs(ctx, id, nil)
 			if err != nil {
 				err = fmt.Errorf("failed to get instance configs: %w", err)

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -68,7 +68,7 @@ func TestAccResourceInstance_basic_smoke(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(16)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },

--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -3,7 +3,6 @@ package instanceconfig
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -105,7 +104,9 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	)
 	if err != nil {
 		if linodego.IsNotFound(err) {
-			log.Printf("[WARN] removing Instance Config ID %q from state because it no longer exists", d.Id())
+			tflog.Warn(ctx, fmt.Sprintf(
+				"removing Instance Config ID %q from state because it no longer exists", d.Id(),
+			))
 			d.SetId("")
 			return nil
 		}

--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -104,7 +104,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		},
 	)
 	if err != nil {
-		if linodego.ErrHasStatus(err, 404) {
+		if linodego.IsNotFound(err) {
 			log.Printf("[WARN] removing Instance Config ID %q from state because it no longer exists", d.Id())
 			d.SetId("")
 			return nil

--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -77,8 +77,8 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	var inst *linodego.Instance
 	var instNetworking *linodego.InstanceIPAddressResponse
 
-	err = helper.RunBatch(
-		func() (err error) {
+	err = helper.RunBatch(ctx,
+		func(ctx context.Context) (err error) {
 			cfg, err = client.GetInstanceConfig(ctx, linodeID, id)
 			if err != nil {
 				err = fmt.Errorf("failed to get instance config: %w", err)
@@ -86,14 +86,14 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 
 			return
 		},
-		func() (err error) {
+		func(ctx context.Context) (err error) {
 			inst, err = client.GetInstance(ctx, linodeID)
 			if err != nil {
 				err = fmt.Errorf("failed to get instance: %w", err)
 			}
 			return
 		},
-		func() (err error) {
+		func(ctx context.Context) (err error) {
 			// We want to guarantee that we're resolving a public IPv4 address
 			instNetworking, err = client.GetInstanceIPAddresses(ctx, linodeID)
 			if err != nil {


### PR DESCRIPTION
## 📝 Description

~~This is to fix an issue that errors can be sent to a closed channel in `helper.RunBatch` function.~~

Instead of fixing existing code, the better solution is to migrate to `sync/errgroup`. Thanks @lgarber-akamai for the idea!

Other MISC changes bundled:
- Migrate `log` to `tflog` in `instanceconfig` package.
- Change `ErrHasStatus(err, 404)` to `IsNotFound(err)`
- ~~Joining all errors in via `errors.Join`~~ No longer needed after migrating to `sync/errgroup`

## ✔️ How to Test

### Automated Testing

```
make int-test PKG_NAME=linode/instance
make int-test PKG_NAME=linode/instanceconfig
```

### Manual Testing

```terraform
resource "linode_instance_config" "my-config" {
  linode_id = linode_instance.my-instance.id
  label = "my-config"

  device {
    device_name = "sda"
    disk_id = linode_instance_disk.boot.id
  }

  booted = true
}

resource "linode_instance_disk" "boot" {
  label = "boot"
  linode_id = linode_instance.my-instance.id
  size = linode_instance.my-instance.specs.0.disk

  image = "linode/ubuntu22.04"
  root_pass = "myc00lpa$$w0rd!!!!!!"
}

resource "linode_instance" "my-instance" {
  label = "my-instance"
  type = "g6-nanode-1"
  region = "us-mia"
}
```

2. Remove the Linode instance on Cloud Manager to force a 404 error returned from API to the Terraform Provider.
3. `terrafrom refresh`
4. Observe no panic (i.e. no provider crash error).