### PR TITLE
fix: Fix LDE-related test failures

### DIFF
--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -31,7 +31,7 @@ func init() {
 	})
 
 	region, err := acceptance.GetRandomRegionWithCaps([]string{
-		linodego.Vlans, linodego.VPCs, linodego.DiskEncryption,
+		linodego.CapabilityVlans, linodego.CapabilityVPCs, linodego.CapabilityDiskEncryption,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -2523,7 +2523,7 @@ func TestAccResourceInstance_diskEncryption(t *testing.T) {
 
 	// Resolve a region that supports disk encryption
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.Linodes, linodego.DiskEncryption},
+		[]string{linodego.CapabilityLinodes, linodego.CapabilityDiskEncryption},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/linode/lke/cluster.go
+++ b/linode/lke/cluster.go
@@ -42,6 +42,7 @@ func ReconcileLKENodePoolSpecs(
 		createOpts := linodego.LKENodePoolCreateOptions{
 			Count: spec.Count,
 			Type:  spec.Type,
+			Tags:  spec.Tags,
 		}
 
 		if createOpts.Count == 0 {

--- a/linode/lke/datasource_test.go
+++ b/linode/lke/datasource_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceLKECluster_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.#", "1"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.type", "g6-standard-2"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.count", "3"),
-						resource.TestCheckResourceAttrSet(dataSourceClusterName, "pool.0.disk_encryption"),
+						resource.TestCheckResourceAttrSet(dataSourceClusterName, "pools.0.disk_encryption"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.nodes.#", "3"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.autoscaler.#", "0"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "control_plane.0.high_availability", "false"),


### PR DESCRIPTION
## 📝 Description

This pull request resolves the following test errors that were occurring after the LDE project branch was merged to dev:

* Capability string enums became out of date due to a breaking change that wasn't accounted for in the LDE branch
* `pool.0.disk_encryption` -> `pools.0.disk_encryption`

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Tests

```
make PKG_NAME=linode/instance int-test
make PKG_NAME=linode/lke int-test
```
