### PR TITLE
add `obj_bucket_force_delete` config option to delete buckets with objects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ This section outlines commonly used provider configuration options.
 
 * `obj_use_temp_keys` - (Optional) If true, temporary object keys will be created implicitly at apply-time for the [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) and [linode_object_storage_object](/docs/resources/object_storage_object.md) resource to use.
 
-* `obj_bucket_force_delete` - (Optional) If true, When deleting a [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) resource all objects, and versions will be purged from the bucket.
+* `obj_bucket_force_delete` - (Optional) If true, all objects and versions will purged from a [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) before it is destroyed.
 
 * `skip_instance_ready_poll` - (Optional) Skip waiting for a linode_instance resource to be running.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,8 @@ This section outlines commonly used provider configuration options.
 
 * `obj_use_temp_keys` - (Optional) If true, temporary object keys will be created implicitly at apply-time for the [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) and [linode_object_storage_object](/docs/resources/object_storage_object.md) resource to use.
 
+* `obj_bucket_force_delete` - (Optional) If true, When deleting a [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) resource all objects, and versions will be purged from the bucket.
+
 * `skip_instance_ready_poll` - (Optional) Skip waiting for a linode_instance resource to be running.
 
 * `skip_instance_delete_poll` - (Optional) Skip waiting for a linode_instance resource to finish deleting.

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -183,6 +183,11 @@ func (p *FrameworkProvider) Schema(
 				Description: "If true, temporary object keys will be created implicitly at apply-time " +
 					"for the linode_object_storage_object and linode_object_sorage_bucket resource.",
 			},
+			"obj_bucket_force_delete": schema.BoolAttribute{
+				Optional: true,
+				Description: "If true, when deleting a linode_object_storage_bucket any objects " +
+					"and versions will be force deleted.",
+			},
 		},
 	}
 }

--- a/linode/framework_provider_config.go
+++ b/linode/framework_provider_config.go
@@ -206,6 +206,9 @@ func (fp *FrameworkProvider) HandleDefaults(
 	if lpm.ObjUseTempKeys.IsNull() {
 		lpm.ObjUseTempKeys = types.BoolValue(false)
 	}
+	if lpm.ObjBucketForceDelete.IsNull() {
+		lpm.ObjBucketForceDelete = types.BoolValue(false)
+	}
 }
 
 func (fp *FrameworkProvider) InitProvider(

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -47,9 +47,10 @@ type Config struct {
 	LKEEventPollMilliseconds     int
 	LKENodeReadyPollMilliseconds int
 
-	ObjAccessKey   string
-	ObjSecretKey   string
-	ObjUseTempKeys bool
+	ObjAccessKey         string
+	ObjSecretKey         string
+	ObjUseTempKeys       bool
+	ObjBucketForceDelete bool
 }
 
 // Client returns a fully initialized Linode client.

--- a/linode/helper/framework_provider_model.go
+++ b/linode/helper/framework_provider_model.go
@@ -26,6 +26,7 @@ func GetFrameworkProviderModelFromSDKv2ProviderConfig(config *Config) *Framework
 		ObjAccessKey:                 types.StringValue(config.ObjAccessKey),
 		ObjSecretKey:                 types.StringValue(config.ObjSecretKey),
 		ObjUseTempKeys:               types.BoolValue(config.ObjUseTempKeys),
+		ObjBucketForceDelete:         types.BoolValue(config.ObjBucketForceDelete),
 	}
 }
 
@@ -53,9 +54,10 @@ type FrameworkProviderModel struct {
 
 	LKENodeReadyPollMilliseconds types.Int64 `tfsdk:"lke_node_ready_poll_ms"`
 
-	ObjAccessKey   types.String `tfsdk:"obj_access_key"`
-	ObjSecretKey   types.String `tfsdk:"obj_secret_key"`
-	ObjUseTempKeys types.Bool   `tfsdk:"obj_use_temp_keys"`
+	ObjAccessKey         types.String `tfsdk:"obj_access_key"`
+	ObjSecretKey         types.String `tfsdk:"obj_secret_key"`
+	ObjUseTempKeys       types.Bool   `tfsdk:"obj_use_temp_keys"`
+	ObjBucketForceDelete types.Bool   `tfsdk:"obj_bucket_force_delete"`
 }
 
 type FrameworkProviderMeta struct {

--- a/linode/helper/objects.go
+++ b/linode/helper/objects.go
@@ -159,6 +159,10 @@ func DeleteAllObjects(
 		}
 	}
 
+	if len(objectsToDelete) == 0 {
+		return nil
+	}
+
 	tflog.Debug(ctx, fmt.Sprintf("Deleting all keys in the list: %v", objectsToDelete))
 	_, err := s3client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
 		Bucket:                    aws.String(bucketName),
@@ -211,6 +215,10 @@ func DeleteAllObjectVersionsAndDeleteMarkers(ctx context.Context, client *s3.Cli
 				},
 			)
 		}
+	}
+
+	if len(objectsToDelete) == 0 {
+		return nil
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Delete all versions and delete markers in the list: %v", objectsToDelete))

--- a/linode/objbucket/tmpl/force_delete.gotf
+++ b/linode/objbucket/tmpl/force_delete.gotf
@@ -1,0 +1,31 @@
+{{ define "object_bucket_force_delete" }}
+
+provider "linode" {
+    obj_use_temp_keys = true
+    obj_bucket_force_delete = true
+}
+
+resource "linode_object_storage_bucket" "foobar" {
+    cluster = "{{ .Cluster }}"
+    label = "{{ .Label }}"
+
+    lifecycle_rule {
+        prefix = "tf"
+        enabled = true
+
+        abort_incomplete_multipart_upload_days = 5
+
+        expiration {
+            date = "2024-06-21"
+        }
+    }
+}
+
+resource "linode_object_storage_object" "test" {
+    bucket     = linode_object_storage_bucket.foobar.label
+    cluster    = "{{ .Cluster }}"
+    key        = "{{ .Key }}"
+    content = "cool"
+}
+
+{{ end }}

--- a/linode/objbucket/tmpl/force_delete_empty.gotf
+++ b/linode/objbucket/tmpl/force_delete_empty.gotf
@@ -1,0 +1,8 @@
+{{ define "object_bucket_force_delete_empty" }}
+
+provider "linode" {
+    obj_use_temp_keys = true
+    obj_bucket_force_delete = true
+}
+
+{{ end }}

--- a/linode/objbucket/tmpl/template.go
+++ b/linode/objbucket/tmpl/template.go
@@ -105,6 +105,19 @@ func TempKeys(t *testing.T, label, cluster, keyName string) string {
 		})
 }
 
+func ForceDelete(t *testing.T, label, cluster, keyName string) string {
+	return acceptance.ExecuteTemplate(t,
+		"object_bucket_force_delete", TemplateData{
+			Key:     objkey.TemplateData{Label: keyName},
+			Label:   label,
+			Cluster: cluster,
+		})
+}
+
+func ForceDelete_Empty(t *testing.T) string {
+	return acceptance.ExecuteTemplate(t, "object_bucket_force_delete_empty", nil)
+}
+
 func ClusterDataBasic(t *testing.T, label, cluster string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_bucket_cluster_data_basic", TemplateData{

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -129,6 +129,12 @@ func Provider() *schema.Provider {
 				Description: "If true, temporary object keys will be created implicitly at apply-time " +
 					"for the linode_object_storage_object and linode_object_sorage_bucket resource.",
 			},
+			"obj_bucket_force_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: "If true, when deleting a linode_object_storage_bucket any objects " +
+					"and versions will be force deleted.",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -259,7 +265,8 @@ func providerConfigure(
 		MinRetryDelayMilliseconds: d.Get("min_retry_delay_ms").(int),
 		MaxRetryDelayMilliseconds: d.Get("max_retry_delay_ms").(int),
 
-		ObjUseTempKeys: d.Get("obj_use_temp_keys").(bool),
+		ObjUseTempKeys:       d.Get("obj_use_temp_keys").(bool),
+		ObjBucketForceDelete: d.Get("obj_bucket_force_delete").(bool),
 	}
 
 	handleDefault(config, d)


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Allows users to set a `obj_bucket_force_delete` flag which will purge a bucket deleted by Terraform of all its objects.

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

```bash
make int-test PKG_NAME="linode/objbucket" ARGS="-run TestAccResourceBucket_forceDelete"
```

1. In a sandbox environment create the following file
```terraform
terraform {
  required_providers {
    linode = {
      source  = "linode/linode"
      version = "2.6.0"
    }
  }
}

provider "linode" {
    obj_use_temp_keys = true
    obj_bucket_force_delete = true
}

resource "linode_object_storage_bucket" "test" {
    cluster = "us-mia-1"
    label = "test-obj-bucket"

    lifecycle_rule {
        prefix = "tf"
        enabled = true

        abort_incomplete_multipart_upload_days = 5

        expiration {
            date = "2024-03-21"
        }
    }
}

resource "linode_object_storage_object" "test" {
    bucket     = linode_object_storage_bucket.test.label
    cluster    = "us-mia-1"
    key        = "foobar"
    content = "cool"
}
```
2. Run `terraform apply`
3. Confirm the bucket/object was created
4. Using another tool add more Objects
```bash
linode-cli obj put ./Makefile test-obj-bucket --cluster us-mia-1
```
5. Comment out or delete the bucket and object resources from your terraform file
```terraform
terraform {
  required_providers {
    linode = {
      source  = "linode/linode"
      version = "2.6.0"
    }
  }
}

provider "linode" {
    obj_use_temp_keys = true
    obj_bucket_force_delete = true
}
```
6. Confirm that the action deleted the bucket and all objects
```bash
linode-cli obj ls test-obj-bucket --cluster us-mia-1
```

resolves #1129 