### PR TITLE
Change all API Doc urls to point to new Techdocs

### DIFF
--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_account
 
 Provides information about a Linode account.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-account).
 
 Due to the sensitive nature of the data exposed by this data source, it should not be used in conjunction with the `LINODE_DEBUG` option.  See the [debugging notes](/providers/linode/linode/latest/docs#debugging) for more details.
 

--- a/docs/data-sources/account_availabilities.md
+++ b/docs/data-sources/account_availabilities.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_account\_availabilities
 
 Provides information about services availabilities for the current Linode account.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-availability).
 
 ## Example Usage
 

--- a/docs/data-sources/account_availability.md
+++ b/docs/data-sources/account_availability.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_account\_availability
 
 Provides details about service availability in a region to an account specifically.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-account-availability).
 
 ## Example Usage
 

--- a/docs/data-sources/account_login.md
+++ b/docs/data-sources/account_login.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_account\_login
 
 Provides details about a specific Linode account login.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-account-login).
 
 ## Example Usage
 

--- a/docs/data-sources/account_logins.md
+++ b/docs/data-sources/account_logins.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_account\_logins
 
 Provides information about Linode account logins that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-account-logins).
 
 ## Example Usage
 

--- a/docs/data-sources/account_settings.md
+++ b/docs/data-sources/account_settings.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_account\_settings
 
 Provides information about Linode account settings.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-account-settings).
 
 ## Example Usage
 

--- a/docs/data-sources/child_account.md
+++ b/docs/data-sources/child_account.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_child\_account
 
 Provides information about a Linode Child Account.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-child-account).
 
 Due to the sensitive nature of the data exposed by this data source, it should not be used in conjunction with the `LINODE_DEBUG` option.  See the [debugging notes](/providers/linode/linode/latest/docs#debugging) for more details.
 

--- a/docs/data-sources/child_accounts.md
+++ b/docs/data-sources/child_accounts.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_child\_accounts
 
 Provides information about Linode Child Accounts that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-child-accounts).
 
 **NOTE: Parent/Child related features may not be generally available.**
 

--- a/docs/data-sources/database_backups.md
+++ b/docs/data-sources/database_backups.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_database\_backups
 
 Provides information about Linode Database Backups that match a set of filters.
+For more information, see the Linode APIv4 docs for [MySQL](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-backups) and [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-backups).
 
 ## Example Usage
 

--- a/docs/data-sources/database_engines.md
+++ b/docs/data-sources/database_engines.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_database\_engines
 
 Provides information about Linode Managed Database engines that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-engines).
 
 ## Example Usage
 

--- a/docs/data-sources/database_mysql.md
+++ b/docs/data-sources/database_mysql.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_database\_mysql
 
 Provides information about a Linode MySQL Database.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-instances).
 
 ## Example Usage
 

--- a/docs/data-sources/database_mysql_backups.md
+++ b/docs/data-sources/database_mysql_backups.md
@@ -6,9 +6,10 @@ description: |-
 
 # Data Source: linode\_database\_mysql\_backups
 
-~> **NOTICE:** This data source has been deprecated in favor of `linode_database_backups`.
-
 Provides information about Linode MySQL Database Backups that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-backups).
+
+~> **NOTICE:** This data source has been deprecated in favor of `linode_database_backups`.
 
 ## Example Usage
 

--- a/docs/data-sources/database_postgresql.md
+++ b/docs/data-sources/database_postgresql.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_database\_postgresql
 
 Provides information about a Linode PostgreSQL Database.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-backups).
 
 ## Example Usage
 

--- a/docs/data-sources/databases.md
+++ b/docs/data-sources/databases.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_databases
 
 Provides information about Linode Managed Databases that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-instances).
 
 ## Example Usage
 

--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_domain
 
 Provides information about a Linode domain.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-domain).
 
 ## Example Usage
 

--- a/docs/data-sources/domain_record.md
+++ b/docs/data-sources/domain_record.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode_domain_record
 
 Provides information about a Linode Domain Record.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-domain-record).
 
 ## Example Usage
 
@@ -44,7 +45,7 @@ The Linode Volume resource exports the following attributes:
 
 - `domain_id` - The associated domain's unique ID.
 
-- `type` - The type of Record this is in the DNS system. See all record types [here](https://www.linode.com/docs/api/domains/#domain-records-list__responses).
+- `type` - The type of Record this is in the DNS system. See all record types [here](https://techdocs.akamai.com/linode-api/reference/get-domain-record).
 
 - `ttl_sec` - The amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers.
 

--- a/docs/data-sources/domain_zonefile.md
+++ b/docs/data-sources/domain_zonefile.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode_domain_zonefile
 
 Provides information about a Linode Domain Zonefile.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-domain-zone).
 
 ## Example Usage
 

--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_domains
 
 Provides information about Linode Domains that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-domains).
 
 ## Example Usage
 

--- a/docs/data-sources/firewall.md
+++ b/docs/data-sources/firewall.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_firewall
 
 Provides details about a Linode Firewall.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-firewall).
 
 ## Example Usage
 

--- a/docs/data-sources/firewalls.md
+++ b/docs/data-sources/firewalls.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_firewalls
 
 Provides information about Linode Cloud Firewalls that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-firewalls).
 
 ## Example Usage
 

--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_image
 
 Provides information about a Linode image
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-image).
 
 ## Example Usage
 

--- a/docs/data-sources/images.md
+++ b/docs/data-sources/images.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_images
 
 Provides information about Linode images that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-images).
 
 ## Example Usage
 

--- a/docs/data-sources/instance_backups.md
+++ b/docs/data-sources/instance_backups.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_instance_backups
 
 Provides details about the backups of an Instance.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-backups).
 
 ## Example Usage
 

--- a/docs/data-sources/instance_networking.md
+++ b/docs/data-sources/instance_networking.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_instance\_networking
 
 Provides details about the networking configuration of an Instance.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-linode-config-interfaces).
 
 ## Example Usage
 
@@ -84,7 +85,7 @@ A list of public IP Address objects belonging to this Linode.
 
 * `gateway` - (Nullable) The default gateway for this address.
 
-* `linode_id` - The ID of the Linode this address currently belongs to. For IPv4 addresses, this is by default the Linode that this address was assigned to on creation, and these addresses my be moved using the [/networking/ipv4/assign](https://www.linode.com/docs/api/networking/#ips-to-linodes-assign) endpoint. For SLAAC and link-local addresses, this value may not be changed.
+* `linode_id` - The ID of the Linode this address currently belongs to. For IPv4 addresses, this is by default the Linode that this address was assigned to on creation, and these addresses my be moved using the [/networking/ipv4/assign](https://techdocs.akamai.com/linode-api/reference/post-assign-ips) endpoint. For SLAAC and link-local addresses, this value may not be changed.
 
 * `prefix` - The number of bits set in the subnet mask.
 

--- a/docs/data-sources/instance_networking.md
+++ b/docs/data-sources/instance_networking.md
@@ -112,7 +112,7 @@ A list of reserved IP Address objects belonging to this Linode.
 
 * `gateway` - (Nullable) The default gateway for this address.
 
-* `linode_id` - The ID of the Linode this address currently belongs to. For IPv4 addresses, this is by default the Linode that this address was assigned to on creation, and these addresses my be moved using the [/networking/ipv4/assign](https://www.linode.com/docs/api/networking/#ips-to-linodes-assign) endpoint. For SLAAC and link-local addresses, this value may not be changed.
+* `linode_id` - The ID of the Linode this address currently belongs to. For IPv4 addresses, this is by default the Linode that this address was assigned to on creation, and these addresses my be moved using the [/networking/ipv4/assign](https://techdocs.akamai.com/linode-api/reference/post-assign-ips) endpoint. For SLAAC and link-local addresses, this value may not be changed.
 
 * `prefix` - The number of bits set in the subnet mask.
 
@@ -139,7 +139,7 @@ A list of shared IP Address objects assigned to this Linode.
 
 * `gateway` - (Nullable) The default gateway for this address.
 
-* `linode_id` - The ID of the Linode this address currently belongs to. For IPv4 addresses, this is by default the Linode that this address was assigned to on creation, and these addresses my be moved using the [/networking/ipv4/assign](https://www.linode.com/docs/api/networking/#ips-to-linodes-assign) endpoint. For SLAAC and link-local addresses, this value may not be changed.
+* `linode_id` - The ID of the Linode this address currently belongs to. For IPv4 addresses, this is by default the Linode that this address was assigned to on creation, and these addresses my be moved using the [/networking/ipv4/assign](https://techdocs.akamai.com/linode-api/reference/post-assign-ips) endpoint. For SLAAC and link-local addresses, this value may not be changed.
 
 * `prefix` - The number of bits set in the subnet mask.
 

--- a/docs/data-sources/instance_type.md
+++ b/docs/data-sources/instance_type.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_instance\_type
 
 Provides information about a Linode instance type
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-linode-type).
 
 ## Example Usage
 
@@ -32,7 +33,7 @@ The Linode Instance Type resource exports the following attributes:
 
 * `label` - The Linode Type's label is for display purposes only
 
-* `class` - The class of the Linode Type. See all classes [here](https://www.linode.com/docs/api/linode-types/#type-view__responses).
+* `class` - The class of the Linode Type. See all classes [here](https://techdocs.akamai.com/linode-api/reference/get-linode-type).
 
 * `disk` - The Disk size, in MB, of the Linode Type
 

--- a/docs/data-sources/instance_types.md
+++ b/docs/data-sources/instance_types.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_instance_types
 
 Provides information about Linode Instance types that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-linode-types).
 
 ## Example Usage
 
@@ -61,7 +62,7 @@ Each Linode Instance type will be stored in the `types` attribute and will expor
 
 * `label` - The Linode Type's label is for display purposes only.
 
-* `class` - The class of the Linode Type. See all classes [here](https://www.linode.com/docs/api/linode-types/#type-view__responses).
+* `class` - The class of the Linode Type. See all classes [here](https://techdocs.akamai.com/linode-api/reference/get-linode-types).
 
 * `disk` - The Disk size, in MB, of the Linode Type.
 

--- a/docs/data-sources/instances.md
+++ b/docs/data-sources/instances.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_instances
 
 Provides information about Linode instances that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-linode-instances).
 
 ## Example Usage
 
@@ -88,7 +89,7 @@ Each Linode instance will be stored in the `instances` attribute and will export
 
 * `watchdog_enabled` - The watchdog, named Lassie, is a Shutdown Watchdog that monitors your Linode and will reboot it if it powers off unexpectedly. It works by issuing a boot job when your Linode powers off without a shutdown job being responsible. To prevent a loop, Lassie will give up if there have been more than 5 boot jobs issued within 15 minutes.
 
-* `image` - An Image ID to deploy the Disk from. Official Linode Images start with linode/, while your Images start with `private/`. See [images](https://api.linode.com/v4/images) for more information on the Images available for you to use. Examples are `linode/debian12`, `linode/fedora39`, `linode/ubuntu22.04`, `linode/arch`, and `private/12345`. See all images [here](https://api.linode.com/v4/linode/images) (Requires a personal access token; docs [here](https://developers.linode.com/api/v4/images)). *This value can not be imported.* *Changing `image` forces the creation of a new Linode Instance.*
+* `image` - An Image ID to deploy the Disk from. Official Linode Images start with linode/, while your Images start with `private/`. See [images](https://api.linode.com/v4/images) for more information on the Images available for you to use. Examples are `linode/debian12`, `linode/fedora39`, `linode/ubuntu22.04`, `linode/arch`, and `private/12345`. See all images [here](https://api.linode.com/v4/linode/images) (Requires a personal access token; docs [here](https://techdocs.akamai.com/linode-api/reference/get-images)). *This value can not be imported.* *Changing `image` forces the creation of a new Linode Instance.*
 
 * `swap_size` - When deploying from an Image, this field is optional with a Linode API default of 512mb, otherwise it is ignored. This is used to set the swap disk size for the newly-created Linode.
 
@@ -138,7 +139,7 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
   * `label` - The Config's label for display purposes.  Also used by `boot_config_label`.
 
-  * `kernel` - A Kernel ID to boot a Linode with. Default is based on image choice. Examples are `linode/latest-64bit`, `linode/grub2`, `linode/direct-disk`, etc. See all kernels [here](https://api.linode.com/v4/linode/kernels). Note that this is a paginated API endpoint ([docs](https://developers.linode.com/api/v4/linode-kernels)).
+  * `kernel` - A Kernel ID to boot a Linode with. Default is based on image choice. Examples are `linode/latest-64bit`, `linode/grub2`, `linode/direct-disk`, etc. See all kernels [here](https://api.linode.com/v4/linode/kernels). Note that this is a paginated API endpoint ([docs](https://techdocs.akamai.com/linode-api/reference/get-kernels)).
 
   * `run_level` - Defines the state of your Linode after booting.
 
@@ -174,7 +175,7 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
 ### Interface
 
-Interface defines a network interfaces that is exposed to a Linode. See the official [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema) for more details.
+Interface defines a network interfaces that is exposed to a Linode. See the official [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/post-linode-config-interface) for more details.
 
 Each interface exports the following attributes:
 

--- a/docs/data-sources/ipv6_range.md
+++ b/docs/data-sources/ipv6_range.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_ipv6\_range
 
 Provides information about a Linode IPv6 Range.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-ipv6-range).
 
 ## Example Usage
 

--- a/docs/data-sources/ipv6_ranges.md
+++ b/docs/data-sources/ipv6_ranges.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_ipv6\_ranges
 
 Provides information about Linode IPv6 ranges that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-ipv6-ranges).
 
 ~> Some fields may not be accessible directly the results of this data source.
 For additional information about a specific IPv6 range consider using the [linode_ipv6_range](ipv6_range.md)

--- a/docs/data-sources/kernel.md
+++ b/docs/data-sources/kernel.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_kernel
 
 Provides information about a Linode kernel
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-kernel).
 
 ## Example Usage
 

--- a/docs/data-sources/kernels.md
+++ b/docs/data-sources/kernels.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_kernels
 
 Provides information about Linode Kernels that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-kernels).
 
 ## Example Usage
 

--- a/docs/data-sources/lke_cluster.md
+++ b/docs/data-sources/lke_cluster.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_lke_cluster
 
 Provides details about an LKE Cluster.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-lke-cluster).
 
 ## Example Usage
 

--- a/docs/data-sources/lke_clusters.md
+++ b/docs/data-sources/lke_clusters.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_lke\_clusters
 
 Provides information about a list of current Linode Kubernetes (LKE) clusters on your account that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-lke-clusters).
 
 ## Example Usage
 

--- a/docs/data-sources/lke_versions.md
+++ b/docs/data-sources/lke_versions.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_lke\_versions
 
 Provides details about the Kubernetes versions available for deployment to a Kubernetes cluster.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-lke-versions).
 
 ## Example Usage
 

--- a/docs/data-sources/networking_ip.md
+++ b/docs/data-sources/networking_ip.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_network\_ip
 
 Provides information about a Linode Networking IP Address
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-ip).
 
 ## Example Usage
 

--- a/docs/data-sources/nodebalancer.md
+++ b/docs/data-sources/nodebalancer.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_nodebalancer
 
 Provides details about a Linode NodeBalancer.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-node-balancer).
 
 ## Example Usage
 

--- a/docs/data-sources/nodebalancer_config.md
+++ b/docs/data-sources/nodebalancer_config.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_nodebalancer_config
 
 Provides details about a Linode NodeBalancer Config.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-config).
 
 ## Example Usage
 

--- a/docs/data-sources/nodebalancer_configs.md
+++ b/docs/data-sources/nodebalancer_configs.md
@@ -7,6 +7,7 @@ description: |-
 # linode_nodebalancer_configs
 
 Provides information about Linode NodeBalancer Configs that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-configs).
 
 ## Example Usage
 

--- a/docs/data-sources/nodebalancer_node.md
+++ b/docs/data-sources/nodebalancer_node.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_nodebalancer_node
 
 Provides details about a Linode NodeBalancer node.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-node-balancer-node).
 
 ## Example Usage
 

--- a/docs/data-sources/nodebalancers.md
+++ b/docs/data-sources/nodebalancers.md
@@ -7,6 +7,7 @@ description: |-
 # linode_nodebalancers
 
 Provides information about Linode NodeBalancers that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-node-balancers).
 
 ## Example Usage
 

--- a/docs/data-sources/object_storage_cluster.md
+++ b/docs/data-sources/object_storage_cluster.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_object\_storage\_cluster
 
 Provides information about a Linode Object Storage Cluster
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-object-storage-cluster).
 
 ## Example Usage
 

--- a/docs/data-sources/placement_group.md
+++ b/docs/data-sources/placement_group.md
@@ -9,6 +9,7 @@ description: |-
 **NOTE: Placement Groups may not currently be available to all users.**
 
 `linode_placement_group` provides details about a Linode placement group.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-placement-group).
 
 ## Example Usage
 

--- a/docs/data-sources/placement_groups.md
+++ b/docs/data-sources/placement_groups.md
@@ -9,6 +9,7 @@ description: |-
 **NOTE: Placement Groups may not currently be available to all users.**
 
 Provides information about a list of Linode Placement Groups that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-placement-groups).
 
 ## Example Usage
 

--- a/docs/data-sources/profile.md
+++ b/docs/data-sources/profile.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_profile
 
 Provides information about a Linode profile.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-profile).
 
 ## Example Usage
 

--- a/docs/data-sources/region.md
+++ b/docs/data-sources/region.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_region
 
 `linode_region` provides details about a specific Linode region. See all regions [here](https://api.linode.com/v4/regions).
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-region).
 
 ## Example Usage
 

--- a/docs/data-sources/regions.md
+++ b/docs/data-sources/regions.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_regions
 
 Provides information about Linode regions that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-regions).
 
 ```hcl
 data "linode_regions" "filtered-regions" {

--- a/docs/data-sources/sshkey.md
+++ b/docs/data-sources/sshkey.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_sshkey
 
 `linode_sshkey` provides access to a specifically labeled SSH Key in the Profile of the User identified by the access token.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-ssh-key).
 
 ## Example Usage
 

--- a/docs/data-sources/sshkeys.md
+++ b/docs/data-sources/sshkeys.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_sshkeys
 
 `linode_sshkey` provides access to a filtered list of SSH Keys in the Profile of the User identified by the access token.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-ssh-keys).
 
 ## Example Usage
 

--- a/docs/data-sources/stackscript.md
+++ b/docs/data-sources/stackscript.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_stackscript
 
 Provides details about a specific Linode StackScript.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-stack-script).
 
 ## Example Usage
 

--- a/docs/data-sources/stackscripts.md
+++ b/docs/data-sources/stackscripts.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_stackscripts
 
 Provides information about Linode StackScripts that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-stack-scripts).
 
 **NOTICE:** Due to the large number of public StackScripts, this data source may time out if `is_public` is not filtered on.
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_user
 
 Provides information about a Linode user
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-user).
 
 ## Example Usage
 

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_users
 
 Provides information about Linode users that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-users).
 
 ```hcl
 data "linode_users" "filtered-users" {

--- a/docs/data-sources/vlans.md
+++ b/docs/data-sources/vlans.md
@@ -11,6 +11,7 @@ To use early access resources, the `api_version` provider argument must be set t
 To learn more, see the [early access documentation](../..#early-access).
 
 Provides details about Linode VLANs.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-vlans).
 
 ## Example Usage
 

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode_volume
 
 Provides information about a Linode Volume.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-volume).
 
 ## Example Usage
 

--- a/docs/data-sources/volumes.md
+++ b/docs/data-sources/volumes.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_volumes
 
 Provides information about Linode volumes that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-volumes).
 
 ```hcl
 data "linode_volumes" "filtered-volumes" {

--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_vpc
 
 Provides information about a Linode VPC.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-vpc).
 
 ## Example Usage
 

--- a/docs/data-sources/vpc_subnet.md
+++ b/docs/data-sources/vpc_subnet.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_vpc\_subnet
 
 Provides information about a Linode VPC subnet.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-vpc-subnet).
 
 ## Example Usage
 

--- a/docs/data-sources/vpc_subnets.md
+++ b/docs/data-sources/vpc_subnets.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_vpc\_subnets
 
 Provides information about a list of Linode VPC subnets that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-vpc-subnets).
 
 ## Example Usage
 

--- a/docs/data-sources/vpcs.md
+++ b/docs/data-sources/vpcs.md
@@ -7,6 +7,7 @@ description: |-
 # Data Source: linode\_vpcs
 
 Provides information about a list of Linode VPCs that match a set of filters.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-vpcs).
 
 ## Example Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ This section outlines commonly used provider configuration options.
 
 * `config_profile` - (Optional) The Linode config profile to use. (default `default`)
 
-* `token` - (Optional) This is your [Linode APIv4 Token](https://developers.linode.com/api/v4#section/Personal-Access-Token).
+* `token` - (Optional) This is your [Linode APIv4 Token](https://techdocs.akamai.com/linode-api/reference/get-started#personal-access-tokens).
 
    The Linode Token can also be specified using the `LINODE_TOKEN` shell environment variable. (e.g. `export LINODE_TOKEN=mytoken`)
 

--- a/docs/resources/account_settings.md
+++ b/docs/resources/account_settings.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_account\_settings
 
 Manages the settings of a Linode account.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-account-settings).
 
 ## Example Usage
 
@@ -27,7 +28,7 @@ The following arguments are supported:
 
 * `network_helper` - (Optional) Enables network helper across all users by default for new Linodes and Linode Configs.
 
-* `longview_subscription` - (Optional) The Longview Pro tier you are currently subscribed to. The value must be a [Longview Subscription](https://www.linode.com/docs/api/longview/#longview-subscriptions-list) ID or null for Longview Free.
+* `longview_subscription` - (Optional) The Longview Pro tier you are currently subscribed to. The value must be a [Longview Subscription](https://techdocs.akamai.com/linode-api/reference/get-longview-subscriptions) ID or null for Longview Free.
 
 ## Additional Results
 

--- a/docs/resources/database_access_controls.md
+++ b/docs/resources/database_access_controls.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_database\_access_controls
 
 Manages the access control for a Linode Database. Only one `linode_database_access_controls` resource should be defined per-database.
+For more information, see the Linode APIv4 docs for [MySQL](https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance) and [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/put-databases-postgre-sql-instance).
 
 ## Example Usage
 
@@ -41,6 +42,6 @@ The following arguments are supported:
 
 * `database_id` - (Required) The unique ID of the target database.
 
-* `database_type` - (Required) The unique type of the target database. (`mysql`, `mongodb`, `postgresql`)
+* `database_type` - (Required) The unique type of the target database. (`mysql`, `postgresql`)
 
 * `allow_list` - (Required) A list of IP addresses that can access the Managed Database. Each item can be a single IP address or a range in CIDR format.

--- a/docs/resources/database_mysql.md
+++ b/docs/resources/database_mysql.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_database\_mysql
 
 Provides a Linode MySQL Database resource. This can be used to create, modify, and delete Linode MySQL Databases.
-For more information, see the [Linode APIv4 docs](https://www.linode.com/docs/api/databases/).
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-instances).
 
 Please keep in mind that Managed Databases can take up to an hour to provision.
 

--- a/docs/resources/database_postgresql.md
+++ b/docs/resources/database_postgresql.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_database\_postgresql
 
 Provides a Linode PostgreSQL Database resource. This can be used to create, modify, and delete Linode PostgreSQL Databases.
-For more information, see the [Linode APIv4 docs](https://www.linode.com/docs/api/databases/).
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances).
 
 Please keep in mind that Managed Databases can take up to an hour to provision.
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_domain
 
 Provides a Linode Domain resource.  This can be used to create, modify, and delete Linode Domains through Linode's managed DNS service.
-For more information, see [DNS Manager](https://www.linode.com/docs/platform/manager/dns-manager/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createDomain).
+For more information, see [DNS Manager](https://www.linode.com/docs/platform/manager/dns-manager/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-domain).
 
 The Linode Guide, [Deploy a WordPress Site Using Terraform and Linode StackScripts](https://www.linode.com/docs/applications/configuration-management/deploy-a-wordpress-site-using-terraform-and-linode-stackscripts/), demonstrates the management of Linode Domain resources in the context of Linode Instance running WordPress.
 

--- a/docs/resources/domain_record.md
+++ b/docs/resources/domain_record.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_domain\_record
 
 Provides a Linode Domain Record resource.  This can be used to create, modify, and delete Linodes Domain Records.
-For more information, see [DNS Manager](https://www.linode.com/docs/platform/manager/dns-manager/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createDomainRecord).
+For more information, see [DNS Manager](https://www.linode.com/docs/platform/manager/dns-manager/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-domain-record).
 
 ## Example Usage
 
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `domain_id` - (Required) The ID of the Domain to access.  *Changing `domain_id` forces the creation of a new Linode Domain Record.*.
 
-* `record_type` - (Required) The type of Record this is in the DNS system. For example, A records associate a domain name with an IPv4 address, and AAAA records associate a domain name with an IPv6 address. See all supported record types [here](https://www.linode.com/docs/api/domains/#domain-record-create__request-body-schema). *Changing `record_type` forces the creation of a new Linode Domain Record.*.
+* `record_type` - (Required) The type of Record this is in the DNS system. For example, A records associate a domain name with an IPv4 address, and AAAA records associate a domain name with an IPv6 address. See all supported record types [here](https://techdocs.akamai.com/linode-api/reference/post-domain-record). *Changing `record_type` forces the creation of a new Linode Domain Record.*.
 
 * `target` - (Required) The target for this Record. This field's actual usage depends on the type of record this represents. For A and AAAA records, this is the address the named Domain should resolve to.
 

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_firewall
 
 Manages a Linode Firewall.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-firewalls).
 
 ## Example Usage
 

--- a/docs/resources/firewall_device.md
+++ b/docs/resources/firewall_device.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_firewall\_device
 
 Manages a Linode Firewall Device.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-firewall-device).
 
 **NOTICE:** Attaching a Linode Firewall Device to a `linode_firewall` resource with user-defined `linodes` may cause device conflicts.
 

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -8,7 +8,7 @@ description: |-
 
 Provides a Linode Image resource.  This can be used to create, modify, and delete Linodes Images.  Linode Images are snapshots of a Linode Instance Disk which can then be used to provision more Linode Instances.  Images can be used across regions.
 
-For more information, see [Linode's documentation on Images](https://www.linode.com/docs/platform/disk-images/linode-images/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createImage).
+For more information, see [Linode's documentation on Images](https://www.linode.com/docs/platform/disk-images/linode-images/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-image).
 
 ## Example Usage
 

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_instance
 
 Provides a Linode Instance resource.  This can be used to create, modify, and delete Linodes.
-For more information, see [Getting Started with Linode](https://linode.com/docs/getting-started/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createLinodeInstance).
+For more information, see [Getting Started with Linode](https://linode.com/docs/getting-started/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-linode-instance).
 
 The Linode Guide, [Use Terraform to Provision Linode Environments](https://www.linode.com/docs/applications/configuration-management/how-to-build-your-infrastructure-using-terraform-and-linode/), provides step-by-step guidance and additional examples.
 
@@ -198,7 +198,7 @@ Just as the Linode API provides, these fields are for the most common provisioni
 
 * `backup_id` - (Optional) A Backup ID from another Linode's available backups. Your User must have read_write access to that Linode, the Backup must have a status of successful, and the Linode must be deployed to the same region as the Backup. See /linode/instances/{linodeId}/backups for a Linode's available backups. This field and the image field are mutually exclusive. *This value can not be imported.* *Changing `backup_id` forces the creation of a new Linode Instance.*
 
-* `image` - (Optional) An Image ID to deploy the Disk from. Official Linode Images start with linode/, while your Images start with `private/`. See [images](https://api.linode.com/v4/images) for more information on the Images available for you to use. Examples are `linode/debian12`, `linode/fedora39`, `linode/ubuntu22.04`, `linode/arch`, and `private/12345`. See all images [here](https://api.linode.com/v4/linode/images) (Requires a personal access token; docs [here](https://developers.linode.com/api/v4/images)). *This value can not be imported.* *Changing `image` forces the creation of a new Linode Instance.*
+* `image` - (Optional) An Image ID to deploy the Disk from. Official Linode Images start with linode/, while your Images start with `private/`. See [images](https://api.linode.com/v4/images) for more information on the Images available for you to use. Examples are `linode/debian12`, `linode/fedora39`, `linode/ubuntu22.04`, `linode/arch`, and `private/12345`. See all images [here](https://api.linode.com/v4/linode/images) (Requires a personal access token; docs [here](https://techdocs.akamai.com/linode-api/reference/get-images)). *This value can not be imported.* *Changing `image` forces the creation of a new Linode Instance.*
 
 * `root_pass` - (Required with `image`) The initial password for the `root` user account. *This value can not be imported.* *Changing `root_pass` forces the creation of a new Linode Instance.* *If omitted, a random password will be generated but will not be stored in Terraform state.*
 
@@ -280,7 +280,7 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
       * `disk_id` - (Computed) The Disk ID of the associated `disk_label`, if used.
 
-    * `kernel` - (Optional) - A Kernel ID to boot a Linode with. Default is based on image choice. Examples are `linode/latest-64bit`, `linode/grub2`, `linode/direct-disk`, etc. See all kernels [here](https://api.linode.com/v4/linode/kernels). Note that this is a paginated API endpoint ([docs](https://developers.linode.com/api/v4/linode-kernels)).
+    * `kernel` - (Optional) - A Kernel ID to boot a Linode with. Default is based on image choice. Examples are `linode/latest-64bit`, `linode/grub2`, `linode/direct-disk`, etc. See all kernels [here](https://api.linode.com/v4/linode/kernels). Note that this is a paginated API endpoint ([docs](https://techdocs.akamai.com/linode-api/reference/get-kernels)).
 
     * `run_level` - (Optional) - Defines the state of your Linode after booting. Defaults to `"default"`.
 
@@ -296,7 +296,7 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
 ### Interface
 
-Interface defines a network interfaces that is exposed to a Linode. See the official [Linode API documentation](https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema) for more details.
+Interface defines a network interfaces that is exposed to a Linode. See the official [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/post-linode-instance) for more details.
 
 A Linode must have a public interface in the first/eth0 position to be reachable via the public internet
 upon boot without additional system configuration. If no public interface is configured, the Linode

--- a/docs/resources/instance_config.md
+++ b/docs/resources/instance_config.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_instance\_config
 
 Provides a Linode Instance Config resource. This can be used to create, modify, and delete Linode Instance Configs.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-add-linode-config).
 
 ~> **NOTICE:** If a VPC interface is defined in your `linode_instance_config` resource and the config is currently booted with the Linode, then the Linode is required to be powered off during the update operation. The Terraform provider will try to implicitly shutdown you Linode instance during the update and restart it when it's finished. Unless you explicitly config the `booted` attribute in the resource or explicitly set `skip_implicit_reboots` to `false` in the Terraform provider config.
 
@@ -164,7 +165,7 @@ The following arguments are supported:
 
 * [`interface`](#interface) - (Optional) An array of Network Interfaces to use for this Configuration Profile.
 
-* `kernel` - (Optional) A Kernel ID to boot a Linode with. Default is `linode/latest-64bit`. Examples are `linode/latest-64bit`, `linode/grub2`, `linode/direct-disk`, etc. See all kernels [here](https://api.linode.com/v4/linode/kernels). Note that this is a paginated API endpoint ([docs](https://developers.linode.com/api/v4/linode-kernels)).
+* `kernel` - (Optional) A Kernel ID to boot a Linode with. Default is `linode/latest-64bit`. Examples are `linode/latest-64bit`, `linode/grub2`, `linode/direct-disk`, etc. See all kernels [here](https://api.linode.com/v4/linode/kernels). Note that this is a paginated API endpoint ([docs](https://techdocs.akamai.com/linode-api/reference/get-kernels)).
 
 * `memory_limit` - (Optional) The memory limit of the Config. Defaults to the total ram of the Linode.
 

--- a/docs/resources/instance_disk.md
+++ b/docs/resources/instance_disk.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_instance\_disk
 
 Provides a Linode Instance Disk resource. This can be used to create, modify, and delete Linode Instance Disks.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-add-linode-disk).
 
 **NOTE:** Deleting a disk will shut down the attached instance if the instance is booted. If the disk was not in use by the booted configuration profile, the instance will be automatically rebooted.
 

--- a/docs/resources/instance_ip.md
+++ b/docs/resources/instance_ip.md
@@ -6,11 +6,12 @@ description: |-
 
 # linode\_instance\_ip
 
+Manages a Linode instance IP.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-add-linode-ip).
+
 ~> **NOTICE:** You may need to contact support to increase your instance IP limit before you can allocate additional IPs.
 
 ~> **NOTICE:** This resource will reboot the specified instance following IP allocation.
-
-Manages a Linode instance IP.
 
 ## Example Usage
 

--- a/docs/resources/instance_shared_ips.md
+++ b/docs/resources/instance_shared_ips.md
@@ -6,13 +6,14 @@ description: |-
 
 # linode\_instance\_shared\_ips
 
+Manages IPs shared to a Linode instance.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-share-ips).
+
 ~> **Beta Notice** IPv6 sharing is currently available through early access.
 To use early access resources, the `api_version` provider argument must be set to `v4beta`.
 To learn more, see the [early access documentation](../..#early-access).
 
 ~> **Notice** This resource should only be defined once per-instance and should not be used alongside the `shared_ipv4` field in `linode_instance`.
-
-Manages IPs shared to a Linode instance.
 
 ## Example Usage
 

--- a/docs/resources/ipv6_range.md
+++ b/docs/resources/ipv6_range.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_ipv6\_range
 
 Manages a Linode IPv6 range.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-ipv6-range).
 
 ~> **NOTICE:** We highly recommend that users do not remove an IPv6 range created by this Terraform resource outside of Terraform. This is because if a user manually removes an IPv6 range created by Terraform, and then assigns some IPv6 ranges to other linodes outside of Terraform, there is a chance that the same IPv6 range can be assigned to another linode, even though the new range is randomly selected. This will result in the newly assigned IPv6 range being managed by this Terraform resource. In this case, the user should manually taint this resource.
 

--- a/docs/resources/lke_cluster.md
+++ b/docs/resources/lke_cluster.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_lke_cluster
 
 Manages an LKE cluster.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-lke-cluster).
 
 ## Example Usage
 

--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -6,13 +6,14 @@ description: |-
 
 # linode\_lke\_node\_pool
 
+Manages an LKE Node Pool.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-lke-cluster-pools).
+
 ~> **Notice** To prevent LKE node pools managed by this resource from being
 recreated by the linode_lke_cluster resource, the cluster's external_pool_tags
  attribute must match the tags attribute of this resource. Please review the
 [Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools)
 section for more information.
-
-Manages an LKE Node Pool.
 
 ## Example Usage
 

--- a/docs/resources/nodebalancer.md
+++ b/docs/resources/nodebalancer.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_nodebalancer
 
 Provides a Linode NodeBalancer resource.  This can be used to create, modify, and delete Linodes NodeBalancers in Linode's managed load balancer service.
-For more information, see [Getting Started with NodeBalancers](https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createNodeBalancer).
+For more information, see [Getting Started with NodeBalancers](https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-node-balancer).
 
 The Linode Guide, [Create a NodeBalancer with Terraform](https://www.linode.com/docs/applications/configuration-management/create-a-nodebalancer-with-terraform/), provides step-by-step guidance and additional examples.
 

--- a/docs/resources/nodebalancer_config.md
+++ b/docs/resources/nodebalancer_config.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_nodebalancer_config
 
 Provides a Linode NodeBalancer Config resource.  This can be used to create, modify, and delete Linodes NodeBalancer Configs.
-For more information, see [Getting Started with NodeBalancers](https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createNodeBalancerConfig).
+For more information, see [Getting Started with NodeBalancers](https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-node-balancer-config).
 
 The Linode Guide, [Create a NodeBalancer with Terraform](https://www.linode.com/docs/applications/configuration-management/create-a-nodebalancer-with-terraform/), provides step-by-step guidance and additional examples.
 

--- a/docs/resources/nodebalancer_node.md
+++ b/docs/resources/nodebalancer_node.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_nodebalancer\_node
 
 Provides a Linode NodeBalancer Node resource.  This can be used to create, modify, and delete Linodes NodeBalancer Nodes.
-For more information, see [Getting Started with NodeBalancers](https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createNodeBalancerNode).
+For more information, see [Getting Started with NodeBalancers](https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-node-balancer-node).
 
 The Linode Guide, [Create a NodeBalancer with Terraform](https://www.linode.com/docs/applications/configuration-management/create-a-nodebalancer-with-terraform/), provides step-by-step guidance and additional examples.
 

--- a/docs/resources/object_storage_bucket.md
+++ b/docs/resources/object_storage_bucket.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_object\_storage\_bucket
 
 Provides a Linode Object Storage Bucket resource. This can be used to create, modify, and delete Linodes Object Storage Buckets.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket).
 
 ## Example Usage
 
@@ -97,7 +98,7 @@ The following arguments are supported:
 
 * `label` - (Required) The label of the Linode Object Storage Bucket.
 
-* `acl` - (Optional) The Access Control Level of the bucket using a canned ACL string. See all ACL strings [in the Linode API v4 documentation](https://linode.com/docs/api/object-storage/#object-storage-bucket-access-update__request-body-schema).
+* `acl` - (Optional) The Access Control Level of the bucket using a canned ACL string. See all ACL strings [in the Linode API v4 documentation](https://techdocs.akamai.com/linode-api/reference/post-object-storage-bucket).
 
 * `access_key` - (Optional) The access key to authenticate with. If not specified with the resource, its value can be
   * configured by [`obj_access_key`](../index.md#configuration-reference) in the provider configuration;

--- a/docs/resources/object_storage_key.md
+++ b/docs/resources/object_storage_key.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_object\_storage\_key
 
 Provides a Linode Object Storage Key resource. This can be used to create, modify, and delete Linodes Object Storage Keys.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-object-storage-keys).
 
 ## Example Usage
 

--- a/docs/resources/placement_group.md
+++ b/docs/resources/placement_group.md
@@ -6,9 +6,10 @@ description: |-
 
 # linode\_placement\_group
 
-**NOTE: Placement Groups may not currently be available to all users.**
-
 Manages a Linode Placement Group.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-placement-group).
+
+**NOTE: Placement Groups may not currently be available to all users.**
 
 ## Example Usage
 

--- a/docs/resources/placement_group_assignment.md
+++ b/docs/resources/placement_group_assignment.md
@@ -6,9 +6,10 @@ description: |-
 
 # linode\_placement\_group\_assignment
 
-**NOTE: Placement Groups may not currently be available to all users.**
-
 Manages a single assignment between a Linode and a Placement Group.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-group-add-linode).
+
+**NOTE: Placement Groups may not currently be available to all users.**
 
 To prevent update conflicts, Linodes managed through the `linode_instance` resource should specify `placement_group_externally_managed`:
 

--- a/docs/resources/rdns.md
+++ b/docs/resources/rdns.md
@@ -10,7 +10,7 @@ Provides a Linode RDNS resource.  This can be used to create and modify RDNS rec
 
 Linode RDNS names must have a matching address value in an A or AAAA record.  This A or AAAA name must be resolvable at the time the RDNS resource is being associated.
 
-For more information, see the [Linode APIv4 docs](https://developers.linode.com/api/v4/networking-ips-address/#put) and the [Configure your Linode for Reverse DNS](https://www.linode.com/docs/networking/dns/configure-your-linode-for-reverse-dns-classic-manager/) guide.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/put-ip) and the [Configure your Linode for Reverse DNS](https://www.linode.com/docs/networking/dns/configure-your-linode-for-reverse-dns-classic-manager/) guide.
 
 ## Example Usage
 

--- a/docs/resources/sshkey.md
+++ b/docs/resources/sshkey.md
@@ -7,7 +7,8 @@ description: |-
 # linode\_sshkey
 
 Provides a Linode SSH Key resource.  This can be used to create, modify, and delete Linodes SSH Keys.  Managed SSH Keys allow instances to be created with a list of Linode usernames, whose SSH keys will be automatically applied to the root account's `~/.ssh/authorized_keys` file.
-For more information, see the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/getSSHKeys).
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-ssh-keys).
+
 **NOTE**: This does not generate a new ssh key, you must have an existing key generated and saved locally.
 
 ## Example Usage

--- a/docs/resources/stackscript.md
+++ b/docs/resources/stackscript.md
@@ -8,7 +8,7 @@ description: |-
 
 Provides a Linode StackScript resource.  This can be used to create, modify, and delete Linode StackScripts.  StackScripts are private or public managed scripts which run within an instance during startup.  StackScripts can include variables whose values are specified when the Instance is created.  
 
-For more information, see [Automate Deployment with StackScripts](https://www.linode.com/docs/platform/stackscripts/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#tag/StackScripts).
+For more information, see [Automate Deployment with StackScripts](https://www.linode.com/docs/platform/stackscripts/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-add-stack-script).
 
 The Linode Guide, [Deploy a WordPress Site Using Terraform and Linode StackScripts](https://www.linode.com/docs/applications/configuration-management/deploy-a-wordpress-site-using-terraform-and-linode-stackscripts/), shows how a public StackScript can be used to provision a Linode Instance.   The guide, [Create a Terraform Module](https://www.linode.com/docs/applications/configuration-management/create-terraform-module/), demonstrates StackScript use through a wrapping module.
 

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -10,7 +10,7 @@ Provides a Linode Token resource.  This can be used to create, modify, and delet
 
 It is common for Terraform itself to be configured with broadly scoped Personal Access Tokens.  Provisioning scripts or tools configured within a Linode Instance should follow the principle of least privilege to afford only the required roles for tools to perform their necessary tasks.  The `linode_token` resource allows for the management of Personal Access Tokens with scopes mirroring or narrowing the scope of the parent token.
 
-For more information, see the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/getTokens).
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-personal-access-tokens).
 
 ## Example Usage
 
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `label` - A label for the Token.
 
-* `scopes` - The scopes this token was created with. These define what parts of the Account the token can be used to access. Many command-line tools, such as the Linode CLI, require tokens with access to *. Tokens with more restrictive scopes are generally more secure. All scopes can be viewed in [the Linode API documentation](https://www.linode.com/docs/api/#oauth-reference).
+* `scopes` - The scopes this token was created with. These define what parts of the Account the token can be used to access. Many command-line tools, such as the Linode CLI, require tokens with access to *. Tokens with more restrictive scopes are generally more secure. All scopes can be viewed in [the Linode API documentation](https://techdocs.akamai.com/linode-api/reference/get-started#oauth-reference).
 
 * `expiry` - When this token will expire. Personal Access Tokens cannot be renewed, so after this time the token will be completely unusable and a new token will need to be generated. Tokens may be created with 'null' as their expiry and will never expire unless revoked.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_user
 
 Manages a Linode User.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-user).
 
 ## Example Usage
 

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -8,7 +8,7 @@ description: |-
 
 Provides a Linode Volume resource.  This can be used to create, modify, and delete Linodes Block Storage Volumes.  Block Storage Volumes are removable storage disks that persist outside the life-cycle of Linode Instances. These volumes can be attached to and detached from Linode instances throughout a region.
 
-For more information, see [How to Use Block Storage with Your Linode](https://www.linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/) and the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/createVolume).
+For more information, see [How to Use Block Storage with Your Linode](https://www.linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/) and the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-volume).
 
 ## Example Usage
 

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_vpc
 
 Manages a Linode VPC.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-vpc).
 
 Please refer to [linode_vpc_subnet](vpc_subnet.html.markdown) to manage the subnets under a Linode VPC.
 

--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -7,6 +7,7 @@ description: |-
 # linode\_vpc\_subnet
 
 Manages a Linode VPC subnet.
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-vpc-subnet).
 
 ## Example Usage
 

--- a/linode/token/framework_resource_schema.go
+++ b/linode/token/framework_resource_schema.go
@@ -37,7 +37,7 @@ var frameworkResourceSchema = schema.Schema{
 				"token can be used to access. Many command-line tools, such as the Linode CLI, require tokens with " +
 				"access to *. Tokens with more restrictive scopes are generally more secure. Multiple scopes are " +
 				"separated by a space character (e.g., \"databases:read_only events:read_only\"). You can find the " +
-				"list of available scopes on Linode API docs site, https://www.linode.com/docs/api#oauth-reference",
+				"list of available scopes on Linode API docs site, https://techdocs.akamai.com/linode-api/reference/get-started#oauth-reference",
 			Required: true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplaceIf(


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Updates all `developer.linode.com` urls to point to the new `https://techdocs.akamai.com/`
Also adds a lot of urls that weren't previously there.
