### PR TITLE
Fix flatten image panic when error happens in image creation

### DIFF
--- a/linode/image/framework_resource.go
+++ b/linode/image/framework_resource.go
@@ -213,6 +213,10 @@ func (r *Resource) Create(
 		image = createResourceFromUpload(ctx, &plan, client, resp, timeoutSeconds)
 	}
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	plan.FlattenImage(image, true, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
## 📝 Description

This is to inspect `resp.Diagnostics` and return early if there is an error.

## ✔️ How to Test
```bash
make int-test PKG_NAME="linode/image"
```