### PR TITLE
test: Fix e2e test firewall syntax and remove ipv6 dependency

### DIFF
--- a/linode/acceptance/tmpl/e2e_test_firewall.gotf
+++ b/linode/acceptance/tmpl/e2e_test_firewall.gotf
@@ -9,7 +9,7 @@ data "http" "ipv4_addr" {
 }
 
 locals {
-    depends_on = [data.http.ipv4_addr]
+    depends_on = [ data.http.ipv4_addr ]
     valid_ipv4_pattern = "^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)$$"
     valid_ipv6_pattern = "^(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}|(?:[a-fA-F0-9]{1,4}:){1,7}:|(?:[a-fA-F0-9]{1,4}:){1,6}:[a-fA-F0-9]{1,4}|(?:[a-fA-F0-9]{1,4}:){1,5}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,4}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,3}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,2}:(?:[a-fA-F0-9]{1,4}:){1,4}|[a-fA-F0-9]{1,4}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,4}:|:(?::[a-fA-F0-9]{1,4}){1,7}|::|(?:[a-fA-F0-9]{1,4}:){1,7}(?::[a-fA-F0-9]{1,4}){1,7}$$"
     valid_ipv4 = can(regex(local.valid_ipv4_pattern, data.http.ipv4_addr.response_body))
@@ -19,7 +19,7 @@ locals {
 }
 
 resource "linode_firewall" "e2e_test_firewall" {
-    depends_on = [local.ipv4_address]
+    depends_on = [ local.ipv4_address ]
 
     label           = "{{.Label}}"
     outbound_policy = "ACCEPT"

--- a/linode/acceptance/tmpl/e2e_test_firewall.gotf
+++ b/linode/acceptance/tmpl/e2e_test_firewall.gotf
@@ -19,8 +19,6 @@ locals {
 }
 
 resource "linode_firewall" "e2e_test_firewall" {
-    depends_on = [ local.ipv4_address ]
-
     label           = "{{.Label}}"
     outbound_policy = "ACCEPT"
     inbound_policy  = "DROP"

--- a/linode/acceptance/tmpl/e2e_test_firewall.gotf
+++ b/linode/acceptance/tmpl/e2e_test_firewall.gotf
@@ -22,7 +22,7 @@ locals {
 }
 
 resource "linode_firewall" "e2e_test_firewall" {
-    depends_on = local.firewall_dependencies
+    depends_on = [data.http.ipv4_addr, data.http.ipv6_addr]
 
     label           = "{{.Label}}"
     outbound_policy = "ACCEPT"

--- a/linode/acceptance/tmpl/e2e_test_firewall.gotf
+++ b/linode/acceptance/tmpl/e2e_test_firewall.gotf
@@ -9,10 +9,7 @@ data "http" "ipv4_addr" {
 }
 
 locals {
-    firewall_dependencies = [
-        data.http.ipv4_addr,
-        data.http.ipv6_addr
-    ]
+    depends_on = [data.http.ipv4_addr]
     valid_ipv4_pattern = "^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)$$"
     valid_ipv6_pattern = "^(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}|(?:[a-fA-F0-9]{1,4}:){1,7}:|(?:[a-fA-F0-9]{1,4}:){1,6}:[a-fA-F0-9]{1,4}|(?:[a-fA-F0-9]{1,4}:){1,5}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,4}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,3}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,2}:(?:[a-fA-F0-9]{1,4}:){1,4}|[a-fA-F0-9]{1,4}:(?:[a-fA-F0-9]{1,4}:){1,4}|(?:[a-fA-F0-9]{1,4}:){1,4}:|:(?::[a-fA-F0-9]{1,4}){1,7}|::|(?:[a-fA-F0-9]{1,4}:){1,7}(?::[a-fA-F0-9]{1,4}){1,7}$$"
     valid_ipv4 = can(regex(local.valid_ipv4_pattern, data.http.ipv4_addr.response_body))
@@ -22,7 +19,7 @@ locals {
 }
 
 resource "linode_firewall" "e2e_test_firewall" {
-    depends_on = [data.http.ipv4_addr, data.http.ipv6_addr]
+    depends_on = [local.ipv4_address]
 
     label           = "{{.Label}}"
     outbound_policy = "ACCEPT"

--- a/linode/user/tmpl/grants_update.gotf
+++ b/linode/user/tmpl/grants_update.gotf
@@ -1,14 +1,12 @@
 {{ define "user_grants_update" }}
 
-{{ template "e2e_test_firewall" . }}
-
 # TODO: reuse no image instance template defined in instance
 resource "linode_instance" "foobar" {
     label = "{{.InstLabel}}"
     group = "tf_test"
     type = "g6-nanode-1"
     region = "us-east"
-    firewall_id = linode_firewall.e2e_test_firewall.id
+    booted = false
 }
 
 resource "linode_user" "test" {


### PR DESCRIPTION
## 📝 Description

Fixing https://github.com/linode/terraform-provider-linode/actions/runs/9389098679
- Also removing ipv6 dependency in the firewall because gha does not support ipv6
- Update TestAccResourceUser_grants 

## ✔️ How to Test

`make test`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**