### PR TITLE
Add Region Support for OBJ (file) Resource

### DIFF
--- a/docs/resources/object_storage_object.md
+++ b/docs/resources/object_storage_object.md
@@ -85,9 +85,11 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to put the object in.
 
-* `cluster` - (Required) The cluster the bucket is in.
-
 * `key` - (Required) They name of the object once it is in the bucket.
+
+* `region` - The cluster the bucket is in. Required if `cluster` is not configured.
+
+* `cluster` - (Deprecated) The cluster the bucket is in. Required if `region` is not configured. Deprecated in favor of `region`.
 
 * `secret_key` - (Optional) The REQUIRED secret key to authenticate with. If it's not specified with the resource, you must provide its value by
   * configuring the [`obj_secret_key`](../index.md#configuration-reference) in the provider configuration;

--- a/linode/obj/resource.go
+++ b/linode/obj/resource.go
@@ -46,17 +46,18 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 
 	config := meta.(*helper.ProviderMeta).Config
 	client := meta.(*helper.ProviderMeta).Client
-	cluster := d.Get("cluster").(string)
+	regionOrCluster := helper.GetRegionOrCluster(d)
+
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 
-	objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, cluster, "read_only")
-	if diags != nil {
-		return diags
-	}
-
+	objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, regionOrCluster, "read_only")
 	if teardownKeysCleanUp != nil {
 		defer teardownKeysCleanUp()
+	}
+
+	if diags != nil {
+		return diags
 	}
 
 	s3client, err := helper.S3ConnectionFromData(ctx, d, meta, objKeys.AccessKey, objKeys.SecretKey)
@@ -118,7 +119,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return putObject(ctx, d, meta)
 	}
 
-	cluster := d.Get("cluster").(string)
+	regionOrCluster := helper.GetRegionOrCluster(d)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 	acl := s3types.ObjectCannedACL(d.Get("acl").(string))
@@ -127,7 +128,7 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		config := meta.(*helper.ProviderMeta).Config
 		client := meta.(*helper.ProviderMeta).Client
 
-		objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, cluster, "read_write")
+		objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, regionOrCluster, "read_write")
 		if diags != nil {
 			return diags
 		}
@@ -167,12 +168,12 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	config := meta.(*helper.ProviderMeta).Config
 	client := meta.(*helper.ProviderMeta).Client
-	cluster := d.Get("cluster").(string)
+	regionOrCluster := helper.GetRegionOrCluster(d)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 	force := d.Get("force_destroy").(bool)
 
-	objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, cluster, "read_write")
+	objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, regionOrCluster, "read_write")
 	if diags != nil {
 		return diags
 	}
@@ -214,11 +215,11 @@ func putObject(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 
 	config := meta.(*helper.ProviderMeta).Config
 	client := meta.(*helper.ProviderMeta).Client
-	cluster := d.Get("cluster").(string)
+	regionOrCluster := helper.GetRegionOrCluster(d)
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
 
-	objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, cluster, "read_write")
+	objKeys, diags, teardownKeysCleanUp := GetObjKeys(ctx, d, config, client, bucket, regionOrCluster, "read_write")
 	if diags != nil {
 		return diags
 	}

--- a/linode/obj/schema_resource.go
+++ b/linode/obj/schema_resource.go
@@ -14,10 +14,18 @@ var resourceSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"cluster": {
-		Type:        schema.TypeString,
-		Description: "The target cluster that the bucket is in.",
-		Required:    true,
-		ForceNew:    true,
+		Type:         schema.TypeString,
+		Description:  "The target cluster that the bucket is in.",
+		Optional:     true,
+		ForceNew:     true,
+		ExactlyOneOf: []string{"cluster", "region"},
+	},
+	"region": {
+		Type:         schema.TypeString,
+		Description:  "The target cluster that the bucket is in.",
+		Optional:     true,
+		ForceNew:     true,
+		ExactlyOneOf: []string{"cluster", "region"},
 	},
 	"key": {
 		Type:        schema.TypeString,

--- a/linode/obj/schema_resource.go
+++ b/linode/obj/schema_resource.go
@@ -22,7 +22,7 @@ var resourceSchema = map[string]*schema.Schema{
 	},
 	"region": {
 		Type:         schema.TypeString,
-		Description:  "The target cluster that the bucket is in.",
+		Description:  "The target region that the bucket is in.",
 		Optional:     true,
 		ForceNew:     true,
 		ExactlyOneOf: []string{"cluster", "region"},

--- a/linode/obj/tmpl/basic.gotf
+++ b/linode/obj/tmpl/basic.gotf
@@ -5,7 +5,11 @@
 
 resource "linode_object_storage_object" "basic" {
     bucket     = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region     = "{{.Region}}"
+    {{else}}
     cluster    = "{{ .Cluster }}"
+    {{end}}
     access_key = linode_object_storage_key.foobar.access_key
     secret_key = linode_object_storage_key.foobar.secret_key
     key        = "test_basic"
@@ -14,7 +18,11 @@ resource "linode_object_storage_object" "basic" {
 
 resource "linode_object_storage_object" "base64" {
     bucket         = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region         = "{{.Region}}"
+    {{else}}
     cluster        = "{{ .Cluster }}"
+    {{end}}
     access_key     = linode_object_storage_key.foobar.access_key
     secret_key     = linode_object_storage_key.foobar.secret_key
     key            = "test_base64"
@@ -23,7 +31,11 @@ resource "linode_object_storage_object" "base64" {
 
 resource "linode_object_storage_object" "source" {
     bucket     = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region     = "{{.Region}}"
+    {{else}}
     cluster    = "{{ .Cluster }}"
+    {{end}}
     access_key = linode_object_storage_key.foobar.access_key
     secret_key = linode_object_storage_key.foobar.secret_key
     key        = "test_source"

--- a/linode/obj/tmpl/creds_configed.gotf
+++ b/linode/obj/tmpl/creds_configed.gotf
@@ -13,7 +13,11 @@ resource "linode_object_storage_object" "creds_configed" {
     provider = linode.creds_configed
 
     bucket     = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region     = "{{.Region}}"
+    {{else}}
     cluster    = "{{ .Cluster }}"
+    {{end}}
     key        = "test_creds_configed"
     content    = "{{.Content}}"
 }

--- a/linode/obj/tmpl/temp_keys.gotf
+++ b/linode/obj/tmpl/temp_keys.gotf
@@ -8,7 +8,11 @@ provider "linode" {
 
 resource "linode_object_storage_object" "temp_keys" {
     bucket     = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region     = "{{.Region}}"
+    {{else}}
     cluster    = "{{ .Cluster }}"
+    {{end}}
     key        = "test_temp_keys"
     content    = "{{.Content}}"
 }

--- a/linode/obj/tmpl/template.go
+++ b/linode/obj/tmpl/template.go
@@ -12,12 +12,13 @@ type TemplateData struct {
 	Bucket  objectbucket.TemplateData
 	Key     objectkey.TemplateData
 	Cluster string
+	Region  string
 
 	Content string
 	Source  string
 }
 
-func Basic(t *testing.T, name, cluster, keyName, content, source string) string {
+func BasicWithCluster(t *testing.T, name, cluster, keyName, content, source string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_object_basic", TemplateData{
 			Bucket:  objectbucket.TemplateData{Label: name, Cluster: cluster},
@@ -28,33 +29,44 @@ func Basic(t *testing.T, name, cluster, keyName, content, source string) string 
 		})
 }
 
-func Updates(t *testing.T, name, cluster, keyName, content, source string) string {
+func Basic(t *testing.T, name, region, keyName, content, source string) string {
 	return acceptance.ExecuteTemplate(t,
-		"object_object_updates", TemplateData{
-			Bucket:  objectbucket.TemplateData{Label: name, Cluster: cluster},
+		"object_object_basic", TemplateData{
+			Bucket:  objectbucket.TemplateData{Label: name, Region: region},
 			Key:     objectkey.TemplateData{Label: keyName},
 			Content: content,
 			Source:  source,
-			Cluster: cluster,
+			Region:  region,
 		})
 }
 
-func CredsConfiged(t *testing.T, name, cluster, keyName, content string) string {
+func Updates(t *testing.T, name, region, keyName, content, source string) string {
+	return acceptance.ExecuteTemplate(t,
+		"object_object_updates", TemplateData{
+			Bucket:  objectbucket.TemplateData{Label: name, Region: region},
+			Key:     objectkey.TemplateData{Label: keyName},
+			Content: content,
+			Source:  source,
+			Region:  region,
+		})
+}
+
+func CredsConfiged(t *testing.T, name, region, keyName, content string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_object_creds_configed", TemplateData{
-			Bucket:  objectbucket.TemplateData{Label: name, Cluster: cluster},
+			Bucket:  objectbucket.TemplateData{Label: name, Region: region},
 			Key:     objectkey.TemplateData{Label: keyName},
 			Content: content,
-			Cluster: cluster,
+			Region:  region,
 		})
 }
 
-func TempKeys(t *testing.T, name, cluster, keyName, content string) string {
+func TempKeys(t *testing.T, name, region, keyName, content string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_object_temp_keys", TemplateData{
-			Bucket:  objectbucket.TemplateData{Label: name, Cluster: cluster},
+			Bucket:  objectbucket.TemplateData{Label: name, Region: region},
 			Key:     objectkey.TemplateData{Label: keyName},
 			Content: content,
-			Cluster: cluster,
+			Region:  region,
 		})
 }

--- a/linode/obj/tmpl/updates.gotf
+++ b/linode/obj/tmpl/updates.gotf
@@ -5,7 +5,11 @@
 
 resource "linode_object_storage_object" "basic" {
     bucket     = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region     = "{{.Region}}"
+    {{else}}
     cluster    = "{{ .Cluster }}"
+    {{end}}
     access_key = linode_object_storage_key.foobar.access_key
     secret_key = linode_object_storage_key.foobar.secret_key
     key        = "test_basic"
@@ -16,7 +20,11 @@ resource "linode_object_storage_object" "basic" {
 
 resource "linode_object_storage_object" "base64" {
     bucket         = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region         = "{{.Region}}"
+    {{else}}
     cluster        = "{{ .Cluster }}"
+    {{end}}
     access_key     = linode_object_storage_key.foobar.access_key
     secret_key     = linode_object_storage_key.foobar.secret_key
     key            = "test_base64"
@@ -27,7 +35,11 @@ resource "linode_object_storage_object" "base64" {
 
 resource "linode_object_storage_object" "source" {
     bucket     = linode_object_storage_bucket.foobar.label
+    {{if .Region }}
+    region     = "{{.Region}}"
+    {{else}}
     cluster    = "{{ .Cluster }}"
+    {{end}}
     access_key = linode_object_storage_key.foobar.access_key
     secret_key = linode_object_storage_key.foobar.secret_key
     key        = "test_source"


### PR DESCRIPTION
## 📝 Description

A part of effort to support the recent OBJ API changes.

## ✔️ How to Test

```bash
make PKG_NAME=linode/obj int-test
```

Note that you might see flaky test results that's not relevant to changes in this PR:
```
    test_retry.go:25: Retrying on test failure: Step 1/1 error: Error running post-apply refresh plan: exit status 1
        
        Error: access_key and secret_key are required.
        
          with linode_object_storage_object.temp_keys,
          on terraform_plugin_test.tf line 28, in resource "linode_object_storage_object" "temp_keys":
          28: resource "linode_object_storage_object" "temp_keys" {
```

The retry logic may get it passed at the end.

```terraform
provider "linode" {
  obj_use_temp_keys = true
}


resource "linode_object_storage_bucket" "foobar" {
  region = "us-mia"
  label  = "my-very-cool-bucket"
}

resource "linode_object_storage_object" "object" {
  bucket = linode_object_storage_bucket.foobar.label
  region = linode_object_storage_bucket.foobar.region
  key    = "my-object"

  content          = "This is the content of the Object..."
  content_type     = "text/plain"
  content_language = "en"
}
```