### PR TITLE
new: Add information about Placement Group limits to the `linode_region` and `linode_regions` data sources

### DIFF
--- a/docs/data-sources/region.md
+++ b/docs/data-sources/region.md
@@ -38,8 +38,16 @@ In addition to all arguments above, the following attributes are exported:
 
 * [`resolvers`] (#resolvers) - An object representing the IP addresses for this region's DNS resolvers.
 
+* [`placement_group_limits`] (#placement-group-limits) - An object representing the limits relating to placement groups in this region.
+
 ### Resolvers
 
 * `ipv4` - The IPv4 addresses for this region’s DNS resolvers, separated by commas.
 
 * `ipv6` - The IPv6 addresses for this region’s DNS resolvers, separated by commas.
+
+### Placement Group Limits
+
+* `maximum_pgs_per_customer` - The maximum number of placement groups allowed for the current user in this region.
+
+* `maximum_linodes_per_pg` - The maximum number of Linodes allowed to be assigned to a placement group in this region.

--- a/docs/data-sources/regions.md
+++ b/docs/data-sources/regions.md
@@ -56,11 +56,20 @@ Each Linode region will be stored in the `regions` attribute and will export the
 
 * [`resolvers`] (#resolvers) - An object representing the IP addresses for this region's DNS resolvers.
 
+
+* [`placement_group_limits`] (#placement-group-limits) - An object representing the limits relating to placement groups in this region.
+
 ### Resolvers
 
 * `ipv4` - The IPv4 addresses for this region’s DNS resolvers, separated by commas.
 
 * `ipv6` - The IPv6 addresses for this region’s DNS resolvers, separated by commas.
+
+### Placement Group Limits
+
+* `maximum_pgs_per_customer` - The maximum number of placement groups allowed for the current user in this region.
+
+* `maximum_linodes_per_pg` - The maximum number of Linodes allowed to be assigned to a placement group in this region.
 
 ## Filterable Fields
 

--- a/docs/data-sources/regions.md
+++ b/docs/data-sources/regions.md
@@ -56,7 +56,6 @@ Each Linode region will be stored in the `regions` attribute and will export the
 
 * [`resolvers`] (#resolvers) - An object representing the IP addresses for this region's DNS resolvers.
 
-
 * [`placement_group_limits`] (#placement-group-limits) - An object representing the limits relating to placement groups in this region.
 
 ### Resolvers

--- a/linode/region/datasource_test.go
+++ b/linode/region/datasource_test.go
@@ -59,6 +59,8 @@ func TestAccDataSourceRegion_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "site_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "resolvers.0.ipv4"),
 					resource.TestCheckResourceAttrSet(resourceName, "resolvers.0.ipv6"),
+					resource.TestCheckResourceAttrSet(resourceName, "placement_group_limits.0.maximum_pgs_per_customer"),
+					resource.TestCheckResourceAttrSet(resourceName, "placement_group_limits.0.maximum_linodes_per_pg"),
 					acceptance.CheckResourceAttrGreaterThan(resourceName, "capabilities.#", 0),
 				),
 			},

--- a/linode/region/framework_datasource.go
+++ b/linode/region/framework_datasource.go
@@ -14,7 +14,7 @@ func NewDataSource() datasource.DataSource {
 		BaseDataSource: helper.NewBaseDataSource(
 			helper.BaseDataSourceConfig{
 				Name:   "linode_region",
-				Schema: &frameworkDataSourceSchema,
+				Schema: &DataSourceSchema,
 			},
 		),
 	}
@@ -58,7 +58,7 @@ func (r *DataSource) Read(
 		return
 	}
 
-	data.parseRegion(region)
+	data.ParseRegion(region)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/region/framework_datasource_schema.go
+++ b/linode/region/framework_datasource_schema.go
@@ -1,11 +1,19 @@
 package region
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var frameworkDataSourceSchema = schema.Schema{
+var ObjectTypePGLimits = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"maximum_pgs_per_customer": types.Int64Type,
+		"maximum_linodes_per_pg":   types.Int64Type,
+	},
+}
+
+var DataSourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
 		"country": schema.StringAttribute{
 			Description: "The country where this Region resides.",
@@ -31,6 +39,11 @@ var frameworkDataSourceSchema = schema.Schema{
 		"status": schema.StringAttribute{
 			Description: "This region’s current operational status.",
 			Computed:    true,
+		},
+		"placement_group_limits": schema.ListAttribute{
+			Description: "Information about placement groups limits for this region.",
+			Computed:    true,
+			ElementType: ObjectTypePGLimits,
 		},
 	},
 	Blocks: map[string]schema.Block{

--- a/linode/region/framework_models.go
+++ b/linode/region/framework_models.go
@@ -6,6 +6,12 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
+// RegionPGLimitsModel represents the placement group limits for a .
+type RegionPGLimitsModel struct {
+	MaximumPGsPerCustomer types.Int64 `tfsdk:"maximum_pgs_per_customer"`
+	MaximumLinodesPerPG   types.Int64 `tfsdk:"maximum_linodes_per_pg"`
+}
+
 // RegionResolversModel represents a region's resolver.
 type RegionResolversModel struct {
 	IPv4 types.String `tfsdk:"ipv4"`
@@ -14,16 +20,17 @@ type RegionResolversModel struct {
 
 // RegionModel represents a single region object.
 type RegionModel struct {
-	Country      types.String           `tfsdk:"country"`
-	ID           types.String           `tfsdk:"id"`
-	Label        types.String           `tfsdk:"label"`
-	SiteType     types.String           `tfsdk:"site_type"`
-	Status       types.String           `tfsdk:"status"`
-	Capabilities []types.String         `tfsdk:"capabilities"`
-	Resolvers    []RegionResolversModel `tfsdk:"resolvers"`
+	Country              types.String           `tfsdk:"country"`
+	ID                   types.String           `tfsdk:"id"`
+	Label                types.String           `tfsdk:"label"`
+	SiteType             types.String           `tfsdk:"site_type"`
+	Status               types.String           `tfsdk:"status"`
+	Capabilities         []types.String         `tfsdk:"capabilities"`
+	Resolvers            []RegionResolversModel `tfsdk:"resolvers"`
+	PlacementGroupLimits []RegionPGLimitsModel  `tfsdk:"placement_group_limits"`
 }
 
-func (m *RegionModel) parseRegion(region *linodego.Region) {
+func (m *RegionModel) ParseRegion(region *linodego.Region) {
 	m.ID = types.StringValue(region.ID)
 	m.Label = types.StringValue(region.Label)
 	m.Status = types.StringValue(region.Status)
@@ -37,5 +44,16 @@ func (m *RegionModel) parseRegion(region *linodego.Region) {
 			IPv4: types.StringValue(region.Resolvers.IPv4),
 			IPv6: types.StringValue(region.Resolvers.IPv6),
 		},
+	}
+
+	regionLimits := region.PlacementGroupLimits
+
+	if regionLimits != nil {
+		m.PlacementGroupLimits = []RegionPGLimitsModel{
+			{
+				MaximumPGsPerCustomer: types.Int64Value(int64(regionLimits.MaximumPGsPerCustomer)),
+				MaximumLinodesPerPG:   types.Int64Value(int64(regionLimits.MaximumLinodesPerPG)),
+			},
+		}
 	}
 }

--- a/linode/region/framework_models_unit_test.go
+++ b/linode/region/framework_models_unit_test.go
@@ -21,12 +21,16 @@ func TestParseRegion(t *testing.T) {
 			IPv4: "192.0.2.0,192.0.2.1",
 			IPv6: "2001:0db8::,2001:0db8::1",
 		},
+		PlacementGroupLimits: &linodego.RegionPlacementGroupLimits{
+			MaximumLinodesPerPG:   5,
+			MaximumPGsPerCustomer: 10,
+		},
 		Label: "Newark, NJ, USA",
 	}
 
 	model := &RegionModel{}
 
-	model.parseRegion(region)
+	model.ParseRegion(region)
 
 	assert.Equal(t, types.StringValue("us-east"), model.ID)
 	assert.Equal(t, types.StringValue("Newark, NJ, USA"), model.Label)
@@ -40,4 +44,7 @@ func TestParseRegion(t *testing.T) {
 
 	assert.Equal(t, types.StringValue("192.0.2.0,192.0.2.1"), model.Resolvers[0].IPv4)
 	assert.Equal(t, types.StringValue("2001:0db8::,2001:0db8::1"), model.Resolvers[0].IPv6)
+
+	assert.Equal(t, types.Int64Value(5), model.PlacementGroupLimits[0].MaximumLinodesPerPG)
+	assert.Equal(t, types.Int64Value(10), model.PlacementGroupLimits[0].MaximumPGsPerCustomer)
 }

--- a/linode/regions/datasource_test.go
+++ b/linode/regions/datasource_test.go
@@ -32,6 +32,14 @@ func TestAccDataSourceRegions_basic_smoke(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "regions.0.site_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "regions.0.resolvers.0.ipv4"),
 					resource.TestCheckResourceAttrSet(resourceName, "regions.0.resolvers.0.ipv6"),
+					resource.TestCheckResourceAttrSet(
+						resourceName,
+						"regions.0.placement_group_limits.0.maximum_pgs_per_customer",
+					),
+					resource.TestCheckResourceAttrSet(
+						resourceName,
+						"regions.0.placement_group_limits.0.maximum_linodes_per_pg",
+					),
 					acceptance.CheckResourceAttrGreaterThan(resourceName, "regions.0.capabilities.#", 0),
 					acceptance.CheckResourceAttrGreaterThan(resourceName, "regions.#", 0),
 				),

--- a/linode/regions/framework_datasource_schema.go
+++ b/linode/regions/framework_datasource_schema.go
@@ -2,8 +2,8 @@ package regions
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
+	"github.com/linode/terraform-provider-linode/v2/linode/region"
 )
 
 var filterConfig = frameworkfilter.Config{
@@ -24,49 +24,8 @@ var frameworkDataSourceSchema = schema.Schema{
 		"filter": filterConfig.Schema(),
 		"regions": schema.ListNestedBlock{
 			NestedObject: schema.NestedBlockObject{
-				Attributes: map[string]schema.Attribute{
-					"country": schema.StringAttribute{
-						Description: "The country where this Region resides.",
-						Computed:    true,
-					},
-					"id": schema.StringAttribute{
-						Description: "The unique ID of this Region.",
-						Computed:    true,
-					},
-					"label": schema.StringAttribute{
-						Description: "Detailed location information for this Region, including city, state or region, and country.",
-						Computed:    true,
-					},
-					"site_type": schema.StringAttribute{
-						Description: "The type of this Region.",
-						Computed:    true,
-					},
-					"capabilities": schema.SetAttribute{
-						Description: "A list of capabilities of this Region.",
-						Computed:    true,
-						ElementType: types.StringType,
-					},
-					"status": schema.StringAttribute{
-						Description: "This region’s current operational status.",
-						Computed:    true,
-					},
-				},
-				Blocks: map[string]schema.Block{
-					"resolvers": schema.ListNestedBlock{
-						NestedObject: schema.NestedBlockObject{
-							Attributes: map[string]schema.Attribute{
-								"ipv4": schema.StringAttribute{
-									Description: "The IPv4 addresses for this region’s DNS resolvers, separated by commas.",
-									Computed:    true,
-								},
-								"ipv6": schema.StringAttribute{
-									Description: "The IPv6 addresses for this region’s DNS resolvers, separated by commas.",
-									Computed:    true,
-								},
-							},
-						},
-					},
-				},
+				Attributes: region.DataSourceSchema.Attributes,
+				Blocks:     region.DataSourceSchema.Blocks,
 			},
 		},
 	},

--- a/linode/regions/framework_models.go
+++ b/linode/regions/framework_models.go
@@ -20,6 +20,7 @@ func (model *RegionFilterModel) parseRegions(regions []linodego.Region) {
 	result := make([]regionResource.RegionModel, len(regions))
 
 	for i, region := range regions {
+		region := region
 		model := regionResource.RegionModel{}
 		model.ParseRegion(&region)
 		result[i] = model

--- a/linode/regions/framework_models.go
+++ b/linode/regions/framework_models.go
@@ -4,62 +4,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
+	regionResource "github.com/linode/terraform-provider-linode/v2/linode/region"
 )
-
-// RegionResolversModel represents a region's resolver.
-type RegionResolversModel struct {
-	IPv4 types.String `tfsdk:"ipv4"`
-	IPv6 types.String `tfsdk:"ipv6"`
-}
-
-// RegionModel represents a single region object.
-type RegionModel struct {
-	Country      types.String           `tfsdk:"country"`
-	ID           types.String           `tfsdk:"id"`
-	Label        types.String           `tfsdk:"label"`
-	SiteType     types.String           `tfsdk:"site_type"`
-	Status       types.String           `tfsdk:"status"`
-	Capabilities []types.String         `tfsdk:"capabilities"`
-	Resolvers    []RegionResolversModel `tfsdk:"resolvers"`
-}
 
 // RegionFilterModel describes the Terraform resource data model to match the
 // resource schema.
 type RegionFilterModel struct {
 	ID      types.String                     `tfsdk:"id"`
 	Filters frameworkfilter.FiltersModelType `tfsdk:"filter"`
-	Regions []RegionModel                    `tfsdk:"regions"`
+	Regions []regionResource.RegionModel     `tfsdk:"regions"`
 }
 
 // parseRegions parses the given list of regions into the `regions` model attribute.
 func (model *RegionFilterModel) parseRegions(regions []linodego.Region) {
-	parseRegion := func(region linodego.Region) RegionModel {
-		var m RegionModel
-		m.ID = types.StringValue(region.ID)
-		m.Label = types.StringValue(region.Label)
-		m.Status = types.StringValue(region.Status)
-		m.Country = types.StringValue(region.Country)
-		m.SiteType = types.StringValue(region.SiteType)
-
-		m.Capabilities = make([]types.String, len(region.Capabilities))
-		for k, c := range region.Capabilities {
-			m.Capabilities[k] = types.StringValue(c)
-		}
-
-		m.Resolvers = []RegionResolversModel{
-			{
-				IPv4: types.StringValue(region.Resolvers.IPv4),
-				IPv6: types.StringValue(region.Resolvers.IPv6),
-			},
-		}
-
-		return m
-	}
-
-	result := make([]RegionModel, len(regions))
+	result := make([]regionResource.RegionModel, len(regions))
 
 	for i, region := range regions {
-		result[i] = parseRegion(region)
+		model := regionResource.RegionModel{}
+		model.ParseRegion(&region)
+		result[i] = model
 	}
 
 	model.Regions = result

--- a/linode/regions/framework_models_unit_test.go
+++ b/linode/regions/framework_models_unit_test.go
@@ -23,6 +23,10 @@ func TestParseRegions(t *testing.T) {
 				IPv4: "192.0.2.0,192.0.2.1",
 				IPv6: "2001:0db8::,2001:0db8::1",
 			},
+			PlacementGroupLimits: &linodego.RegionPlacementGroupLimits{
+				MaximumLinodesPerPG:   6,
+				MaximumPGsPerCustomer: 11,
+			},
 		},
 		{
 			ID:           "ap-west",
@@ -34,6 +38,10 @@ func TestParseRegions(t *testing.T) {
 			Resolvers: linodego.RegionResolvers{
 				IPv4: "192.0.2.4,192.0.2.3",
 				IPv6: "2001:0db8::,2001:0db8::3",
+			},
+			PlacementGroupLimits: &linodego.RegionPlacementGroupLimits{
+				MaximumLinodesPerPG:   5,
+				MaximumPGsPerCustomer: 10,
 			},
 		},
 	}
@@ -54,7 +62,20 @@ func TestParseRegions(t *testing.T) {
 		for j, capability := range regions[i].Capabilities {
 			assert.Equal(t, types.StringValue(capability), model.Regions[i].Capabilities[j])
 		}
+
 		assert.Equal(t, types.StringValue(expectedRegion.Resolvers.IPv4), model.Regions[i].Resolvers[0].IPv4)
 		assert.Equal(t, types.StringValue(expectedRegion.Resolvers.IPv6), model.Regions[i].Resolvers[0].IPv6)
+
+		assert.Equal(
+			t,
+			types.Int64Value(int64(expectedRegion.PlacementGroupLimits.MaximumPGsPerCustomer)),
+			model.Regions[i].PlacementGroupLimits[0].MaximumPGsPerCustomer,
+		)
+
+		assert.Equal(
+			t,
+			types.Int64Value(int64(expectedRegion.PlacementGroupLimits.MaximumLinodesPerPG)),
+			model.Regions[i].PlacementGroupLimits[0].MaximumLinodesPerPG,
+		)
 	}
 }


### PR DESCRIPTION
## 📝 Description

This pull request adds the `placement_group_limits` field to the schema for the `linode_region` and `linode_regions` data sources.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and pointed your local environment at an API instance where Placement Groups are enabled:

```
export LINODE_URL=...
export LINODE_TOKEN=...
```

### Unit Testing

```
make unit-test
```

### Integration Testing

```
make PKG_NAME=linode/region int-test
make PKG_NAME=linode/regions int-test
```

### Manual Testing

In a Terraform provider sandbox environment (e.g. dx-devenv), apply the following:

```terraform
output "plural-limits" {
  value = {for r in data.linode_regions.test.regions : r.id => r.placement_group_limits}
}

output "singular-limits" {
  value = {(data.linode_region.test.id): data.linode_region.test.placement_group_limits}
}

data "linode_regions" "test" {
  filter {
    name = "capabilities"
    values = ["Placement Group"]
  }
}

data "linode_region" "test" {
  id = data.linode_regions.test.regions.0.id
}
```

2. Ensure the apply runs successfully and the output looks similar to the following:

```
plural-limits = {
  "eu-west" = tolist([
    {
      "maximum_linodes_per_pg" = 5
      "maximum_pgs_per_customer" = 100
    },
  ])
  "us-east" = tolist([
    {
      "maximum_linodes_per_pg" = 5
      "maximum_pgs_per_customer" = 100
    },
  ])
}
singular-limits = {
  "us-east" = tolist([
    {
      "maximum_linodes_per_pg" = 5
      "maximum_pgs_per_customer" = 100
    },
  ])
}
```