### PR TITLE
test: Add Calico Inbound and Outbound policies to LKE nodes for E2E

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -46,7 +46,7 @@ jobs:
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_1 }}" >> $GITHUB_ENV
               ;;
             "USER_2")
-              echo "TEST_TAGS=instancenetworking,instancesharedips,instancetype,instancetypes,ipv6range,ipv6ranges,kernel,kernels,lke,nb,nbconfig,nbconfigs,nbnode,nbs,sshkey,sshkeys" >> $GITHUB_ENV
+              echo "TEST_TAGS=instancenetworking,instancesharedips,instancetype,instancetypes,ipv6range,ipv6ranges,kernel,kernels,nb,nbconfig,nbconfigs,nbnode,nbs,sshkey,sshkeys" >> $GITHUB_ENV
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_2 }}" >> $GITHUB_ENV
               ;;
             "USER_3")
@@ -54,7 +54,7 @@ jobs:
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_3 }}" >> $GITHUB_ENV
               ;;
             "USER_4")
-              echo "TEST_TAGS=firewall,firewalldevice,firewalls,image,images,lkeclusters,lkenodepool,lkeversions,obj,objbucket,token,user,users,vlan,volume,volumes,vpc,vpcs" >> $GITHUB_ENV
+              echo "TEST_TAGS=firewall,firewalldevice,firewalls,image,images,lke,lkeclusters,lkenodepool,lkeversions,obj,objbucket,token,user,users,vlan,volume,volumes,vpc,vpcs" >> $GITHUB_ENV
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_4 }}" >> $GITHUB_ENV
               ;;
           esac
@@ -119,3 +119,30 @@ jobs:
         env:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
+
+
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration_tests]
+    if: always()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE # Only Running against Matrix USER 4 which includes LKE test suite
+        run: |
+          cd scripts && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN_USER_4 }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -46,7 +46,7 @@ jobs:
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_1 }}" >> $GITHUB_ENV
               ;;
             "USER_2")
-              echo "TEST_TAGS=instancenetworking,instancesharedips,instancetype,instancetypes,ipv6range,ipv6ranges,kernel,kernels,nb,nbconfig,nbconfigs,nbnode,nbs,sshkey,sshkeys" >> $GITHUB_ENV
+              echo "TEST_TAGS=firewall,firewalldevice,firewalls,image,images,instancenetworking,instancesharedips,instancetype,instancetypes,ipv6range,ipv6ranges,kernel,kernels,nb,nbconfig,nbconfigs,nbnode,nbs,sshkey,sshkeys" >> $GITHUB_ENV
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_2 }}" >> $GITHUB_ENV
               ;;
             "USER_3")
@@ -54,7 +54,7 @@ jobs:
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_3 }}" >> $GITHUB_ENV
               ;;
             "USER_4")
-              echo "TEST_TAGS=firewall,firewalldevice,firewalls,image,images,lke,lkeclusters,lkenodepool,lkeversions,obj,objbucket,token,user,users,vlan,volume,volumes,vpc,vpcs" >> $GITHUB_ENV
+              echo "TEST_TAGS=lke,lkeclusters,lkenodepool,lkeversions,obj,objbucket,token,user,users,vlan,volume,volumes,vpc,vpcs" >> $GITHUB_ENV
               echo "LINODE_TOKEN=${{ secrets.LINODE_TOKEN_USER_4 }}" >> $GITHUB_ENV
               ;;
           esac

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -52,11 +52,26 @@ jobs:
 
       - run: make deps
 
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
       - run: make PKG_NAME="${{ inputs.module }}" int-test
         if: ${{ steps.disallowed-character-check.outputs.result == 'pass' }}
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           RUN_LONG_TESTS: ${{ inputs.run_long_tests }}
+
+      - name: Apply Calico Rules to LKE
+        if: always()
+        run: |
+          cd scripts && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
       
       - name: Get the hash value of the latest commit from the PR branch
         uses: octokit/graphql-action@v2.x

--- a/scripts/lke-policy.yaml
+++ b/scripts/lke-policy.yaml
@@ -1,0 +1,78 @@
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: lke-rules
+spec:
+  preDNAT: true
+  applyOnForward: true
+  order: 100
+  # Remember to run calicoctl patch command for this to work
+  selector: ""
+  ingress:
+    # Allow ICMP
+    - action: Allow
+      protocol: ICMP
+    - action: Allow
+      protocol: ICMPv6
+
+    # Allow LKE-required ports
+    - action: Allow
+      protocol: TCP
+      destination:
+        nets:
+          - 192.168.128.0/17
+          - 10.0.0.0/8
+        ports:
+          - 10250
+          - 10256
+          - 179
+    - action: Allow
+      protocol: UDP
+      destination:
+        nets:
+          - 192.168.128.0/17
+          - 10.2.0.0/16
+        ports:
+          - 51820
+
+    # Allow NodeBalancer ingress to the Node Ports & Allow DNS
+    - action: Allow
+      protocol: TCP
+      source:
+        nets:
+          - 192.168.255.0/24
+          - 10.0.0.0/8
+      destination:
+        ports:
+          - 53
+          - 30000:32767
+    - action: Allow
+      protocol: UDP
+      source:
+        nets:
+          - 192.168.255.0/24
+          - 10.0.0.0/8
+      destination:
+        ports:
+          - 53
+          - 30000:32767
+
+    # Allow cluster internal communication
+    - action: Allow
+      destination:
+        nets:
+          - 10.0.0.0/8
+    - action: Allow
+      source:
+        nets:
+          - 10.0.0.0/8
+
+    # 127.0.0.1/32 is needed for kubectl exec and node-shell
+    - action: Allow
+      destination:
+        nets:
+          - 127.0.0.1/32
+
+    # Block everything else
+    - action: Deny
+    - action: Log

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+RETRIES=3
+DELAY=30
+
+# Function to retry a command with exponential backoff
+retry_command() {
+    local retries=$1
+    local wait_time=60
+    shift
+    until "$@"; do
+        if ((retries == 0)); then
+            echo "Command failed after multiple retries. Exiting."
+            exit 1
+        fi
+        echo "Command failed. Retrying in $wait_time seconds..."
+        sleep $wait_time
+        ((retries--))
+        wait_time=$((wait_time * 2))
+    done
+}
+
+# Fetch the list of LKE cluster IDs
+CLUSTER_IDS=$(curl -s -H "Authorization: Bearer $LINODE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://api.linode.com/v4/lke/clusters" | jq -r '.data[].id')
+
+# Check if CLUSTER_IDS is empty
+if [ -z "$CLUSTER_IDS" ]; then
+    echo "All clusters have been cleaned and properly destroyed. No need to apply inbound or outbound rules"
+    exit 0
+fi
+
+for ID in $CLUSTER_IDS; do
+    echo "Applying Calico rules to nodes in Cluster ID: $ID"
+
+    # Download cluster configuration file with retry
+    for ((i=1; i<=RETRIES; i++)); do
+        config_response=$(curl -sH "Authorization: Bearer $LINODE_TOKEN" "https://api.linode.com/v4/lke/clusters/$ID/kubeconfig")
+        if [[ $config_response != *"kubeconfig is not yet available"* ]]; then
+            echo $config_response | jq -r '.[] | @base64d' > "${ID}_config.yaml"
+            break
+        fi
+        echo "Attempt $i to download kubeconfig for cluster $ID failed. Retrying in $DELAY seconds..."
+        sleep $DELAY
+    done
+
+    if [[ $config_response == *"kubeconfig is not yet available"* ]]; then
+        echo "kubeconfig for cluster id:$ID not available after $RETRIES attempts, mostly likely it is an empty cluster. Skipping..."
+    else
+        # Export downloaded config file
+        export KUBECONFIG="$(pwd)/${ID}_config.yaml"
+
+        retry_command $RETRIES kubectl get nodes
+
+        retry_command $RETRIES calicoctl patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
+
+        retry_command $RETRIES calicoctl apply -f "$(pwd)/lke-policy.yaml"
+    fi
+done


### PR DESCRIPTION
## 📝 Description

A new script, `lke_calico_rules_e2e.sh`, has been added and is called in the E2E workflow file after the `Run the integration test suite step` in `e2e-suite.yml`

Key Points:
- `kubectl` and `calicoctl` binaries are required as pre-req which are downloed in the e2e worflow file
- The script retrieves all LKE clusters in the test account and applies Calico rules to the corresponding nodes. If no clusters exist, no action is taken. In most cases, clusters are cleaned and deleted properly after test execution
- Due to the delay in the availability of LKE cluster configurations and the provisioning times of node instances, it is challenging to apply Calico rules directly within the test framework. Therefore, the script is separated and executed independently in the workflow file

## ✔️ How to Test

https://github.com/ykim-1/terraform-provider-linode/actions/runs/9488084325/job/26147468599

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**