### PR TITLE
fix: Ignore 404 when reading LKE ACL

### DIFF
--- a/docs/resources/lke_cluster.md
+++ b/docs/resources/lke_cluster.md
@@ -62,8 +62,8 @@ resource "linode_lke_cluster" "test" {
         acl {
             enabled = true
             addresses {
-                ipv4 = "0.0.0.0/0"
-                ipv6 = "2001:db8::/32"
+                ipv4 = ["0.0.0.0/0"]
+                ipv6 = ["2001:db8::/32"]
             }
         }
     }

--- a/linode/lke/framework_datasource.go
+++ b/linode/lke/framework_datasource.go
@@ -101,8 +101,9 @@ func (r *DataSource) Read(
 	acl, err := client.GetLKEClusterControlPlaneACL(ctx, clusterId)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok &&
-			lerr.Code == 400 && strings.Contains(lerr.Message, "Cluster does not support Control Plane ACL") {
-			// The cluster does not have a Gateway. Nothing to do here.
+			(lerr.Code == 404 ||
+				(lerr.Code == 400 && strings.Contains(lerr.Message, "Cluster does not support Control Plane ACL"))) {
+			// The customer doesn't have access to LKE or the cluster does not have a Gateway. Nothing to do here.
 		} else {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to get Control Plane ACL for LKE cluster %d", clusterId),

--- a/linode/lke/framework_datasource.go
+++ b/linode/lke/framework_datasource.go
@@ -103,7 +103,7 @@ func (r *DataSource) Read(
 		if lerr, ok := err.(*linodego.Error); ok &&
 			(lerr.Code == 404 ||
 				(lerr.Code == 400 && strings.Contains(lerr.Message, "Cluster does not support Control Plane ACL"))) {
-			// The customer doesn't have access to LKE or the cluster does not have a Gateway. Nothing to do here.
+			// The customer doesn't have access to LKE ACL or the cluster does not have a Gateway. Nothing to do here.
 		} else {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Failed to get Control Plane ACL for LKE cluster %d", clusterId),

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -101,7 +101,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		if lerr, ok := err.(*linodego.Error); ok &&
 			(lerr.Code == 404 ||
 				(lerr.Code == 400 && strings.Contains(lerr.Message, "Cluster does not support Control Plane ACL"))) {
-			// The customer doesn't have access to LKE or the cluster does not have a Gateway. Nothing to do here.
+			// The customer doesn't have access to LKE ACL or the cluster does not have a Gateway. Nothing to do here.
 		} else {
 			return diag.Errorf("failed to get control plane ACL for LKE cluster %d: %s", id, err)
 		}

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -99,8 +99,9 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 	acl, err := client.GetLKEClusterControlPlaneACL(ctx, id)
 	if err != nil {
 		if lerr, ok := err.(*linodego.Error); ok &&
-			lerr.Code == 400 && strings.Contains(lerr.Message, "Cluster does not support Control Plane ACL") {
-			// The cluster does not have a Gateway. Nothing to do here.
+			(lerr.Code == 404 ||
+				(lerr.Code == 400 && strings.Contains(lerr.Message, "Cluster does not support Control Plane ACL"))) {
+			// The customer doesn't have access to LKE or the cluster does not have a Gateway. Nothing to do here.
 		} else {
 			return diag.Errorf("failed to get control plane ACL for LKE cluster %d: %s", id, err)
 		}


### PR DESCRIPTION
## 📝 Description

Ignore the 404 error returned from the ACL read path because of missing customer permission.

Missing permission on the ACL write path will still return a 403 error.

Addressed #1447 

## ✔️ How to Test

```
make PKG_NAME="linode/lke" int-test
```

Manual test:

1. Remove the required tag from your account to perform this test
2. Create a LKE cluster without ACL in the control plane
```
resource "linode_lke_cluster" "test" {
    label       = "my-cluster"     
    k8s_version = "1.28"           
    region      = "us-east"     
    tags        = ["prod"]         
    control_plane {
        high_availability = true
    }
    pool {
        type  = "g6-standard-2"
        count = 1
    }
}
```
3. Observe no error raised
4. Run the following config to read the cluster
```
data "linode_lke_cluster" "test" {
    id = linode_lke_cluster.test.id
}
```
5. Obeserve no error raised during this process
