### PR TITLE
Fix `kernels` integration test with updated filter

### DIFF
--- a/linode/kernels/datasource_test.go
+++ b/linode/kernels/datasource_test.go
@@ -42,10 +42,8 @@ func TestAccDataSourceKernels_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kernels.0.architecture", "x86_64"),
 					resource.TestCheckResourceAttr(resourceName, "kernels.0.deprecated", "false"),
 					resource.TestCheckResourceAttr(resourceName, "kernels.0.kvm", "true"),
-					resource.TestCheckResourceAttr(resourceName, "kernels.0.label", "Latest 64 bit (6.2.9-x86_64-linode160)"),
 					resource.TestCheckResourceAttr(resourceName, "kernels.0.pvops", "true"),
-					resource.TestCheckResourceAttr(resourceName, "kernels.0.version", "6.2.9"),
-					resource.TestCheckResourceAttr(resourceName, "kernels.0.xen", "false"),
+					acceptance.CheckResourceAttrContains(resourceName, "kernels.0.label", "Latest 64 bit"),
 				),
 			},
 			{

--- a/linode/kernels/tmpl/data_filter.gotf
+++ b/linode/kernels/tmpl/data_filter.gotf
@@ -25,7 +25,8 @@ data "linode_kernels" "kernels" {
     
     filter {
         name = "label"
-        values = ["Latest 64 bit (6.2.9-x86_64-linode160)"]
+        values = ["Latest 64 bit"]
+        match_by="substring"
     }
 
     filter {
@@ -33,15 +34,6 @@ data "linode_kernels" "kernels" {
         values = [true]
     }
 
-    filter {
-        name = "version"
-        values = ["6.2.9"]
-    }
-
-    filter {
-        name = "xen"
-        values = ["false"]
-    }
 }
 
 {{ end }}


### PR DESCRIPTION
## 📝 Description

The kernels test was failing because of outdated filter. Updated the filter content and removed some filters to reduce the chance of failures due to updated information from API response.

## ✔️ How to Test

`make int-test PKG_NAME=linode/kernels`
