### PR TITLE
Include resource and data source name as a comment in user-agent

### DIFF
--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -671,7 +671,7 @@ func GetTestClient() (*linodego.Client, error) {
 		APIURL:      os.Getenv("LINODE_URL"),
 	}
 
-	client, err := config.Client(context.Background())
+	client, err := config.Client(context.Background(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/linode/account/framework_datasource.go
+++ b/linode/account/framework_datasource.go
@@ -63,7 +63,7 @@ func (d *DataSource) Read(
 	resp *datasource.ReadResponse,
 ) {
 	tflog.Debug(ctx, "Read data.linode_account")
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/accountavailabilities/framework_datasource.go
+++ b/linode/accountavailabilities/framework_datasource.go
@@ -33,7 +33,7 @@ func (r *DataSource) Read(
 	tflog.Debug(ctx, "Read data.linode_account_availabilities")
 	var data AccountAvailabilityFilterModel
 
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/accountavailability/framework_datasource.go
+++ b/linode/accountavailability/framework_datasource.go
@@ -31,7 +31,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_account_availability")
 	var data AccountAvailabilityModel
-	client := d.Meta.Client
+	client := d.Client
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/accountlogin/framework_datasource.go
+++ b/linode/accountlogin/framework_datasource.go
@@ -13,11 +13,18 @@ import (
 )
 
 func NewDataSource() datasource.DataSource {
-	return &DataSource{}
+	return &DataSource{
+		BaseDataSource: helper.NewBaseDataSource(
+			helper.BaseDataSourceConfig{
+				Name:   "linode_account_login",
+				Schema: &frameworkDataSourceSchema,
+			},
+		),
+	}
 }
 
 type DataSource struct {
-	client *linodego.Client
+	helper.BaseDataSource
 }
 
 func (data *DatasourceModel) parseAccountLogin(accountLogin *linodego.Login) {
@@ -29,24 +36,6 @@ func (data *DatasourceModel) parseAccountLogin(accountLogin *linodego.Login) {
 	data.Status = types.StringValue(accountLogin.Status)
 }
 
-func (d *DataSource) Configure(
-	ctx context.Context,
-	req datasource.ConfigureRequest,
-	resp *datasource.ConfigureResponse,
-) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	meta := helper.GetDataSourceMeta(req, resp)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	d.client = meta.Client
-}
-
 type DatasourceModel struct {
 	Datetime   types.String `tfsdk:"datetime"`
 	ID         types.Int64  `tfsdk:"id"`
@@ -54,14 +43,6 @@ type DatasourceModel struct {
 	Restricted types.Bool   `tfsdk:"restricted"`
 	Username   types.String `tfsdk:"username"`
 	Status     types.String `tfsdk:"status"`
-}
-
-func (d *DataSource) Metadata(
-	ctx context.Context,
-	req datasource.MetadataRequest,
-	resp *datasource.MetadataResponse,
-) {
-	resp.TypeName = "linode_account_login"
 }
 
 func (d *DataSource) Schema(
@@ -78,7 +59,7 @@ func (d *DataSource) Read(
 	resp *datasource.ReadResponse,
 ) {
 	tflog.Debug(ctx, "Read data.linode_account_login")
-	client := d.client
+	client := d.Client
 
 	var data DatasourceModel
 

--- a/linode/accountlogins/framework_datasource.go
+++ b/linode/accountlogins/framework_datasource.go
@@ -33,7 +33,7 @@ func (r *DataSource) Read(
 	tflog.Debug(ctx, "Read data.linode_account_logins")
 	var data AccountLoginFilterModel
 
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/accountsettings/framework_datasource.go
+++ b/linode/accountsettings/framework_datasource.go
@@ -31,7 +31,7 @@ func (r *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_account_settings")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data AccountSettingsModel
 

--- a/linode/accountsettings/framework_resource.go
+++ b/linode/accountsettings/framework_resource.go
@@ -61,7 +61,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read linode_account_settings")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data AccountSettingsModel
 
@@ -144,7 +144,7 @@ func (r *Resource) updateAccountSettings(
 	ctx context.Context,
 	plan *AccountSettingsModel,
 ) diag.Diagnostics {
-	client := r.Meta.Client
+	client := r.Client
 	var diagnostics diag.Diagnostics
 
 	// Longview Plan update functionality has been moved

--- a/linode/backup/framework_datasource.go
+++ b/linode/backup/framework_datasource.go
@@ -32,7 +32,7 @@ func (d *DataSource) Read(
 	tflog.Debug(ctx, "Read data.linode_instance_backups")
 
 	var data DataSourceModel
-	client := d.Meta.Client
+	client := d.Client
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/databaseaccesscontrols/resource.go
+++ b/linode/databaseaccesscontrols/resource.go
@@ -14,6 +14,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
+const resourceUserAgentComment = "linode_database_access_controls resource"
+
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		Schema:        resourceSchema,
@@ -28,7 +30,7 @@ func Resource() *schema.Resource {
 }
 
 func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	dbID, dbType, err := parseID(d.Id())
 	if err != nil {
@@ -63,7 +65,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	dbID, dbType, err := parseID(d.Id())
 	if err != nil {
@@ -82,7 +84,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	dbID, dbType, err := parseID(d.Id())
 	if err != nil {

--- a/linode/databaseaccesscontrols/resource.go
+++ b/linode/databaseaccesscontrols/resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
-const resourceUserAgentComment = "linode_database_access_controls resource"
+const resourceUserAgentComment = "linode_database_access_controls"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{

--- a/linode/databasebackups/framework_datasource.go
+++ b/linode/databasebackups/framework_datasource.go
@@ -57,7 +57,7 @@ func (r *DataSource) Read(
 		}
 
 		result, d := filterConfig.GetAndFilter(
-			ctx, r.Meta.Client, data.Filters, listMySQLBackups, data.Order, data.OrderBy)
+			ctx, r.Client, data.Filters, listMySQLBackups, data.Order, data.OrderBy)
 		if d != nil {
 			resp.Diagnostics.Append(d)
 			return
@@ -86,7 +86,7 @@ func (r *DataSource) Read(
 		}
 
 		result, d := filterConfig.GetAndFilter(
-			ctx, r.Meta.Client, data.Filters, listPostgresSQLBackups, data.Order, data.OrderBy)
+			ctx, r.Client, data.Filters, listPostgresSQLBackups, data.Order, data.OrderBy)
 		if d != nil {
 			resp.Diagnostics.Append(d)
 			return

--- a/linode/databaseengines/framework_datasource.go
+++ b/linode/databaseengines/framework_datasource.go
@@ -43,7 +43,7 @@ func (r *DataSource) Read(
 	data.ID = id
 
 	result, d := filterConfig.GetAndFilter(
-		ctx, r.Meta.Client, data.Filters, listEngines, data.Order, data.OrderBy)
+		ctx, r.Client, data.Filters, listEngines, data.Order, data.OrderBy)
 	if d != nil {
 		resp.Diagnostics.Append(d)
 		return

--- a/linode/databasemysql/framework_datasource.go
+++ b/linode/databasemysql/framework_datasource.go
@@ -27,7 +27,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/databasemysql/resource.go
+++ b/linode/databasemysql/resource.go
@@ -19,6 +19,8 @@ const (
 	createDBTimeout = 90 * time.Minute
 	updateDBTimeout = 5 * time.Minute
 	deleteDBTimeout = 5 * time.Minute
+
+	resourceUserAgentComment = "linode_database_access_controls resource"
 )
 
 func Resource() *schema.Resource {
@@ -40,7 +42,7 @@ func Resource() *schema.Resource {
 }
 
 func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode MySQL database ID %s as int: %s", d.Id(), err)
@@ -92,7 +94,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	p, err := client.NewEventPollerWithoutEntity(linodego.EntityDatabase, linodego.ActionDatabaseCreate)
 	if err != nil {
@@ -170,7 +172,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -237,7 +239,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode MySQL database ID %s as int: %s", d.Id(), err)

--- a/linode/databasemysql/resource.go
+++ b/linode/databasemysql/resource.go
@@ -20,7 +20,7 @@ const (
 	updateDBTimeout = 5 * time.Minute
 	deleteDBTimeout = 5 * time.Minute
 
-	resourceUserAgentComment = "linode_database_access_controls resource"
+	resourceUserAgentComment = "linode_database_access_controls"
 )
 
 func Resource() *schema.Resource {

--- a/linode/databasemysqlbackups/datasource.go
+++ b/linode/databasemysqlbackups/datasource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
 func DataSource() *schema.Resource {
@@ -17,7 +18,10 @@ func DataSource() *schema.Resource {
 }
 
 func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	results, err := filterConfig.FilterDataSource(ctx, d, meta, listBackups, flattenBackup)
+	client := helper.GetSDKClientWithUserAgent(
+		"data.linode_database_mysql_backups", meta.(*helper.ProviderMeta),
+	)
+	results, err := filterConfig.FilterDataSource(ctx, d, &client, listBackups, flattenBackup)
 	if err != nil {
 		return nil
 	}

--- a/linode/databasepostgresql/framework_datasource.go
+++ b/linode/databasepostgresql/framework_datasource.go
@@ -28,7 +28,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/databasepostgresql/resource.go
+++ b/linode/databasepostgresql/resource.go
@@ -19,6 +19,8 @@ const (
 	createDBTimeout = 75 * time.Minute
 	updateDBTimeout = 5 * time.Minute
 	deleteDBTimeout = 5 * time.Minute
+
+	resourceUserAgentComment = "linode_database_postgresql resource"
 )
 
 func Resource() *schema.Resource {
@@ -40,7 +42,7 @@ func Resource() *schema.Resource {
 }
 
 func readResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode PostgreSQL database ID %s as int: %s", d.Id(), err)
@@ -94,7 +96,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	p, err := client.NewEventPollerWithoutEntity(linodego.EntityDatabase, linodego.ActionDatabaseCreate)
 	if err != nil {
@@ -175,7 +177,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -237,7 +239,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode PostgreSQL database ID %s as int: %s", d.Id(), err)

--- a/linode/databasepostgresql/resource.go
+++ b/linode/databasepostgresql/resource.go
@@ -20,7 +20,7 @@ const (
 	updateDBTimeout = 5 * time.Minute
 	deleteDBTimeout = 5 * time.Minute
 
-	resourceUserAgentComment = "linode_database_postgresql resource"
+	resourceUserAgentComment = "linode_database_postgresql"
 )
 
 func Resource() *schema.Resource {

--- a/linode/databases/framework_datasource.go
+++ b/linode/databases/framework_datasource.go
@@ -43,7 +43,7 @@ func (r *DataSource) Read(
 	data.ID = id
 
 	result, d := filterConfig.GetAndFilter(
-		ctx, r.Meta.Client, data.Filters, listDatabases, data.Order, data.OrderBy)
+		ctx, r.Client, data.Filters, listDatabases, data.Order, data.OrderBy)
 	if d != nil {
 		resp.Diagnostics.Append(d)
 		return

--- a/linode/domain/framework_datasource.go
+++ b/linode/domain/framework_datasource.go
@@ -71,7 +71,7 @@ func (d *DataSource) Read(
 func (d *DataSource) getDomainByID(ctx context.Context, id int) (*linodego.Domain, diag.Diagnostic) {
 	tflog.Trace(ctx, "client.GetDomain(...)")
 
-	domain, err := d.Meta.Client.GetDomain(ctx, id)
+	domain, err := d.Client.GetDomain(ctx, id)
 	if err != nil {
 		return nil, diag.NewErrorDiagnostic(
 			fmt.Sprintf("Failed to get Domain with id %d", id),
@@ -95,7 +95,7 @@ func (d *DataSource) getDomainByDomain(ctx context.Context, domain string) (*lin
 		)
 	}
 
-	domains, err := d.Meta.Client.ListDomains(ctx, linodego.NewListOptions(0, string(filter)))
+	domains, err := d.Client.ListDomains(ctx, linodego.NewListOptions(0, string(filter)))
 	if err != nil {
 		return nil, diag.NewErrorDiagnostic(
 			"Failed to list matching domains",

--- a/linode/domain/resource.go
+++ b/linode/domain/resource.go
@@ -15,7 +15,7 @@ import (
 	linodediffs "github.com/linode/terraform-provider-linode/v2/linode/helper/customdiffs"
 )
 
-const resourceUserAgentComment = "linode_domain resource"
+const resourceUserAgentComment = "linode_domain"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{

--- a/linode/domain/resource.go
+++ b/linode/domain/resource.go
@@ -15,6 +15,8 @@ import (
 	linodediffs "github.com/linode/terraform-provider-linode/v2/linode/helper/customdiffs"
 )
 
+const resourceUserAgentComment = "linode_domain resource"
+
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		Schema:        resourceSchema,
@@ -36,7 +38,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_domain")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode Domain ID %s as int: %s", d.Id(), err)
@@ -76,7 +78,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tflog.Debug(ctx, "Create linode_domain")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	createOpts := linodego.DomainCreateOptions{
 		Domain:      d.Get("domain").(string),
@@ -133,7 +135,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_domain")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -190,7 +192,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Delete linode_domain")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode Domain id %s as int", d.Id())

--- a/linode/domainrecord/framework_datasource.go
+++ b/linode/domainrecord/framework_datasource.go
@@ -63,7 +63,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_domain_record")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/domainrecord/resource.go
+++ b/linode/domainrecord/resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
-const resourceUserAgentComment = "linode_domain_record resource"
+const resourceUserAgentComment = "linode_domain_record"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{

--- a/linode/domainrecord/resource.go
+++ b/linode/domainrecord/resource.go
@@ -14,6 +14,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
+const resourceUserAgentComment = "linode_domain_record resource"
+
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		Schema:        resourceSchema,
@@ -65,7 +67,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_domain_record")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode DomainRecord ID %s as int: %s", d.Id(), err)
@@ -140,7 +142,7 @@ func domainRecordFromResourceData(d *schema.ResourceData) *linodego.DomainRecord
 func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tflog.Debug(ctx, "Create linode_domain_record")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	domainID := d.Get("domain_id").(int)
 	rec := domainRecordFromResourceData(d)
 
@@ -177,7 +179,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_domain_record")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	domainID := d.Get("domain_id").(int)
 	rec := domainRecordFromResourceData(d)
 
@@ -214,7 +216,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Delete linode_domain_record")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	domainID := d.Get("domain_id").(int)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {

--- a/linode/domains/framework_datasource.go
+++ b/linode/domains/framework_datasource.go
@@ -41,7 +41,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listDomains,
+		ctx, d.Client, data.Filters, listDomains,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)

--- a/linode/domainzonefile/framework_datasource.go
+++ b/linode/domainzonefile/framework_datasource.go
@@ -58,7 +58,7 @@ func (d *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/firewall/framework_datasource.go
+++ b/linode/firewall/framework_datasource.go
@@ -31,7 +31,7 @@ func (d *DataSource) Read(
 	tflog.Debug(ctx, "Read data.linode_firewall")
 
 	var data FirewallModel
-	client := d.Meta.Client
+	client := d.Client
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/firewall/resource.go
+++ b/linode/firewall/resource.go
@@ -14,7 +14,7 @@ import (
 	linodediffs "github.com/linode/terraform-provider-linode/v2/linode/helper/customdiffs"
 )
 
-const resourceUserAgentComment = "linode_firewall resource"
+const resourceUserAgentComment = "linode_firewall"
 
 func resourceFirewallRules() *schema.Resource {
 	return &schema.Resource{

--- a/linode/firewall/resource.go
+++ b/linode/firewall/resource.go
@@ -14,6 +14,8 @@ import (
 	linodediffs "github.com/linode/terraform-provider-linode/v2/linode/helper/customdiffs"
 )
 
+const resourceUserAgentComment = "linode_firewall resource"
+
 func resourceFirewallRules() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceRuleSchema,
@@ -47,7 +49,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_firewall")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("failed to parse Firewall %s as int: %s", d.Id(), err)
@@ -93,7 +95,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	createOpts := linodego.FirewallCreateOptions{
 		Label: d.Get("label").(string),
@@ -140,7 +142,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_firewall")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("failed to parse Firewall %s as int: %s", d.Id(), err)
@@ -216,7 +218,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	ctx = populateLogAttributes(ctx, d)
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("failed to parse Firewall %s as int: %s", d.Id(), err)

--- a/linode/firewalldevice/framework_resource.go
+++ b/linode/firewalldevice/framework_resource.go
@@ -36,7 +36,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create linode_firewall_device")
 
 	var plan FirewallDeviceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -105,7 +105,7 @@ func (r *Resource) Read(
 		"device_id":   state.ID.ValueString(),
 	})
 
-	client := r.Meta.Client
+	client := r.Client
 
 	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -181,7 +181,7 @@ func (r *Resource) Delete(
 	var state FirewallDeviceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	client := r.Meta.Client
+	client := r.Client
 
 	id := helper.FrameworkSafeStringToInt(
 		state.ID.ValueString(),

--- a/linode/firewalls/framework_datasource.go
+++ b/linode/firewalls/framework_datasource.go
@@ -46,7 +46,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listFirewalls,
+		ctx, d.Client, data.Filters, listFirewalls,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)
@@ -56,7 +56,7 @@ func (d *DataSource) Read(
 	resp.Diagnostics.Append(
 		data.parseFirewalls(
 			ctx,
-			d.Meta.Client,
+			d.Client,
 			helper.AnySliceToTyped[linodego.Firewall](result),
 		)...,
 	)

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -82,7 +82,7 @@ func CreateFrameworkProviderWithMeta(version string, meta *helper.ProviderMeta) 
 	return &FrameworkProvider{
 		ProviderVersion: version,
 		Meta: &helper.FrameworkProviderMeta{
-			Client: &meta.Client,
+			Client: meta.Client,
 			Config: helper.GetFrameworkProviderModelFromSDKv2ProviderConfig(meta.Config),
 		},
 	}

--- a/linode/framework_provider_config.go
+++ b/linode/framework_provider_config.go
@@ -290,7 +290,7 @@ func (fp *FrameworkProvider) InitProvider(
 		client.SetRetryMaxWaitTime(time.Duration(maxRetryDelayMilliseconds) * time.Millisecond)
 	}
 
-	userAgent := fp.fwProviderUserAgent(tfVersion, UAPrefix)
+	userAgent := fp.userAgent(tfVersion, UAPrefix)
 	client.SetUserAgent(userAgent)
 	fp.Meta.ProviderUserAgent = userAgent
 
@@ -300,7 +300,7 @@ func (fp *FrameworkProvider) InitProvider(
 	fp.Meta.Client = client
 }
 
-func (fp *FrameworkProvider) fwProviderUserAgent(
+func (fp *FrameworkProvider) userAgent(
 	tfVersion string,
 	UAPrefix string,
 ) string {

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -21,8 +21,9 @@ const UAEnvVar = "TF_APPEND_USER_AGENT"
 const DefaultLinodeURL = "https://api.linode.com"
 
 type ProviderMeta struct {
-	Client linodego.Client
-	Config *Config
+	ProviderUserAgent string
+	Client            linodego.Client
+	Config            *Config
 }
 
 // Config represents the Linode provider configuration.
@@ -53,7 +54,7 @@ type Config struct {
 }
 
 // Client returns a fully initialized Linode client.
-func (c *Config) Client(ctx context.Context) (*linodego.Client, error) {
+func (c *Config) Client(ctx context.Context, meta *ProviderMeta) (*linodego.Client, error) {
 	loggingTransport := NewAPILoggerTransport(
 		logging.NewSubsystemLoggingHTTPTransport(
 			APILoggerSubsystem,
@@ -117,6 +118,10 @@ func (c *Config) Client(ctx context.Context) (*linodego.Client, error) {
 		userAgent = c.UAPrefix + " " + userAgent
 	}
 	client.SetUserAgent(userAgent)
+	if meta != nil {
+		meta.ProviderUserAgent = userAgent
+	}
+
 	ApplyAllRetryConditions(&client)
 
 	// We always want to disable resty debugging in favor

--- a/linode/helper/filter.go
+++ b/linode/helper/filter.go
@@ -202,12 +202,10 @@ func (f FilterConfig) FilterResults(
 func (f FilterConfig) FilterDataSource(
 	ctx context.Context,
 	d *schema.ResourceData,
-	meta interface{},
+	client *linodego.Client,
 	listFunc FilterListFunc,
 	flattenFunc FilterFlattenFunc,
 ) ([]map[string]interface{}, error) {
-	client := meta.(*ProviderMeta).Client
-
 	filterID, err := f.GetFilterID(d)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate filter id: %s", err)
@@ -223,7 +221,7 @@ func (f FilterConfig) FilterDataSource(
 		"filter": filter,
 	})
 
-	items, err := listFunc(ctx, d, &client, &linodego.ListOptions{
+	items, err := listFunc(ctx, d, client, &linodego.ListOptions{
 		Filter: filter,
 	})
 	if err != nil {

--- a/linode/helper/framework_datasource_base.go
+++ b/linode/helper/framework_datasource_base.go
@@ -50,7 +50,7 @@ func (r *BaseDataSource) Configure(
 		return
 	}
 
-	r.Client = GetFwClientWithUserAgent(r.Config.Name+" data source", r.Meta)
+	r.Client = GetFwClientWithUserAgent("data."+r.Config.Name, r.Meta)
 
 	if r.Config.IsEarlyAccess {
 		resp.Diagnostics.Append(

--- a/linode/helper/framework_datasource_base.go
+++ b/linode/helper/framework_datasource_base.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/linode/linodego"
 )
 
 // NewBaseDataSource returns a new instance of the BaseDataSource
@@ -29,6 +30,9 @@ type BaseDataSourceConfig struct {
 type BaseDataSource struct {
 	Config BaseDataSourceConfig
 	Meta   *FrameworkProviderMeta
+
+	// Data source level linodego Client containing specific configurations.
+	Client *linodego.Client
 }
 
 func (r *BaseDataSource) Configure(
@@ -45,6 +49,8 @@ func (r *BaseDataSource) Configure(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	r.Client = GetFwClientWithUserAgent(r.Config.Name+" data source", r.Meta)
 
 	if r.Config.IsEarlyAccess {
 		resp.Diagnostics.Append(

--- a/linode/helper/framework_provider_model.go
+++ b/linode/helper/framework_provider_model.go
@@ -59,6 +59,7 @@ type FrameworkProviderModel struct {
 }
 
 type FrameworkProviderMeta struct {
-	Client *linodego.Client
-	Config *FrameworkProviderModel
+	ProviderUserAgent string
+	Client            linodego.Client
+	Config            *FrameworkProviderModel
 }

--- a/linode/helper/framework_resource_base.go
+++ b/linode/helper/framework_resource_base.go
@@ -59,7 +59,7 @@ func (r *BaseResource) Configure(
 		return
 	}
 
-	r.Client = GetFwClientWithUserAgent(r.Config.Name+" resource", r.Meta)
+	r.Client = GetFwClientWithUserAgent(r.Config.Name, r.Meta)
 
 	if r.Config.IsEarlyAccess {
 		resp.Diagnostics.Append(

--- a/linode/helper/framework_resource_base.go
+++ b/linode/helper/framework_resource_base.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
 )
 
 // NewBaseResource returns a new instance of the BaseResource
@@ -38,6 +39,9 @@ type BaseResourceConfig struct {
 type BaseResource struct {
 	Config BaseResourceConfig
 	Meta   *FrameworkProviderMeta
+
+	// Resource level linodego Client containing specific configurations.
+	Client *linodego.Client
 }
 
 func (r *BaseResource) Configure(
@@ -54,6 +58,8 @@ func (r *BaseResource) Configure(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	r.Client = GetFwClientWithUserAgent(r.Config.Name+" resource", r.Meta)
 
 	if r.Config.IsEarlyAccess {
 		resp.Diagnostics.Append(

--- a/linode/helper/provider_meta.go
+++ b/linode/helper/provider_meta.go
@@ -11,7 +11,7 @@ func GetFwClientWithUserAgent(
 	meta *FrameworkProviderMeta,
 ) *linodego.Client {
 	client := meta.Client
-	client.SetUserAgent(generate(meta.ProviderUserAgent, resourceOrDataSourceUAComment))
+	client.SetUserAgent(generateUserAgent(meta.ProviderUserAgent, resourceOrDataSourceUAComment))
 
 	return &client
 }
@@ -21,12 +21,12 @@ func GetSDKClientWithUserAgent(
 	meta *ProviderMeta,
 ) linodego.Client {
 	client := meta.Client
-	client.SetUserAgent(generate(meta.ProviderUserAgent, resourceOrDataSourceUAComment))
+	client.SetUserAgent(generateUserAgent(meta.ProviderUserAgent, resourceOrDataSourceUAComment))
 
 	return client
 }
 
-func generate(providerUserAgent, resourceOrDataSourceUAComment string) string {
+func generateUserAgent(providerUserAgent, resourceOrDataSourceUAComment string) string {
 	if resourceOrDataSourceUAComment == "" {
 		return providerUserAgent
 	}

--- a/linode/helper/provider_meta.go
+++ b/linode/helper/provider_meta.go
@@ -1,0 +1,35 @@
+package helper
+
+import (
+	"fmt"
+
+	"github.com/linode/linodego"
+)
+
+func GetFwClientWithUserAgent(
+	resourceOrDataSourceUAComment string,
+	meta *FrameworkProviderMeta,
+) *linodego.Client {
+	client := meta.Client
+	client.SetUserAgent(generate(meta.ProviderUserAgent, resourceOrDataSourceUAComment))
+
+	return &client
+}
+
+func GetSDKClientWithUserAgent(
+	resourceOrDataSourceUAComment string,
+	meta *ProviderMeta,
+) linodego.Client {
+	client := meta.Client
+	client.SetUserAgent(generate(meta.ProviderUserAgent, resourceOrDataSourceUAComment))
+
+	return client
+}
+
+func generate(providerUserAgent, resourceOrDataSourceUAComment string) string {
+	if resourceOrDataSourceUAComment == "" {
+		return providerUserAgent
+	}
+
+	return providerUserAgent + fmt.Sprintf(" (%s)", resourceOrDataSourceUAComment)
+}

--- a/linode/image/framework_datasource.go
+++ b/linode/image/framework_datasource.go
@@ -31,7 +31,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_image")
 
-	client := d.Meta.Client
+	client := d.Client
 	var data ImageModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)

--- a/linode/image/framework_resource.go
+++ b/linode/image/framework_resource.go
@@ -188,7 +188,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create "+r.Config.Name)
 
 	var plan ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -232,7 +232,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read "+r.Config.Name)
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var state ResourceModel
 
@@ -290,7 +290,7 @@ func (r *Resource) Update(
 	imageID := plan.ID.ValueString()
 	ctx = populateLogAttributes(ctx, imageID)
 
-	client := r.Meta.Client
+	client := r.Client
 
 	updateOpts := linodego.ImageUpdateOptions{}
 	shouldUpdate := false
@@ -342,7 +342,7 @@ func (r *Resource) Delete(
 	imageID := state.ID.ValueString()
 	ctx = populateLogAttributes(ctx, imageID)
 
-	client := r.Meta.Client
+	client := r.Client
 
 	tflog.Trace(ctx, "client.DeleteImage(...)")
 

--- a/linode/images/framework_datasource.go
+++ b/linode/images/framework_datasource.go
@@ -47,7 +47,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listImages,
+		ctx, d.Client, data.Filters, listImages,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)

--- a/linode/instance/datasource.go
+++ b/linode/instance/datasource.go
@@ -50,7 +50,7 @@ func DataSource() *schema.Resource {
 func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tflog.Debug(ctx, "Read data.linode_instances")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent("linode_instance data source", meta.(*helper.ProviderMeta))
 
 	filterID, err := filterConfig.GetFilterID(d)
 	if err != nil {

--- a/linode/instance/datasource.go
+++ b/linode/instance/datasource.go
@@ -50,7 +50,9 @@ func DataSource() *schema.Resource {
 func readDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tflog.Debug(ctx, "Read data.linode_instances")
 
-	client := helper.GetSDKClientWithUserAgent("linode_instance data source", meta.(*helper.ProviderMeta))
+	client := helper.GetSDKClientWithUserAgent(
+		"data.linode_instance", meta.(*helper.ProviderMeta),
+	)
 
 	filterID, err := filterConfig.GetFilterID(d)
 	if err != nil {

--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -1169,7 +1169,7 @@ func validateBooted(ctx context.Context, d *schema.ResourceData) error {
 func handleBootedUpdate(
 	ctx context.Context, d *schema.ResourceData, meta interface{}, instanceID, configID int,
 ) error {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	deadlineSeconds := getDeadlineSeconds(ctx, d)
 

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -20,7 +20,7 @@ const (
 	LinodeInstanceUpdateTimeout = time.Hour
 	LinodeInstanceDeleteTimeout = 10 * time.Minute
 
-	resourceUserAgentComment = "linode_instance resource"
+	resourceUserAgentComment = "linode_instance"
 )
 
 func Resource() *schema.Resource {

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -19,6 +19,8 @@ const (
 	LinodeInstanceCreateTimeout = 15 * time.Minute
 	LinodeInstanceUpdateTimeout = time.Hour
 	LinodeInstanceDeleteTimeout = 10 * time.Minute
+
+	resourceUserAgentComment = "linode_instance resource"
 )
 
 func Resource() *schema.Resource {
@@ -47,7 +49,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_instance")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode instance ID %s as int: %s", d.Id(), err)
@@ -176,7 +178,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Create linode_instance")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	if err := validateBooted(ctx, d); err != nil {
 		return diag.Errorf("failed to validate: %v", err)
@@ -535,7 +537,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_instance")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	skipImplicitReboots := meta.(*helper.ProviderMeta).Config.SkipImplicitReboots
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -854,7 +856,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Delete linode_instance")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode Instance ID %s as int", d.Id())

--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -14,7 +14,7 @@ import (
 	instancehelpers "github.com/linode/terraform-provider-linode/v2/linode/instance"
 )
 
-const resourceUserAgentComment = "linode_instance_config resource"
+const resourceUserAgentComment = "linode_instance_config"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{

--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -14,6 +14,8 @@ import (
 	instancehelpers "github.com/linode/terraform-provider-linode/v2/linode/instance"
 )
 
+const resourceUserAgentComment = "linode_instance_config resource"
+
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		Schema:        resourceSchema,
@@ -64,7 +66,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_instance_config")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -151,7 +153,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Create linode_instance_config")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	linodeID := d.Get("linode_id").(int)
 
@@ -208,7 +210,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_instance_config")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -349,7 +351,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Delete linode_instance_config")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {

--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -67,7 +67,7 @@ func (r *Resource) Create(
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	client := r.Meta.Client
+	client := r.Client
 
 	timeoutSeconds := helper.FrameworkSafeFloat64ToInt(createTimeout.Seconds(), &resp.Diagnostics)
 	linodeID := helper.FrameworkSafeInt64ToInt(plan.LinodeID.ValueInt64(), &resp.Diagnostics)
@@ -183,7 +183,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 
 	tflog.Trace(ctx, "client.GetInstanceDisk(...)")
 	disk, err := client.GetInstanceDisk(ctx, linodeID, id)
@@ -238,7 +238,7 @@ func (r *Resource) Update(
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	client := r.Meta.Client
+	client := r.Client
 	timeoutSeconds := helper.FrameworkSafeFloat64ToInt(updateTimeout.Seconds(), &resp.Diagnostics)
 	size := helper.FrameworkSafeInt64ToInt(plan.Size.ValueInt64(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -306,7 +306,7 @@ func (r *Resource) Delete(
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	client := r.Meta.Client
+	client := r.Client
 
 	linodeID, id := getLinodeIDAndDiskID(state, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/linode/instanceip/framework_resource.go
+++ b/linode/instanceip/framework_resource.go
@@ -53,7 +53,7 @@ func (r *Resource) Create(
 
 	isPublic := plan.Public.ValueBool()
 
-	client := r.Meta.Client
+	client := r.Client
 	ip, err := client.AddInstanceIPAddress(ctx, linodeID, isPublic)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -144,7 +144,7 @@ func (r *Resource) Read(
 
 	ctx = populateLogAttributes(ctx, &state)
 
-	client := r.Meta.Client
+	client := r.Client
 	address := state.Address.ValueString()
 	linodeID := helper.FrameworkSafeInt64ToInt(
 		state.LinodeID.ValueInt64(),
@@ -207,7 +207,7 @@ func (r *Resource) Update(
 			RDNS: rdns,
 		}
 
-		client := r.Meta.Client
+		client := r.Client
 		address := plan.Address.ValueString()
 		linodeID := plan.LinodeID.ValueInt64()
 
@@ -258,7 +258,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 	address := state.Address.ValueString()
 	linodeID := helper.FrameworkSafeInt64ToInt(
 		state.LinodeID.ValueInt64(),

--- a/linode/instancenetworking/framework_datasource.go
+++ b/linode/instancenetworking/framework_datasource.go
@@ -30,7 +30,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_instance_networking")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/instancesharedips/framework_resource.go
+++ b/linode/instancesharedips/framework_resource.go
@@ -75,7 +75,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create "+r.Config.Name)
 
 	var plan ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -98,7 +98,7 @@ func (r *Resource) Read(
 	resp *resource.ReadResponse,
 ) {
 	tflog.Debug(ctx, "Read "+r.Config.Name)
-	client := r.Meta.Client
+	client := r.Client
 
 	var state ResourceModel
 
@@ -148,7 +148,7 @@ func (r *Resource) Update(
 
 	ctx = populateLogAttributes(ctx, plan)
 
-	client := r.Meta.Client
+	client := r.Client
 
 	if !plan.Addresses.Equal(state.Addresses) {
 		CreateOrUpdateSharedIPs(ctx, client, &plan, &resp.Diagnostics)
@@ -181,7 +181,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 
 	options := linodego.IPAddressesShareOptions{
 		LinodeID: linodeID,

--- a/linode/instancetype/framework_datasource.go
+++ b/linode/instancetype/framework_datasource.go
@@ -31,7 +31,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_instance_type")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/instancetypes/framework_datasource.go
+++ b/linode/instancetypes/framework_datasource.go
@@ -46,7 +46,7 @@ func (r *DataSource) Read(
 	data.ID = id
 
 	result, d := filterConfig.GetAndFilter(
-		ctx, r.Meta.Client, data.Filters, listInstanceTypes, data.Order, data.OrderBy)
+		ctx, r.Client, data.Filters, listInstanceTypes, data.Order, data.OrderBy)
 	if d != nil {
 		resp.Diagnostics.Append(d)
 		return

--- a/linode/ipv6range/framework_datasource.go
+++ b/linode/ipv6range/framework_datasource.go
@@ -33,7 +33,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_ipv6_range")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -36,7 +36,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create linode_ipv6_range")
 
 	var data ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -141,7 +141,7 @@ func (r *Resource) Read(
 	tflog.Debug(ctx, "Read linode_ipv6_range")
 
 	var data ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -187,7 +187,7 @@ func (r *Resource) Update(
 	tflog.Debug(ctx, "Update linode_ipv6_range")
 
 	var plan, state ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -257,7 +257,7 @@ func (r *Resource) Delete(
 	tflog.Debug(ctx, "Delete linode_ipv6_range")
 
 	var data ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/ipv6ranges/framework_datasource.go
+++ b/linode/ipv6ranges/framework_datasource.go
@@ -34,7 +34,7 @@ func (r *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_ipv6_ranges")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data IPv6RangeFilterModel
 

--- a/linode/kernel/framework_datasource.go
+++ b/linode/kernel/framework_datasource.go
@@ -30,7 +30,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_kernel")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/kernels/framework_datasource.go
+++ b/linode/kernels/framework_datasource.go
@@ -46,7 +46,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listKernels,
+		ctx, d.Client, data.Filters, listKernels,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)

--- a/linode/lke/framework_datasource.go
+++ b/linode/lke/framework_datasource.go
@@ -32,7 +32,7 @@ func (r *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_lke_cluster")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data LKEDataModel
 

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -24,6 +24,8 @@ const (
 	createLKETimeout = 35 * time.Minute
 	updateLKETimeout = 40 * time.Minute
 	deleteLKETimeout = 15 * time.Minute
+
+	resourceUserAgentComment = "linode_lke_cluster resource"
 )
 
 func Resource() *schema.Resource {
@@ -53,7 +55,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_lke_cluster")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode LKE Cluster ID: %s", err)
@@ -132,7 +134,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Create linode_lke_cluster")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	controlPlane := d.Get("control_plane").([]interface{})
 
@@ -218,7 +220,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	tflog.Debug(ctx, "Update linode_lke_cluster")
 
 	providerMeta := meta.(*helper.ProviderMeta)
-	client := providerMeta.Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, providerMeta)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("failed parsing Linode LKE Cluster ID: %s", err)
@@ -345,7 +347,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Delete linode_lke_cluster")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("failed parsing Linode LKE Cluster ID: %s", err)

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -25,7 +25,7 @@ const (
 	updateLKETimeout = 40 * time.Minute
 	deleteLKETimeout = 15 * time.Minute
 
-	resourceUserAgentComment = "linode_lke_cluster resource"
+	resourceUserAgentComment = "linode_lke_cluster"
 )
 
 func Resource() *schema.Resource {

--- a/linode/lkeclusters/framework_datasource.go
+++ b/linode/lkeclusters/framework_datasource.go
@@ -45,7 +45,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listLKEClusters,
+		ctx, d.Client, data.Filters, listLKEClusters,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)

--- a/linode/lkenodepool/framework_resource.go
+++ b/linode/lkenodepool/framework_resource.go
@@ -36,7 +36,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read linode_lke_node_pool")
 	var data NodePoolModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -92,7 +92,7 @@ func (r *Resource) Create(
 ) {
 	tflog.Debug(ctx, "Create linode_lke_node_pool")
 	var plan NodePoolModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -161,7 +161,7 @@ func (r *Resource) Update(
 ) {
 	tflog.Debug(ctx, "Update linode_lke_node_pool")
 	var state, plan NodePoolModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -222,7 +222,7 @@ func (r *Resource) Delete(
 ) {
 	tflog.Debug(ctx, "Delete linode_lke_node_pool")
 	var data NodePoolModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/lkeversions/framework_datasource.go
+++ b/linode/lkeversions/framework_datasource.go
@@ -56,7 +56,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_lke_versions")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/nb/framework_datasource.go
+++ b/linode/nb/framework_datasource.go
@@ -33,7 +33,7 @@ func (d *DataSource) Read(
 	tflog.Debug(ctx, "Read data.linode_nodebalancer")
 
 	var data NodeBalancerDataSourceModel
-	client := d.Meta.Client
+	client := d.Client
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -40,7 +40,7 @@ func (r *Resource) Create(
 ) {
 	tflog.Debug(ctx, "Create linode_nodebalancer")
 	var data NodeBalancerModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -119,7 +119,7 @@ func (r *Resource) Read(
 	tflog.Debug(ctx, "Read linode_nodebalancer")
 
 	var data NodeBalancerModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -181,7 +181,7 @@ func (r *Resource) Update(
 	tflog.Debug(ctx, "Update linode_nodebalancer")
 
 	var plan, state NodeBalancerModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -255,7 +255,7 @@ func (r *Resource) Delete(
 	tflog.Debug(ctx, "Delete linode_nodebalancer")
 
 	var data NodeBalancerModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/nbconfig/framework_datasource.go
+++ b/linode/nbconfig/framework_datasource.go
@@ -32,7 +32,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_nodebalancer_config")
 
-	client := d.Meta.Client
+	client := d.Client
 	var data DataSourceModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)

--- a/linode/nbconfig/framework_resource.go
+++ b/linode/nbconfig/framework_resource.go
@@ -64,7 +64,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create "+r.Config.Name)
 
 	var plan ResourceModelV1
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -114,7 +114,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read "+r.Config.Name)
 
-	client := r.Meta.Client
+	client := r.Client
 	var state ResourceModelV1
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -174,7 +174,7 @@ func (r *Resource) Update(
 	var state ResourceModelV1
 	var plan ResourceModelV1
 
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -219,7 +219,7 @@ func (r *Resource) Delete(
 ) {
 	tflog.Debug(ctx, "Delete "+r.Config.Name)
 	var state ResourceModelV1
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/nbconfigs/framework_datasource.go
+++ b/linode/nbconfigs/framework_datasource.go
@@ -46,7 +46,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, data.listNodeBalancerConfigs,
+		ctx, d.Client, data.Filters, data.listNodeBalancerConfigs,
 		// There are no API filterable fields, so we don't need to provide
 		// order and order_by.
 		types.StringNull(), types.StringNull())

--- a/linode/nbnode/framework_datasource.go
+++ b/linode/nbnode/framework_datasource.go
@@ -32,7 +32,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.nb_node")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/nbnode/resource.go
+++ b/linode/nbnode/resource.go
@@ -15,6 +15,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
+const resourceUserAgentComment = "linode_nb_node resource"
+
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		Schema:        resourceSchema,
@@ -32,7 +34,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_nb_node")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode NodeBalancerNode ID %s as int: %s", d.Id(), err)
@@ -106,7 +108,7 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Create linode_nb_node")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	nodebalancerID, ok := d.Get("nodebalancer_id").(int)
 	if !ok {
@@ -146,7 +148,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_nb_node")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -184,7 +186,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_nb_node")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode NodeBalancerConfig ID %s as int: %s", d.Id(), err)

--- a/linode/nbnode/resource.go
+++ b/linode/nbnode/resource.go
@@ -15,7 +15,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
-const resourceUserAgentComment = "linode_nb_node resource"
+const resourceUserAgentComment = "linode_nb_node"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{

--- a/linode/nbs/framework_datasource.go
+++ b/linode/nbs/framework_datasource.go
@@ -45,7 +45,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listNodeBalancers,
+		ctx, d.Client, data.Filters, listNodeBalancers,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)

--- a/linode/networkingip/framework_datasource.go
+++ b/linode/networkingip/framework_datasource.go
@@ -73,7 +73,7 @@ func (d *DataSource) Read(
 	ctx = tflog.SetField(ctx, "address", data.Address.ValueString())
 	tflog.Trace(ctx, "client.GetIPAddress(...)")
 
-	ip, err := d.Meta.Client.GetIPAddress(ctx, data.Address.ValueString())
+	ip, err := d.Client.GetIPAddress(ctx, data.Address.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to get IP Address: %s", err.Error(),

--- a/linode/obj/resource.go
+++ b/linode/obj/resource.go
@@ -21,7 +21,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
-const resourceUserAgentComment = "linode_object_storage_object resource"
+const resourceUserAgentComment = "linode_object_storage_object"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{

--- a/linode/obj/resource.go
+++ b/linode/obj/resource.go
@@ -21,6 +21,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
+const resourceUserAgentComment = "linode_object_storage_object resource"
+
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceSchema,
@@ -45,7 +47,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	tflog.Debug(ctx, "reading linode_object_storage_object")
 
 	config := meta.(*helper.ProviderMeta).Config
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	cluster := d.Get("cluster").(string)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
@@ -125,7 +127,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if d.HasChange("acl") {
 		config := meta.(*helper.ProviderMeta).Config
-		client := meta.(*helper.ProviderMeta).Client
+		client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 		objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, cluster, "read_write")
 		if diags != nil {
@@ -166,7 +168,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	tflog.Debug(ctx, "deleting linode_object_storage_object")
 
 	config := meta.(*helper.ProviderMeta).Config
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	cluster := d.Get("cluster").(string)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
@@ -213,7 +215,7 @@ func putObject(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 	tflog.Debug(ctx, "entered 'putObject' function")
 
 	config := meta.(*helper.ProviderMeta).Config
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	cluster := d.Get("cluster").(string)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)

--- a/linode/objbucket/framework_datasource.go
+++ b/linode/objbucket/framework_datasource.go
@@ -53,7 +53,7 @@ func (d *DataSource) Read(
 	resp *datasource.ReadResponse,
 ) {
 	tflog.Debug(ctx, "Read linode_object_storage_bucket")
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -18,6 +18,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/obj"
 )
 
+const resourceUserAgentComment = "linode_object_storage_bucket resource"
+
 func resourceLifecycleExpiration() *schema.Resource {
 	return &schema.Resource{
 		Schema: resourceSchemaExpiration,
@@ -54,7 +56,7 @@ func readResource(
 ) diag.Diagnostics {
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_object_storage_bucket")
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	config := meta.(*helper.ProviderMeta).Config
 
 	cluster, label, err := DecodeBucketID(ctx, d.Id())
@@ -137,7 +139,7 @@ func createResource(
 ) diag.Diagnostics {
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Create linode_object_storage_bucket")
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	cluster := d.Get("cluster").(string)
 	label := d.Get("label").(string)
@@ -168,7 +170,7 @@ func updateResource(
 ) diag.Diagnostics {
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_object_storage_bucket")
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	if d.HasChanges("acl", "cors_enabled") {
 		tflog.Debug(ctx, "'acl' changes detected, will update bucket access")
@@ -236,7 +238,7 @@ func deleteResource(
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Delete linode_object_storage_bucket")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 	cluster, label, err := DecodeBucketID(ctx, d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing Linode ObjectStorageBucket id %s", d.Id())

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -18,7 +18,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/obj"
 )
 
-const resourceUserAgentComment = "linode_object_storage_bucket resource"
+const resourceUserAgentComment = "linode_object_storage_bucket"
 
 func resourceLifecycleExpiration() *schema.Resource {
 	return &schema.Resource{

--- a/linode/objcluster/framework_datasource.go
+++ b/linode/objcluster/framework_datasource.go
@@ -47,7 +47,7 @@ func (d *DataSource) Read(
 	resp *datasource.ReadResponse,
 ) {
 	tflog.Debug(ctx, "Read linode_object_storage_cluster")
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -36,7 +36,7 @@ func (r *Resource) Create(
 ) {
 	tflog.Debug(ctx, "Create linode_object_storage_key")
 	var data ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -92,7 +92,7 @@ func (r *Resource) Read(
 	resp *resource.ReadResponse,
 ) {
 	tflog.Debug(ctx, "Read linode_object_storage_key")
-	client := r.Meta.Client
+	client := r.Client
 	var data ResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -176,7 +176,7 @@ func (r *Resource) Update(
 		tflog.Debug(ctx, "client.UpdateObjectStorageKey(...)", map[string]any{
 			"options": updateOpts,
 		})
-		key, err := r.Meta.Client.UpdateObjectStorageKey(ctx, id, updateOpts)
+		key, err := r.Client.UpdateObjectStorageKey(ctx, id, updateOpts)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to update Object Storage Key (%d)", id),
@@ -214,7 +214,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 	tflog.Debug(ctx, "client.DeleteObjectStorageKey(...)")
 	err := client.DeleteObjectStorageKey(ctx, id)
 	if err != nil {

--- a/linode/profile/framework_datasource.go
+++ b/linode/profile/framework_datasource.go
@@ -86,7 +86,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_profile")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -262,10 +262,14 @@ func providerConfigure(
 		ObjUseTempKeys: d.Get("obj_use_temp_keys").(bool),
 	}
 
+	meta := helper.ProviderMeta{
+		Config: config,
+	}
+
 	handleDefault(config, d)
 
 	config.TerraformVersion = terraformVersion
-	client, err := config.Client(ctx)
+	client, err := config.Client(ctx, &meta)
 	if err != nil {
 		return nil, diag.Errorf("failed to initialize client: %s", err)
 	}
@@ -274,8 +278,7 @@ func providerConfigure(
 	if _, err := client.ListTypes(ctx, linodego.NewListOptions(100, "")); err != nil {
 		return nil, diag.Errorf("Error connecting to the Linode API: %s", err)
 	}
-	return &helper.ProviderMeta{
-		Client: *client,
-		Config: config,
-	}, nil
+	meta.Client = *client
+
+	return &meta, nil
 }

--- a/linode/provider_test.go
+++ b/linode/provider_test.go
@@ -37,7 +37,7 @@ api_version = v4beta
 		ObjSecretKey:          "efgh",
 	}
 
-	client, err := config.Client(context.Background())
+	client, err := config.Client(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ api_version = v4beta
 	config.APIURL = ""
 	config.APIVersion = ""
 
-	client, err = config.Client(context.Background())
+	client, err = config.Client(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ api_version = v4beta
 	}
 
 	config.ConfigProfile = "cool"
-	client, err = config.Client(context.Background())
+	client, err = config.Client(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -47,7 +47,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create linode_rdns")
 
 	var plan ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -120,7 +120,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read linode_rdns")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data ResourceModel
 
@@ -185,7 +185,7 @@ func (r *Resource) Update(
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var updateOpts linodego.IPAddressUpdateOptions
 
@@ -231,7 +231,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 
 	updateOpts := linodego.IPAddressUpdateOptions{
 		RDNS: nil,

--- a/linode/region/framework_datasource.go
+++ b/linode/region/framework_datasource.go
@@ -31,7 +31,7 @@ func (r *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_region")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data RegionModel
 

--- a/linode/regions/framework_datasource.go
+++ b/linode/regions/framework_datasource.go
@@ -47,7 +47,7 @@ func (r *DataSource) Read(
 	data.ID = id
 
 	result, d := filterConfig.GetAndFilter(
-		ctx, r.Meta.Client, data.Filters, listRegions,
+		ctx, r.Client, data.Filters, listRegions,
 		// There are no API filterable fields so we don't need to provide
 		// order and order_by.
 		types.StringNull(), types.StringNull())

--- a/linode/sshkey/framework_datasource.go
+++ b/linode/sshkey/framework_datasource.go
@@ -69,7 +69,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_sshkey")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -37,7 +37,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create linode_sshkey")
 
 	var data ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -78,7 +78,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Create linode_sshkey")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data ResourceModel
 
@@ -154,7 +154,7 @@ func (r *Resource) Update(
 			"options": updateOpts,
 		})
 
-		key, err := r.Meta.Client.UpdateSSHKey(
+		key, err := r.Client.UpdateSSHKey(
 			ctx,
 			id,
 			updateOpts,
@@ -190,7 +190,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 
 	ctx = tflog.SetField(ctx, "sshkey_id", id)
 	tflog.Trace(ctx, "client.DeleteSSHKey(...)")

--- a/linode/sshkeys/framework_datasource.go
+++ b/linode/sshkeys/framework_datasource.go
@@ -49,7 +49,7 @@ func (d *DataSource) Read(
 	ctx = tflog.SetField(ctx, "sshkey_filter_id", data.ID.ValueString())
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listSSHKeys,
+		ctx, d.Client, data.Filters, listSSHKeys,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)

--- a/linode/stackscript/framework_datasource.go
+++ b/linode/stackscript/framework_datasource.go
@@ -29,7 +29,7 @@ func (r *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	client := r.Meta.Client
+	client := r.Client
 
 	var data StackScriptModel
 

--- a/linode/stackscript/framework_resource.go
+++ b/linode/stackscript/framework_resource.go
@@ -86,7 +86,7 @@ func (r *Resource) Create(
 ) {
 	tflog.Debug(ctx, "Create linode_stackscript")
 	var data StackScriptModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -141,7 +141,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read linode_stackscript")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data StackScriptModel
 
@@ -243,7 +243,7 @@ func (r *Resource) Delete(
 ) {
 	tflog.Debug(ctx, "Delete linode_stackscript")
 	var data StackScriptModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -276,7 +276,7 @@ func (r *Resource) updateStackScript(
 	plan *StackScriptModel,
 	stackScriptID int,
 ) {
-	client := r.Meta.Client
+	client := r.Client
 
 	updateOpts := linodego.StackscriptUpdateOptions{
 		Label:       plan.Label.ValueString(),

--- a/linode/stackscripts/framework_datasource.go
+++ b/linode/stackscripts/framework_datasource.go
@@ -43,7 +43,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listStackscripts,
+		ctx, d.Client, data.Filters, listStackscripts,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -38,7 +38,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create linode_token")
 
 	var data ResourceModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -89,7 +89,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read linode_token")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data ResourceModel
 
@@ -159,7 +159,7 @@ func (r *Resource) Update(
 			return
 		}
 
-		client := r.Meta.Client
+		client := r.Client
 
 		tflog.Trace(ctx, "client.GetToken(...)")
 		token, err := client.GetToken(ctx, tokenID)
@@ -213,7 +213,7 @@ func (r *Resource) Delete(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 
 	tflog.Debug(ctx, "client.DeleteToken(...)")
 

--- a/linode/user/framework_datasource.go
+++ b/linode/user/framework_datasource.go
@@ -32,7 +32,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_user")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data DataSourceModel
 

--- a/linode/user/resource.go
+++ b/linode/user/resource.go
@@ -13,6 +13,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
+const resourceUserAgentComment = "linode_user resource"
+
 var resourceLinodeUserGrantFields = []string{
 	"global_grants", "domain_grant", "firewall_grant", "image_grant",
 	"linode_grant", "longview_grant", "nodebalancer_grant", "stackscript_grant", "volume_grant",
@@ -34,7 +36,7 @@ func Resource() *schema.Resource {
 func createResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tflog.Debug(ctx, "Create linode_user")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	createOpts := linodego.UserCreateOptions{
 		Email:      d.Get("email").(string),
@@ -67,7 +69,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Read linode_user")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	username := d.Id()
 
@@ -115,7 +117,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Update linode_user")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	id := d.Id()
 	username := d.Get("username").(string)
@@ -149,7 +151,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 	ctx = populateLogAttributes(ctx, d)
 	tflog.Debug(ctx, "Delete linode_user")
 
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	username := d.Id()
 
@@ -161,7 +163,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func updateUserGrants(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*helper.ProviderMeta).Client
+	client := helper.GetSDKClientWithUserAgent(resourceUserAgentComment, meta.(*helper.ProviderMeta))
 
 	username := d.Id()
 	restricted := d.Get("restricted").(bool)

--- a/linode/user/resource.go
+++ b/linode/user/resource.go
@@ -13,7 +13,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
-const resourceUserAgentComment = "linode_user resource"
+const resourceUserAgentComment = "linode_user"
 
 var resourceLinodeUserGrantFields = []string{
 	"global_grants", "domain_grant", "firewall_grant", "image_grant",

--- a/linode/users/framework_datasource.go
+++ b/linode/users/framework_datasource.go
@@ -44,14 +44,14 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	result, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client, data.Filters, listUsers,
+		ctx, d.Client, data.Filters, listUsers,
 		data.Order, data.OrderBy)
 	if diag != nil {
 		resp.Diagnostics.Append(diag)
 		return
 	}
 
-	resp.Diagnostics.Append(data.parseUsers(ctx, d.Meta.Client, helper.AnySliceToTyped[linodego.User](result))...)
+	resp.Diagnostics.Append(data.parseUsers(ctx, d.Client, helper.AnySliceToTyped[linodego.User](result))...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/vlan/framework_datasource.go
+++ b/linode/vlan/framework_datasource.go
@@ -47,7 +47,7 @@ func (d *DataSource) Read(
 	data.ID = id
 
 	results, diag := filterConfig.GetAndFilter(
-		ctx, d.Meta.Client,
+		ctx, d.Client,
 		data.Filters,
 		listVLANs,
 		data.Order,

--- a/linode/volume/framework_datasource.go
+++ b/linode/volume/framework_datasource.go
@@ -31,7 +31,7 @@ func (r *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_volume")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	var data VolumeDataSourceModel
 

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -83,7 +83,7 @@ func (r *Resource) CreateVolumeFromSource(
 ) *linodego.Volume {
 	tflog.Debug(ctx, "Create volume from source")
 
-	client := r.Meta.Client
+	client := r.Client
 	sourceVolumeID := helper.FrameworkSafeInt64ToInt(data.SourceVolumeID.ValueInt64(), diags)
 	if diags.HasError() {
 		return nil
@@ -212,7 +212,7 @@ func (r *Resource) CreateVolume(
 ) *linodego.Volume {
 	tflog.Debug(ctx, "Create new volume")
 
-	client := r.Meta.Client
+	client := r.Client
 
 	size := helper.FrameworkSafeInt64ToInt(data.Size.ValueInt64(), diags)
 
@@ -323,7 +323,7 @@ func (r *Resource) Read(
 		return
 	}
 
-	client := r.Meta.Client
+	client := r.Client
 
 	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -412,7 +412,7 @@ func (r *Resource) Update(
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	client := r.Meta.Client
+	client := r.Client
 
 	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), &resp.Diagnostics)
 	size := helper.FrameworkSafeInt64ToInt(plan.Size.ValueInt64(), &resp.Diagnostics)
@@ -598,7 +598,7 @@ func (r *Resource) Delete(
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 
-	client := r.Meta.Client
+	client := r.Client
 
 	id := helper.FrameworkSafeStringToInt(state.ID.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/linode/volumes/framework_datasource.go
+++ b/linode/volumes/framework_datasource.go
@@ -28,7 +28,7 @@ func (r *DataSource) Read(
 	req datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	client := r.Meta.Client
+	client := r.Client
 
 	var data VolumeFilterModel
 

--- a/linode/vpc/framework_datasource.go
+++ b/linode/vpc/framework_datasource.go
@@ -32,7 +32,7 @@ func (d *DataSource) Read(
 ) {
 	tflog.Debug(ctx, "Read data.linode_vpc")
 
-	client := d.Meta.Client
+	client := d.Client
 
 	var data VPCModel
 

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -37,7 +37,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Create linode_vpc")
 
 	var data VPCModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -80,7 +80,7 @@ func (r *Resource) Read(
 	tflog.Debug(ctx, "Read linode_vpc")
 
 	var data VPCModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -130,7 +130,7 @@ func (r *Resource) Update(
 ) {
 	tflog.Debug(ctx, "Update linode_vpc")
 
-	client := r.Meta.Client
+	client := r.Client
 	var plan, state VPCModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -186,7 +186,7 @@ func (r *Resource) Delete(
 ) {
 	tflog.Debug(ctx, "Delete linode_vpc")
 
-	client := r.Meta.Client
+	client := r.Client
 	var data VPCModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)

--- a/linode/vpcs/framework_datasource.go
+++ b/linode/vpcs/framework_datasource.go
@@ -48,7 +48,7 @@ func (r *DataSource) Read(
 	data.ID = id
 
 	result, d := filterConfig.GetAndFilter(
-		ctx, r.Meta.Client, data.Filters, ListVPCs,
+		ctx, r.Client, data.Filters, ListVPCs,
 		// There are no API filterable fields so we don't need to provide
 		// order and order_by.
 		types.StringNull(), types.StringNull())

--- a/linode/vpcsubnet/framework_datasource.go
+++ b/linode/vpcsubnet/framework_datasource.go
@@ -31,7 +31,7 @@ func (d *DataSource) Read(
 	resp *datasource.ReadResponse,
 ) {
 	tflog.Trace(ctx, "Read data.linode_vpc_subnet")
-	client := d.Meta.Client
+	client := d.Client
 
 	var data VPCSubnetModel
 

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -59,7 +59,7 @@ func (r *Resource) Create(
 	tflog.Debug(ctx, "Read linode_vpc_subnet")
 
 	var data VPCSubnetModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -110,7 +110,7 @@ func (r *Resource) Read(
 ) {
 	tflog.Debug(ctx, "Read linode_vpc_subnet")
 
-	client := r.Meta.Client
+	client := r.Client
 	var data VPCSubnetModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -167,7 +167,7 @@ func (r *Resource) Update(
 	tflog.Debug(ctx, "Update linode_vpc_subnet")
 
 	var plan, state VPCSubnetModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -227,7 +227,7 @@ func (r *Resource) Delete(
 	tflog.Debug(ctx, "Delete linode_vpc_subnet")
 
 	var data VPCSubnetModel
-	client := r.Meta.Client
+	client := r.Client
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/linode/vpcsubnets/framework_datasource.go
+++ b/linode/vpcsubnets/framework_datasource.go
@@ -51,7 +51,7 @@ func (r *DataSource) Read(
 	data.ID = id
 
 	result, d := filterConfig.GetAndFilter(
-		ctx, r.Meta.Client, data.Filters, data.ListVPCSubnets,
+		ctx, r.Client, data.Filters, data.ListVPCSubnets,
 		// There are no API filterable fields so we don't need to provide
 		// order and order_by.
 		types.StringNull(), types.StringNull())


### PR DESCRIPTION
## 📝 Description

This is to include resource or data source name in the user agent of the API calls.

## ✔️ How to Test

### Automated Testing

Which runs very looooong and may have intermittent errors.
```bash
make test
```

### Manual Testing

- Enable logging:
```bash
export TF_LOG=DEBUG
export TF_LOG_PATH=$PWD/log.txt 
export TF_LOG_PROVIDER_LINODE_REQUESTS=DEBUG
```
- Deploy some resources, like:
```terraform
resource "linode_vpc" "test" {
    label = "test-vpc${count.index}"
    region = "us-mia"
    description = "My first VPC."
    count = 3
}

resource "linode_nodebalancer" "foobar" {
    label = "mynodebalancer${count.index}"
    region = "us-mia"
    client_conn_throttle = 20
    count = 3
}
```
- Inspect `log.txt` for user agents recorded, they should be something like `User-Agent="HashiCorp Terraform/1.8.1 (+https://www.terraform.io) Terraform-Plugin-Framework/1.8.0 terraform-provider-linode/dev (linode_vpc resource)"`