### PR TITLE
new: Add `linode_placement_groups` data source

### DIFF
--- a/docs/resources/placement_groups.md
+++ b/docs/resources/placement_groups.md
@@ -1,0 +1,80 @@
+---
+page_title: "Linode: linode_placement_groups"
+description: |-
+  Lists Linode Placement Groups on your account.
+---
+
+# Data Source: linode\_placement\_groups
+
+Provides information about a list of Linode Placement Groups that match a set of filters.
+
+## Example Usage
+
+The following example shows how one might use this data source to list Placement Groups.
+
+```hcl
+data "linode_placement_groups" "all" {}
+
+data "linode_placement_groups" "filtered" {
+    filter {
+        name = "label"
+        values = ["my-label"]
+    }
+}
+
+output "all-pgs" {
+  value = data.linode_placement_groups.all.placement_groups
+}
+
+output "filtered-pgs" {
+  value = data.linode_placement_groups.filtered.placement_groups
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* [`filter`](#filter) - (Optional) A set of filters used to select Linode Placement Groups that meet certain requirements.
+
+### Filter
+
+* `name` - (Required) The name of the field to filter by. See the [Filterable Fields section](#filterable-fields) for a complete list of filterable fields.
+
+* `values` - (Required) A list of values for the filter to allow. These values should all be in string form.
+
+* `match_by` - (Optional) The method to match the field by. (`exact`, `regex`, `substring`; default `exact`)
+
+## Attributes Reference
+
+Each Linode Placement Group will be stored in the `placement_groups` attribute and will export the following attributes:
+
+* `label` - The label of the Placement Group. This field can only contain ASCII letters, digits and dashes.
+
+* `region` - The region of the Placement Group.
+
+* `affinity_type` - The affinity policy to use when placing Linodes in this group.
+
+* `is_strict` - Whether Linodes must be able to become compliant during assignment. (Default `true`)
+
+* `is_compliant` - Whether all Linodes in this group are currently compliant with the group's affinity policy.
+
+* `members` - A set of Linodes currently assigned to this Placement Group.
+
+  * `linode_id` - The ID of the Linode.
+
+  * `is_compliant` - Whether this Linode is currently compliant with the group's affinity policy.
+
+## Filterable Fields
+
+* `id`
+
+* `label`
+
+* `region`
+
+* `affinity_type`
+
+* `is_strict`
+
+* `is_compliant`

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -53,6 +53,7 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/objcluster"
 	"github.com/linode/terraform-provider-linode/v2/linode/objkey"
 	"github.com/linode/terraform-provider-linode/v2/linode/placementgroup"
+	"github.com/linode/terraform-provider-linode/v2/linode/placementgroups"
 	"github.com/linode/terraform-provider-linode/v2/linode/profile"
 	"github.com/linode/terraform-provider-linode/v2/linode/rdns"
 	"github.com/linode/terraform-provider-linode/v2/linode/region"
@@ -269,5 +270,6 @@ func (p *FrameworkProvider) DataSources(ctx context.Context) []func() datasource
 		lke.NewDataSource,
 		lkeclusters.NewDataSource,
 		placementgroup.NewDataSource,
+		placementgroups.NewDataSource,
 	}
 }

--- a/linode/placementgroup/framework_datasource.go
+++ b/linode/placementgroup/framework_datasource.go
@@ -14,7 +14,7 @@ func NewDataSource() datasource.DataSource {
 		BaseDataSource: helper.NewBaseDataSource(
 			helper.BaseDataSourceConfig{
 				Name:   "linode_placement_group",
-				Schema: &frameworkDatasourceSchema,
+				Schema: &DataSourceSchema,
 			},
 		),
 	}
@@ -59,6 +59,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	data.parsePlacementGroup(pg)
+	data.ParsePlacementGroup(pg)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/linode/placementgroup/framework_datasource_schema.go
+++ b/linode/placementgroup/framework_datasource_schema.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 )
 
-var frameworkDatasourceSchema = schema.Schema{
+var DataSourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
 		"id": schema.Int64Attribute{
 			Description: "The ID of the placement group.",

--- a/linode/placementgroup/framework_models.go
+++ b/linode/placementgroup/framework_models.go
@@ -37,7 +37,7 @@ type PlacementGroupMemberModel struct {
 	IsCompliant types.Bool  `tfsdk:"is_compliant"`
 }
 
-func (data *PlacementGroupDataSourceModel) parsePlacementGroup(
+func (data *PlacementGroupDataSourceModel) ParsePlacementGroup(
 	pg *linodego.PlacementGroup,
 ) {
 	data.Label = types.StringValue(pg.Label)

--- a/linode/placementgroup/framework_models_unit_test.go
+++ b/linode/placementgroup/framework_models_unit_test.go
@@ -30,7 +30,7 @@ func TestFlattenPGModel(t *testing.T) {
 		},
 	}
 
-	model := PlacementGroupModel{}
+	model := PlacementGroupResourceModel{}
 	model.FlattenPlacementGroup(context.Background(), &pg, false)
 
 	require.Equal(t, "123", model.ID.ValueString())

--- a/linode/placementgroups/datasource_test.go
+++ b/linode/placementgroups/datasource_test.go
@@ -1,0 +1,66 @@
+//go:build integration || vpcs
+
+package placementgroups_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/v2/linode/placementgroups/tmpl"
+)
+
+func TestAccDataSourcePlacementGroups_basic(t *testing.T) {
+	t.Parallel()
+
+	const dsAllName = "data.linode_placement_groups.all"
+	const dsByLabelName = "data.linode_placement_groups.by-label"
+	const dsByATName = "data.linode_placement_groups.by-affinity-type"
+
+	baseLabel := acctest.RandomWithPrefix("tf-test")
+
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{"Placement Group"})
+	if err != nil {
+		t.Error(fmt.Errorf("failed to get region with PG capability: %w", err))
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataBasic(t, baseLabel, testRegion),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CheckResourceAttrGreaterThan(dsAllName, "placement_groups.#", 3),
+					resource.TestCheckResourceAttrSet(dsAllName, "placement_groups.0.id"),
+					resource.TestCheckResourceAttrSet(dsAllName, "placement_groups.0.label"),
+					resource.TestCheckResourceAttrSet(dsAllName, "placement_groups.0.affinity_type"),
+					resource.TestCheckResourceAttrSet(dsAllName, "placement_groups.0.region"),
+					resource.TestCheckResourceAttrSet(dsAllName, "placement_groups.0.is_compliant"),
+					resource.TestCheckResourceAttrSet(dsAllName, "placement_groups.0.is_strict"),
+					resource.TestCheckResourceAttrSet(dsAllName, "placement_groups.0.members.#"),
+
+					resource.TestCheckResourceAttr(dsByLabelName, "placement_groups.#", "1"),
+					resource.TestCheckResourceAttrSet(dsByLabelName, "placement_groups.0.id"),
+					resource.TestCheckResourceAttr(dsByLabelName, "placement_groups.0.label", baseLabel+"-1"),
+					resource.TestCheckResourceAttr(dsByLabelName, "placement_groups.0.affinity_type", "anti_affinity:local"),
+					resource.TestCheckResourceAttr(dsByLabelName, "placement_groups.0.region", testRegion),
+					resource.TestCheckResourceAttrSet(dsByLabelName, "placement_groups.0.is_compliant"),
+					resource.TestCheckResourceAttr(dsByLabelName, "placement_groups.0.is_strict", "true"),
+					resource.TestCheckResourceAttr(dsByLabelName, "placement_groups.0.members.#", "0"),
+
+					acceptance.CheckResourceAttrGreaterThan(dsByATName, "placement_groups.#", 3),
+					resource.TestCheckResourceAttrSet(dsByATName, "placement_groups.0.id"),
+					resource.TestCheckResourceAttrSet(dsByATName, "placement_groups.0.label"),
+					resource.TestCheckResourceAttrSet(dsByATName, "placement_groups.0.affinity_type"),
+					resource.TestCheckResourceAttrSet(dsByATName, "placement_groups.0.region"),
+					resource.TestCheckResourceAttrSet(dsByATName, "placement_groups.0.is_compliant"),
+					resource.TestCheckResourceAttrSet(dsByATName, "placement_groups.0.is_strict"),
+					resource.TestCheckResourceAttrSet(dsByATName, "placement_groups.0.members.#"),
+				),
+			},
+		},
+	})
+}

--- a/linode/placementgroups/datasource_test.go
+++ b/linode/placementgroups/datasource_test.go
@@ -1,4 +1,4 @@
-//go:build integration || vpcs
+//go:build integration || placement_groups
 
 package placementgroups_test
 

--- a/linode/placementgroups/framework_datasource.go
+++ b/linode/placementgroups/framework_datasource.go
@@ -1,0 +1,79 @@
+package placementgroups
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper"
+)
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{
+		BaseDataSource: helper.NewBaseDataSource(
+			helper.BaseDataSourceConfig{
+				Name:   "linode_placement_groups",
+				Schema: &frameworkDataSourceSchema,
+			},
+		),
+	}
+}
+
+type DataSource struct {
+	helper.BaseDataSource
+}
+
+func (r *DataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	tflog.Debug(ctx, "Read data.linode_placement_groups")
+
+	var data PlacementGroupFilterModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, d := filterConfig.GenerateID(data.Filters)
+	if d != nil {
+		resp.Diagnostics.Append(d)
+		return
+	}
+	data.ID = id
+
+	result, d := filterConfig.GetAndFilter(
+		ctx,
+		r.Meta.Client,
+		data.Filters,
+		listPlacementGroups,
+		data.Order,
+		data.OrderBy,
+	)
+	if d != nil {
+		resp.Diagnostics.Append(d)
+		return
+	}
+
+	data.ParsePlacementGroups(helper.AnySliceToTyped[linodego.PlacementGroup](result))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func listPlacementGroups(ctx context.Context, client *linodego.Client, filter string) ([]any, error) {
+	pgs, err := client.ListPlacementGroups(ctx, &linodego.ListOptions{
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return helper.TypedSliceToAny(pgs), nil
+}

--- a/linode/placementgroups/framework_models.go
+++ b/linode/placementgroups/framework_models.go
@@ -1,0 +1,34 @@
+package placementgroups
+
+import (
+	"github.com/linode/terraform-provider-linode/v2/linode/placementgroup"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
+)
+
+type PlacementGroupFilterModel struct {
+	ID              types.String                                   `tfsdk:"id"`
+	Filters         frameworkfilter.FiltersModelType               `tfsdk:"filter"`
+	Order           types.String                                   `tfsdk:"order"`
+	OrderBy         types.String                                   `tfsdk:"order_by"`
+	PlacementGroups []placementgroup.PlacementGroupDataSourceModel `tfsdk:"placement_groups"`
+}
+
+func (model *PlacementGroupFilterModel) ParsePlacementGroups(
+	pgs []linodego.PlacementGroup,
+) {
+	pgModels := make([]placementgroup.PlacementGroupDataSourceModel, len(pgs))
+
+	for i, pg := range pgs {
+		pg := pg
+		var pgModel placementgroup.PlacementGroupDataSourceModel
+		pgModel.ID = types.Int64Value(int64(pg.ID))
+		pgModel.ParsePlacementGroup(&pg)
+		pgModels[i] = pgModel
+
+	}
+
+	model.PlacementGroups = pgModels
+}

--- a/linode/placementgroups/framework_schema_datasource.go
+++ b/linode/placementgroups/framework_schema_datasource.go
@@ -1,0 +1,37 @@
+package placementgroups
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
+	"github.com/linode/terraform-provider-linode/v2/linode/placementgroup"
+)
+
+var filterConfig = frameworkfilter.Config{
+	"id":            {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeInt},
+	"label":         {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"region":        {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"affinity_type": {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"is_compliant":  {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
+	"is_strict":     {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
+}
+
+var frameworkDataSourceSchema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Description: "The data source's unique ID.",
+			Computed:    true,
+		},
+		"order":    filterConfig.OrderSchema(),
+		"order_by": filterConfig.OrderBySchema(),
+	},
+	Blocks: map[string]schema.Block{
+		"filter": filterConfig.Schema(),
+		"placement_groups": schema.ListNestedBlock{
+			Description: "The returned list of Placement Groups.",
+			NestedObject: schema.NestedBlockObject{
+				Attributes: placementgroup.DataSourceSchema.Attributes,
+				Blocks:     placementgroup.DataSourceSchema.Blocks,
+			},
+		},
+	},
+}

--- a/linode/placementgroups/tmpl/data_basic.gotf
+++ b/linode/placementgroups/tmpl/data_basic.gotf
@@ -1,0 +1,34 @@
+{{ define "placement_groups_data_basic" }}
+
+data "linode_placement_groups" "all" {
+    depends_on = [linode_placement_group.test]
+}
+
+data "linode_placement_groups" "by-label" {
+    depends_on = [linode_placement_group.test]
+
+    filter {
+        name = "label"
+        values = [linode_placement_group.test[1].label]
+    }
+}
+
+data "linode_placement_groups" "by-affinity-type" {
+    depends_on = [linode_placement_group.test]
+
+    filter {
+        name = "affinity_type"
+        values = ["anti_affinity:local"]
+    }
+}
+
+resource "linode_placement_group" "test" {
+    count = 3
+
+    label = "{{.Label}}-${count.index}"
+    region = "{{.Region}}"
+    affinity_type = "anti_affinity:local"
+    is_strict = true
+}
+
+{{ end }}

--- a/linode/placementgroups/tmpl/template.go
+++ b/linode/placementgroups/tmpl/template.go
@@ -1,0 +1,20 @@
+package tmpl
+
+import (
+	"testing"
+
+	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
+)
+
+type TemplateData struct {
+	Label  string
+	Region string
+}
+
+func DataBasic(t *testing.T, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"placement_groups_data_basic", TemplateData{
+			Label:  label,
+			Region: region,
+		})
+}


### PR DESCRIPTION
## 📝 Description

This pull request adds support for listing and filtering on Placement Groups using a new `linode_placement_groups` data source.

~~This pull request depends on #1409 and will need to be rebased before merging.~~

## ✔️ How to Test

The following test steps assume you have pointed your local environment at a Linode API instance where Placement Groups are available:

```
export LINODE_URL=...
export LINODE_TOKEN=...
```

### Integration Testing

```
make PKG_NAME=linode/placementgroups int-test
```

### Manual Testing

1. In a Terraform provider sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
data "linode_placement_groups" "all" {
  depends_on = [linode_placement_group.test]
}

data "linode_placement_groups" "filtered" {
 depends_on = [linode_placement_group.test]

  filter {
    name = "label"
    values = ["my-placement-group"]
  }
}

resource "linode_placement_group" "test" {
  label = "my-placement-group"
  region = "us-east"
  affinity_type = "anti_affinity:local"
  is_strict = true
}

output "all-pgs" {
  value = data.linode_placement_groups.all.placement_groups
}

output "filtered-pgs" {
  value = data.linode_placement_groups.filtered.placement_groups
}
```
2. Ensure the apply completes successfully.
3. Re-plan the configuration. This is necessary to populate the outputs because of a quirk with how Terraform reads dependent data source & outputs.
4. Ensure the `all-pgs` and `filtered-pgs` outputs are populated as expected in the plan output.