### PR TITLE
Remove explicit log for GET requests

### DIFF
--- a/linode/account/framework_datasource.go
+++ b/linode/account/framework_datasource.go
@@ -67,8 +67,6 @@ func (d *DataSource) Read(
 
 	var data DataSourceModel
 
-	tflog.Trace(ctx, "client.GetAccount(...)")
-
 	account, err := client.GetAccount(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/accountavailability/framework_datasource.go
+++ b/linode/accountavailability/framework_datasource.go
@@ -38,9 +38,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetAccountAvailability(...)", map[string]any{
-		"region": data.Region.ValueString(),
-	})
 	availability, err := client.GetAccountAvailability(ctx, data.Region.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/accountlogin/framework_datasource.go
+++ b/linode/accountlogin/framework_datasource.go
@@ -91,9 +91,7 @@ func (d *DataSource) Read(
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	tflog.Trace(ctx, "client.GetLogin(...)", map[string]any{
-		"login_id": loginID,
-	})
+
 	accountlogin, err := client.GetLogin(ctx, loginID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/accountsettings/framework_datasource.go
+++ b/linode/accountsettings/framework_datasource.go
@@ -49,7 +49,6 @@ func (r *DataSource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetAccountSettings(...)")
 	settings, err := client.GetAccountSettings(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/accountsettings/framework_resource.go
+++ b/linode/accountsettings/framework_resource.go
@@ -74,7 +74,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetAccount(...)")
 	account, err := client.GetAccount(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -84,7 +83,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetAccountSettings(...)")
 	settings, err := client.GetAccountSettings(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/backup/framework_datasource.go
+++ b/linode/backup/framework_datasource.go
@@ -48,7 +48,6 @@ func (d *DataSource) Read(
 	}
 
 	ctx = tflog.SetField(ctx, "linode_id", linodeID)
-	tflog.Trace(ctx, "client.GetInstanceBackups(...)")
 
 	backups, err := client.GetInstanceBackups(ctx, linodeID)
 	if err != nil {

--- a/linode/domain/framework_datasource.go
+++ b/linode/domain/framework_datasource.go
@@ -69,8 +69,6 @@ func (d *DataSource) Read(
 }
 
 func (d *DataSource) getDomainByID(ctx context.Context, id int) (*linodego.Domain, diag.Diagnostic) {
-	tflog.Trace(ctx, "client.GetDomain(...)")
-
 	domain, err := d.Meta.Client.GetDomain(ctx, id)
 	if err != nil {
 		return nil, diag.NewErrorDiagnostic(

--- a/linode/domain/resource.go
+++ b/linode/domain/resource.go
@@ -42,8 +42,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diag.Errorf("Error parsing Linode Domain ID %s as int: %s", d.Id(), err)
 	}
 
-	tflog.Trace(ctx, "client.GetDomain(...)")
-
 	domain, err := client.GetDomain(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/domainrecord/framework_datasource.go
+++ b/linode/domainrecord/framework_datasource.go
@@ -97,8 +97,6 @@ func (d *DataSource) Read(
 
 		ctx = tflog.SetField(ctx, "record_id", recordID)
 
-		tflog.Trace(ctx, "client.GetDomainRecord(...)")
-
 		rec, err := client.GetDomainRecord(ctx, domainID, recordID)
 		if err != nil {
 			resp.Diagnostics.AddError("Error fetching domain record: %v", err.Error())

--- a/linode/domainrecord/resource.go
+++ b/linode/domainrecord/resource.go
@@ -72,8 +72,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	}
 	domainID := d.Get("domain_id").(int)
 
-	tflog.Trace(ctx, "client.GetDomainRecord(...)")
-
 	record, err := client.GetDomainRecord(ctx, domainID, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -248,10 +246,6 @@ func reconcileName(ctx context.Context, client linodego.Client, d *schema.Resour
 	}
 
 	domainId := d.Get("domain_id").(int)
-
-	tflog.Trace(ctx, "client.GetDomain(...)", map[string]any{
-		"domain_id": domainId,
-	})
 
 	domain, err := client.GetDomain(ctx, domainId)
 	if err != nil {

--- a/linode/firewall/framework_datasource.go
+++ b/linode/firewall/framework_datasource.go
@@ -45,7 +45,6 @@ func (d *DataSource) Read(
 
 	ctx = tflog.SetField(ctx, "firewall_id", firewallID)
 
-	tflog.Trace(ctx, "client.GetFirewall(...)")
 	firewall, err := client.GetFirewall(ctx, firewallID)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -55,7 +54,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetFirewallRules(...)")
 	rules, err := client.GetFirewallRules(ctx, firewallID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/firewall/resource.go
+++ b/linode/firewall/resource.go
@@ -53,7 +53,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("failed to parse Firewall %s as int: %s", d.Id(), err)
 	}
 
-	tflog.Trace(ctx, "client.GetFirewall(...)")
 	firewall, err := client.GetFirewall(ctx, id)
 	if err != nil {
 		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code == 404 {
@@ -64,7 +63,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("failed to get firewall %d: %s", id, err)
 	}
 
-	tflog.Trace(ctx, "client.GetFirewallRules(...)")
 	rules, err := client.GetFirewallRules(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get rules for firewall %d: %s", id, err)

--- a/linode/firewalldevice/framework_resource.go
+++ b/linode/firewalldevice/framework_resource.go
@@ -120,8 +120,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetFirewallDevice(...)")
-
 	device, err := client.GetFirewallDevice(ctx, firewallID, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/image/framework_datasource.go
+++ b/linode/image/framework_datasource.go
@@ -49,8 +49,6 @@ func (d *DataSource) Read(
 
 	ctx = tflog.SetField(ctx, "image_id", data.ID.ValueString())
 
-	tflog.Trace(ctx, "client.GetImage(...)")
-
 	image, err := client.GetImage(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/image/framework_resource.go
+++ b/linode/image/framework_resource.go
@@ -249,7 +249,6 @@ func (r *Resource) Read(
 
 	ctx = populateLogAttributes(ctx, imageID)
 
-	tflog.Trace(ctx, "client.GetImage(...)")
 	image, err := client.GetImage(ctx, imageID)
 	if err != nil {
 		if linodego.IsNotFound(err) {

--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -185,7 +185,6 @@ func (r *Resource) Read(
 
 	client := r.Meta.Client
 
-	tflog.Trace(ctx, "client.GetInstanceDisk(...)")
 	disk, err := client.GetInstanceDisk(ctx, linodeID, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -430,7 +429,6 @@ func diskInConfig(
 		return false, nil
 	}
 
-	tflog.Trace(ctx, "client.GetInstanceConfig(...)")
 	cfg, err := client.GetInstanceConfig(ctx, linodeID, configID)
 	if err != nil {
 		return false, err

--- a/linode/instancesharedips/framework_resource.go
+++ b/linode/instancesharedips/framework_resource.go
@@ -213,7 +213,6 @@ func (r *Resource) Delete(
 func GetSharedIPsForLinode(ctx context.Context, client *linodego.Client, linodeID int) ([]string, error) {
 	tflog.Debug(ctx, "Enter GetSharedIPsForLinode")
 
-	tflog.Debug(ctx, "client.GetInstanceIPAddresses(...)")
 	networking, err := client.GetInstanceIPAddresses(ctx, linodeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get instance (%d) networking: %s", linodeID, err)

--- a/linode/ipv6range/framework_datasource.go
+++ b/linode/ipv6range/framework_datasource.go
@@ -46,7 +46,6 @@ func (d *DataSource) Read(
 	rangeStr := rangeStrSplit[0]
 
 	ctx = tflog.SetField(ctx, "ipv6_range", rangeStr)
-	tflog.Trace(ctx, "client.GetIPv6Range(...)")
 
 	rangeData, err := client.GetIPv6Range(ctx, rangeStr)
 	if err != nil {

--- a/linode/ipv6range/framework_resource.go
+++ b/linode/ipv6range/framework_resource.go
@@ -105,8 +105,6 @@ func (r *Resource) Create(
 	// only returns two fields for the newly created range (range and route_target).
 	// We need to make a second call out to the GET endpoint to populate more
 	// computed fields (region, is_bgp, linodes).
-	tflog.Trace(ctx, "client.GetIPv6Range(...)")
-
 	ipv6rangeR, err := client.GetIPv6Range(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -153,7 +151,6 @@ func (r *Resource) Read(
 	}
 
 	ctx = populateLogAttributes(ctx, data)
-	tflog.Trace(ctx, "client.GetIPv6Range(...)")
 
 	ipv6range, err := client.GetIPv6Range(ctx, data.ID.ValueString())
 	if err != nil {
@@ -196,7 +193,6 @@ func (r *Resource) Update(
 	}
 
 	ctx = populateLogAttributes(ctx, plan)
-	tflog.Trace(ctx, "client.GetIPv6Range(...)")
 
 	ipv6range, err := client.GetIPv6Range(ctx, plan.ID.ValueString())
 	if err != nil {

--- a/linode/kernel/framework_datasource.go
+++ b/linode/kernel/framework_datasource.go
@@ -40,7 +40,6 @@ func (d *DataSource) Read(
 	}
 
 	ctx = tflog.SetField(ctx, "kernel_id", data.ID.ValueString())
-	tflog.Trace(ctx, "client.GetKernel(...)")
 
 	kernel, err := client.GetKernel(ctx, data.ID.ValueString())
 	if err != nil {

--- a/linode/lke/framework_datasource.go
+++ b/linode/lke/framework_datasource.go
@@ -48,8 +48,6 @@ func (r *DataSource) Read(
 
 	ctx = tflog.SetField(ctx, "cluster_id", clusterId)
 
-	tflog.Trace(ctx, "client.GetLKECluster(...)")
-
 	cluster, err := client.GetLKECluster(ctx, clusterId)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -70,8 +68,6 @@ func (r *DataSource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetLKEClusterKubeconfig(...)")
-
 	kubeconfig, err := client.GetLKEClusterKubeconfig(ctx, clusterId)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -91,8 +87,6 @@ func (r *DataSource) Read(
 		)
 		return
 	}
-
-	tflog.Trace(ctx, "client.GetLKEClusterDashboard(...)")
 
 	dashboard, err := client.GetLKEClusterDashboard(ctx, clusterId)
 	if err != nil {

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -64,7 +64,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diag.Errorf("failed to parse linode lke cluster pools: %d", id)
 	}
 
-	tflog.Trace(ctx, "client.GetLKECluster(...)")
 	cluster, err := client.GetLKECluster(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -86,7 +85,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		pools = filterExternalPools(ctx, externalPoolTags, pools)
 	}
 
-	tflog.Trace(ctx, "client.GetLKEClusterKubeconfig(...)")
 	kubeconfig, err := client.GetLKEClusterKubeconfig(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get kubeconfig for LKE cluster %d: %s", id, err)
@@ -100,7 +98,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	flattenedControlPlane := flattenLKEClusterControlPlane(cluster.ControlPlane)
 
-	tflog.Trace(ctx, "client.GetLKEClusterDashboard(...)")
 	dashboard, err := client.GetLKEClusterDashboard(ctx, id)
 	if err != nil {
 		return diag.Errorf("failed to get dashboard URL for LKE cluster %d: %s", id, err)

--- a/linode/lkenodepool/framework_resource.go
+++ b/linode/lkenodepool/framework_resource.go
@@ -58,7 +58,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetLKENodePool(...)")
 	nodePool, err := client.GetLKENodePool(ctx, clusterID, poolID)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/nb/framework_datasource.go
+++ b/linode/nb/framework_datasource.go
@@ -49,7 +49,6 @@ func (d *DataSource) Read(
 	}
 
 	ctx = tflog.SetField(ctx, "nodebalancer_id", nodeBalancerID)
-	tflog.Trace(ctx, "client.GetNodeBalancer(...)")
 
 	nodeBalancer, err := client.GetNodeBalancer(ctx, nodeBalancerID)
 	if err != nil {

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -136,7 +136,6 @@ func (r *Resource) Read(
 	}
 
 	ctx = populateLogAttributes(ctx, data)
-	tflog.Trace(ctx, "client.GetNodeBalancer(...)")
 
 	nodeBalancer, err := client.GetNodeBalancer(ctx, id)
 	if err != nil {

--- a/linode/nbconfig/framework_datasource.go
+++ b/linode/nbconfig/framework_datasource.go
@@ -46,11 +46,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	tflog.Debug(ctx, "client.GetNodeBalancerConfig(...)", map[string]any{
-		"nodebalancer_id": nodeBalancerID,
-		"config_id":       configID,
-	})
-
 	config, err := client.GetNodeBalancerConfig(ctx, nodeBalancerID, configID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/nbconfig/framework_resource.go
+++ b/linode/nbconfig/framework_resource.go
@@ -133,8 +133,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetNodeBalancerConfig(...)")
-
 	config, err := client.GetNodeBalancerConfig(ctx, nodeBalancerID, id)
 	if err != nil {
 		if linodego.IsNotFound(err) {

--- a/linode/nbnode/framework_datasource.go
+++ b/linode/nbnode/framework_datasource.go
@@ -52,7 +52,6 @@ func (d *DataSource) Read(
 	}
 
 	ctx = tflog.SetField(ctx, "node_id", id)
-	tflog.Trace(ctx, "client.GetNodeBalancerNode(...)")
 
 	node, err := client.GetNodeBalancerNode(ctx, nodeBalancerID, configID, id)
 	if err != nil {

--- a/linode/nbnode/resource.go
+++ b/linode/nbnode/resource.go
@@ -46,8 +46,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diag.Errorf("Error parsing Linode NodeBalancer ID %v as int", d.Get("config_id"))
 	}
 
-	tflog.Trace(ctx, "client.GetNodeBalancerNode(...)")
-
 	node, err := client.GetNodeBalancerNode(ctx, nodebalancerID, configID, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/networkingip/framework_datasource.go
+++ b/linode/networkingip/framework_datasource.go
@@ -71,7 +71,6 @@ func (d *DataSource) Read(
 	}
 
 	ctx = tflog.SetField(ctx, "address", data.Address.ValueString())
-	tflog.Trace(ctx, "client.GetIPAddress(...)")
 
 	ip, err := d.Meta.Client.GetIPAddress(ctx, data.Address.ValueString())
 	if err != nil {

--- a/linode/objkey/framework_resource.go
+++ b/linode/objkey/framework_resource.go
@@ -114,8 +114,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Debug(ctx, "client.GetObjectStorageKey(...)")
-
 	key, err := client.GetObjectStorageKey(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/profile/framework_datasource.go
+++ b/linode/profile/framework_datasource.go
@@ -95,7 +95,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetProfile(...)")
 	profile, err := client.GetProfile(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -67,10 +67,6 @@ func (r *Resource) Create(
 
 	address := plan.Address.ValueString()
 
-	tflog.Trace(ctx, "client.GetIPAddress(...)", map[string]any{
-		"address": address,
-	})
-
 	ip, err := client.GetIPAddress(ctx, address)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -135,7 +131,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetIPAddress(...)")
 	ip, err := client.GetIPAddress(ctx, data.ID.ValueString())
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/region/framework_datasource.go
+++ b/linode/region/framework_datasource.go
@@ -43,7 +43,6 @@ func (r *DataSource) Read(
 	id := data.ID.ValueString()
 
 	ctx = tflog.SetField(ctx, "region_id", id)
-	tflog.Trace(ctx, "client.GetRegion(...)")
 
 	region, err := client.GetRegion(ctx, id)
 	if err != nil {

--- a/linode/sshkey/framework_resource.go
+++ b/linode/sshkey/framework_resource.go
@@ -97,7 +97,6 @@ func (r *Resource) Read(
 	}
 
 	ctx = tflog.SetField(ctx, "sshkey_id", id)
-	tflog.Trace(ctx, "client.GetSSHKey(...)")
 
 	key, err := client.GetSSHKey(ctx, id)
 	if err != nil {

--- a/linode/stackscript/framework_datasource.go
+++ b/linode/stackscript/framework_datasource.go
@@ -47,8 +47,6 @@ func (r *DataSource) Read(
 
 	tflog.Debug(ctx, "Read data.linode_stackscript")
 
-	tflog.Trace(ctx, "client.GetStackscript(...)")
-
 	stackscript, err := client.GetStackscript(ctx, id)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/stackscript/framework_resource.go
+++ b/linode/stackscript/framework_resource.go
@@ -161,8 +161,6 @@ func (r *Resource) Read(
 
 	ctx = tflog.SetField(ctx, "stackscript_id", id)
 
-	tflog.Trace(ctx, "client.GetStackscript(...)")
-
 	stackscript, err := client.GetStackscript(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/token/framework_resource.go
+++ b/linode/token/framework_resource.go
@@ -109,7 +109,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetToken(...)")
 	token, err := client.GetToken(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -161,7 +160,6 @@ func (r *Resource) Update(
 
 		client := r.Meta.Client
 
-		tflog.Trace(ctx, "client.GetToken(...)")
 		token, err := client.GetToken(ctx, tokenID)
 		if err != nil {
 			resp.Diagnostics.AddError(

--- a/linode/user/framework_datasource.go
+++ b/linode/user/framework_datasource.go
@@ -44,7 +44,6 @@ func (d *DataSource) Read(
 	username := data.Username.ValueString()
 
 	ctx = tflog.SetField(ctx, "username", username)
-	tflog.Trace(ctx, "client.GetUser(...)")
 
 	user, err := client.GetUser(ctx, username)
 	if err != nil {
@@ -60,8 +59,6 @@ func (d *DataSource) Read(
 	}
 
 	if user.Restricted {
-		tflog.Trace(ctx, "client.GetUserGrants(...)")
-
 		grants, err := client.GetUserGrants(ctx, data.Username.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(

--- a/linode/user/resource.go
+++ b/linode/user/resource.go
@@ -71,8 +71,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	username := d.Id()
 
-	tflog.Trace(ctx, "client.GetUser(...)")
-
 	user, err := client.GetUser(ctx, username)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
@@ -84,8 +82,6 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	}
 
 	if user.Restricted {
-		tflog.Trace(ctx, "client.GetUserGrants(...)")
-
 		grants, err := client.GetUserGrants(ctx, username)
 		if err != nil {
 			return diag.Errorf("failed to get user grants (%s): %s", username, err)

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -90,7 +90,6 @@ func (r *Resource) CreateVolumeFromSource(
 	}
 
 	ctx = tflog.SetField(ctx, "source_volume_id", sourceVolumeID)
-	tflog.Trace(ctx, "client.GetVolume(...)")
 
 	sourceVolume, err := client.GetVolume(ctx, sourceVolumeID)
 	if err != nil {
@@ -331,8 +330,6 @@ func (r *Resource) Read(
 	}
 
 	ctx = tflog.SetField(ctx, "volume_id", id)
-
-	tflog.Trace(ctx, "client.GetVolume(...)")
 
 	volume, err := client.GetVolume(ctx, id)
 	if err != nil {

--- a/linode/vpc/framework_datasource.go
+++ b/linode/vpc/framework_datasource.go
@@ -48,7 +48,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetVPC(...)")
 	vpc, err := client.GetVPC(ctx, id)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/vpc/framework_resource.go
+++ b/linode/vpc/framework_resource.go
@@ -98,7 +98,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetVPC(...)")
 	vpc, err := client.GetVPC(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {

--- a/linode/vpcsubnet/framework_datasource.go
+++ b/linode/vpcsubnet/framework_datasource.go
@@ -49,7 +49,6 @@ func (d *DataSource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetVPCSubnet(...)")
 	vpcSubnet, err := client.GetVPCSubnet(ctx, vpcId, id)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/linode/vpcsubnet/framework_resource.go
+++ b/linode/vpcsubnet/framework_resource.go
@@ -130,7 +130,6 @@ func (r *Resource) Read(
 		return
 	}
 
-	tflog.Trace(ctx, "client.GetVPCSubnet(...)")
 	subnet, err := client.GetVPCSubnet(ctx, vpcId, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {


### PR DESCRIPTION
## 📝 Description

Clean up the explicit logs for GET requests, to make log more clear and readable. Keep a couple of GET logs for status polling operations.

Remaining GET logging:
https://github.com/linode/terraform-provider-linode/blob/bc4667484cf2db02f4c80215f0f4eec57076826c/linode/instancedisk/framework_resource.go#L145
https://github.com/linode/terraform-provider-linode/blob/bc4667484cf2db02f4c80215f0f4eec57076826c/linode/instancedisk/framework_resource.go#L280
https://github.com/linode/terraform-provider-linode/blob/0c708610303073b30772fca343e964c858cef2c4/linode/lkenodepool/nodepool.go#L24

