### PR TITLE
Fix concurrent map write on framework timeout blocks

### DIFF
--- a/linode/accountsettings/framework_resource.go
+++ b/linode/accountsettings/framework_resource.go
@@ -18,7 +18,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_account_settings",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/firewalldevice/framework_resource.go
+++ b/linode/firewalldevice/framework_resource.go
@@ -18,7 +18,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_firewall_device",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/helper/framework_resource_base.go
+++ b/linode/helper/framework_resource_base.go
@@ -28,7 +28,7 @@ type BaseResourceConfig struct {
 	IDType attr.Type
 
 	// Optional
-	Schema        *schema.Schema
+	Schema        schema.Schema
 	TimeoutOpts   *timeouts.Opts
 	IsEarlyAccess bool
 }
@@ -75,15 +75,6 @@ func (r *BaseResource) Schema(
 	req resource.SchemaRequest,
 	resp *resource.SchemaResponse,
 ) {
-	if r.Config.Schema == nil {
-		resp.Diagnostics.AddError(
-			"Missing Schema",
-			"Base resource was not provided a schema. "+
-				"Please provide a Schema config attribute or implement, the Schema(...) function.",
-		)
-		return
-	}
-
 	if r.Config.TimeoutOpts != nil {
 		if r.Config.Schema.Blocks == nil {
 			r.Config.Schema.Blocks = make(map[string]schema.Block)
@@ -91,7 +82,7 @@ func (r *BaseResource) Schema(
 		r.Config.Schema.Blocks["timeouts"] = timeouts.Block(ctx, *r.Config.TimeoutOpts)
 	}
 
-	resp.Schema = *r.Config.Schema
+	resp.Schema = r.Config.Schema
 }
 
 // ImportState should be overridden for resources with

--- a/linode/image/framework_resource.go
+++ b/linode/image/framework_resource.go
@@ -30,7 +30,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_image",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 				TimeoutOpts: &timeouts.Opts{
 					Create: true,
 				},

--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -29,7 +29,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_instance_disk",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 				TimeoutOpts: &timeouts.Opts{
 					Update: true,
 					Create: true,

--- a/linode/instanceip/framework_resource.go
+++ b/linode/instanceip/framework_resource.go
@@ -18,7 +18,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_instance_ip",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/instancesharedips/framework_resource.go
+++ b/linode/instancesharedips/framework_resource.go
@@ -20,7 +20,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_instance_shared_ips",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -18,7 +18,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_ipv6_range",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/lkenodepool/framework_resource.go
+++ b/linode/lkenodepool/framework_resource.go
@@ -19,7 +19,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_lke_node_pool",
 				IDType: types.StringType,
-				Schema: &resourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/lkenodepool/framework_resource_schema.go
+++ b/linode/lkenodepool/framework_resource_schema.go
@@ -15,7 +15,7 @@ import (
 	linodeplanmodifiers "github.com/linode/terraform-provider-linode/v2/linode/helper/planmodifiers"
 )
 
-var resourceSchema = schema.Schema{
+var frameworkResourceSchema = schema.Schema{
 	Version: 0,
 	Attributes: map[string]schema.Attribute{
 		"id": schema.StringAttribute{

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -23,7 +23,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_nodebalancer",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/nbconfig/framework_resource.go
+++ b/linode/nbconfig/framework_resource.go
@@ -19,7 +19,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_nodebalancer_config",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchemaV1,
+				Schema: frameworkResourceSchemaV1,
 			},
 		),
 	}

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -19,7 +19,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_object_storage_key",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -24,7 +24,7 @@ func NewResource() resource.Resource {
 		BaseResource: helper.NewBaseResource(
 			helper.BaseResourceConfig{
 				Name:   "linode_rdns",
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 				IDType: types.StringType,
 				TimeoutOpts: &timeouts.Opts{
 					Update: true,

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -19,7 +19,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_sshkey",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/stackscript/framework_resource.go
+++ b/linode/stackscript/framework_resource.go
@@ -19,7 +19,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_stackscript",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchemaV1,
+				Schema: frameworkResourceSchemaV1,
 			},
 		),
 	}

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -20,7 +20,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_token",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -27,7 +27,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_volume",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 				TimeoutOpts: &timeouts.Opts{
 					Update: true,
 					Create: true,

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -19,7 +19,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_vpc",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -19,7 +19,7 @@ func NewResource() resource.Resource {
 			helper.BaseResourceConfig{
 				Name:   "linode_vpc_subnet",
 				IDType: types.StringType,
-				Schema: &frameworkResourceSchema,
+				Schema: frameworkResourceSchema,
 			},
 		),
 	}


### PR DESCRIPTION
## 📝 Description

The previous version of Terraform Provider uses a pointer that points to a framework schema while editing a map in the schema from the `Schema` function of the base resource. This caused a concurrent map write issue leading to provider crash.

## ✔️ How to Test
Let's run full integration test on GitHub workflow multiple times to verify the concurrent map issue is gone.
Run 1: https://github.com/linode/terraform-provider-linode/actions/runs/8991257262
Run 2: https://github.com/linode/terraform-provider-linode/actions/runs/8991713925
Run 3: TBD
Local test is not recommended because it will run for more than 30 minutes, but you can still do it:
```bash
make int-test
```