### PR TITLE
fix: Apply Crossplane plan ID workaround across all Framework resources

### DIFF
--- a/linode/accountsettings/framework_resource.go
+++ b/linode/accountsettings/framework_resource.go
@@ -128,6 +128,13 @@ func (r *Resource) Update(
 
 	plan.CopyFrom(state, true)
 
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	// Apply the state changes
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/linode/firewalldevice/framework_resource.go
+++ b/linode/firewalldevice/framework_resource.go
@@ -169,6 +169,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/image/framework_resource.go
+++ b/linode/image/framework_resource.go
@@ -322,6 +322,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -290,6 +290,14 @@ func (r *Resource) Update(
 	plan.FlattenDisk(disk, true)
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/instanceip/framework_resource.go
+++ b/linode/instanceip/framework_resource.go
@@ -243,6 +243,13 @@ func (r *Resource) Update(
 	}
 	plan.CopyFrom(ctx, state, true)
 
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/instancesharedips/framework_resource.go
+++ b/linode/instancesharedips/framework_resource.go
@@ -158,6 +158,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -246,6 +246,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/lkenodepool/framework_resource.go
+++ b/linode/lkenodepool/framework_resource.go
@@ -208,6 +208,14 @@ func (r *Resource) Update(
 	}
 
 	plan.FlattenLKENodePool(readyPool, true, &resp.Diagnostics)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -243,7 +243,16 @@ func (r *Resource) Update(
 
 		resp.Diagnostics.Append(plan.FlattenNodeBalancer(ctx, nodeBalancer, firewalls, true)...)
 	}
+
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/nbconfig/framework_resource.go
+++ b/linode/nbconfig/framework_resource.go
@@ -209,6 +209,14 @@ func (r *Resource) Update(
 
 	plan.FlattenNodeBalancerConfig(config, true)
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -188,6 +188,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -213,7 +213,16 @@ func (r *Resource) Update(
 		}
 		plan.FlattenInstanceIP(ip, true)
 	}
+
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -167,7 +167,16 @@ func (r *Resource) Update(
 		}
 		plan.FlattenSSHKey(key, true)
 	}
+
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/stackscript/framework_resource.go
+++ b/linode/stackscript/framework_resource.go
@@ -233,6 +233,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -189,6 +189,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -543,6 +543,14 @@ func (r *Resource) Update(
 	}
 
 	plan.CopyFrom(state, true)
+
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -176,6 +176,13 @@ func (r *Resource) Update(
 	}
 	plan.CopyFrom(ctx, state, true)
 
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -216,6 +216,13 @@ func (r *Resource) Update(
 		req.State.GetAttribute(ctx, path.Root("updated"), &plan.Updated)
 	}
 
+	// Workaround for Crossplane issue where ID is not
+	// properly populated in plan
+	// See TPT-2865 for more details
+	if plan.ID.ValueString() == "" {
+		plan.ID = state.ID
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused resources managed through Crossplane to have their IDs dropped during update operations. In short, this issue occurred because the plan's ID is populated with an empty string (`UseStateForUnknown` isn't respected), so `preserveKnown` will not implicitly update the ID when applying the state to the plan.

## ✔️ How to Test

N/A