### PR TITLE
fix: Revert RunBatch(...) usage

### DIFF
--- a/linode/helper/batch.go
+++ b/linode/helper/batch.go
@@ -10,6 +10,7 @@ type BatchFunction func(ctx context.Context) error
 
 // RunBatch is intended to simplify executing functions concurrently.
 // This is handy for running certain non-sequential API requests in parallel.
+// NOTE: This should NOT be used until linodego has been confirmed to be thread-safe.
 func RunBatch(ctx context.Context, toExecute ...BatchFunction) error {
 	eg, ctx := errgroup.WithContext(ctx)
 


### PR DESCRIPTION
## 📝 Description

This change reverts all usage of `helper.RunBatch(...)` in response to a thread-safety issue in the underlying HTTP client used by linodego. We have plans to resolve this issue in the future but have decided to drop concurrency from API requests in TF for the time being.

Test runs:
* https://github.com/linode/terraform-provider-linode/actions/runs/8850661690
* https://github.com/linode/terraform-provider-linode/actions/runs/8850663250

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make PKG_NAME=linode/instance int-test
make PKG_NAME=linode/instanceconfig int-test
```
