### PR TITLE
fix: Resolve issues that prevented goreleaser v2.x compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,4 @@
-# Visit https://goreleaser.com for documentation on how to customize this
-# behavior.
+version: 2
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,4 +43,4 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
## 📝 Description

This pull request resolves various issues that prevented our `.goreleaser.yml` file from being compatible with goreleaser v2.x, which is implicitly used by the [Terraform Provider Release action](https://github.com/hashicorp/ghaction-terraform-provider-release).

Test Release: https://github.com/lgarber-akamai/terraform-provider-linode/releases/tag/v0.3.0
Test Release Workflow Run: https://github.com/lgarber-akamai/terraform-provider-linode/actions/runs/9388683947

**Needs backport to dev.**

## ✔️ How to Test

N/A