### PR TITLE
doc: Add notes to documentation for limited LKE ACL availability

### DIFF
--- a/docs/data-sources/lke_cluster.md
+++ b/docs/data-sources/lke_cluster.md
@@ -82,7 +82,7 @@ In addition to all arguments above, the following attributes are exported:
 
   * `high_availability` - Whether High Availability is enabled for the cluster Control Plane.
   
-  * `acl` - The ACL configuration for an LKE cluster's control plane.
+  * `acl` - The ACL configuration for an LKE cluster's control plane. **NOTE: Control Plane ACLs may not currently be available to all users.**
 
     * `enabled` - The default policy. A value of true means a default policy of DENY. A value of false means a default policy of ALLOW.
 

--- a/docs/resources/lke_cluster.md
+++ b/docs/resources/lke_cluster.md
@@ -59,6 +59,9 @@ resource "linode_lke_cluster" "test" {
 
     control_plane {
         high_availability = true
+      
+        # NOTE: Control Plane ACLs may not currently be available to
+        # all users.
         acl {
             enabled = true
             addresses {
@@ -121,7 +124,7 @@ The following arguments are supported in the `control_plane` specification block
 
 * `high_availability` - (Optional) Defines whether High Availability is enabled for the cluster Control Plane. This is an **irreversible** change.
 
-* [`acl`](#acl) - (Optional) Defines the ACL configuration for an LKE cluster's control plane.
+* [`acl`](#acl) - (Optional) Defines the ACL configuration for an LKE cluster's control plane. **NOTE: Control Plane ACLs may not currently be available to  all users.**
 
 ### acl
 


### PR DESCRIPTION
## 📝 Description

This pull request adds notes to the `linode_lke_cluster` and `data.linode_lke_cluster` documentation suggesting that LKE ACLs may not be currently available to users.

## ✔️ How to Test

N/A

## 📷 Preview

<img width="669" alt="Doc_Preview_Tool___Terraform_Registry" src="https://github.com/linode/terraform-provider-linode/assets/114949949/541e14d5-17f5-4e99-b9cf-d45bef4794ec">
<img width="701" alt="Doc_Preview_Tool___Terraform_Registry" src="https://github.com/linode/terraform-provider-linode/assets/114949949/0e1c4f6f-a8e0-46c8-b226-913b7d180fb2">
