### PR TITLE
Add taints and labels support in LKE data source

### DIFF
--- a/docs/data-sources/lke_cluster.md
+++ b/docs/data-sources/lke_cluster.md
@@ -73,11 +73,15 @@ In addition to all arguments above, the following attributes are exported:
 
     * `max` - The maximum number of nodes to autoscale to.
 
-  * `disks` - This Node Pool’s custom disk layout.
+  * `taints` - Kubernetes taints to add to node pool nodes. Taints help control how pods are scheduled onto nodes, specifically allowing them to repel certain pods.
 
-    * `size` - The size of this custom disk partition in MB.
+    * `effect` - The Kubernetes taint effect. The accepted values are `NoSchedule`, `PreferNoSchedule` and `NoExecute`. For the descriptions of these values, see [Kubernetes Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 
-    * `type` - This custom disk partition’s filesystem type.
+    * `key` - The Kubernetes taint key.
+
+    * `value` - The Kubernetes taint value.
+
+  * `labels` - Key-value pairs added as labels to nodes in the node pool. Labels help classify your nodes and to easily select subsets of objects.
 
 * `control_plane` - The settings for the Kubernetes Control Plane.
 

--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -70,8 +70,8 @@ resource "linode_lke_cluster" "my-cluster" {
     # externally managed node pools from being deleted.
     external_pool_tags = [local.external_pool_tag]
 
-  # Due to certain restrictions in Terraform and LKE, 
-  # the cluster must be defined with at least one node pool.
+    # Due to certain restrictions in Terraform and LKE, 
+    # the cluster must be defined with at least one node pool.
     pool {
         type  = "g6-standard-1"
         count = 1

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -508,6 +509,20 @@ func CheckEventAbsent(name string, entityType linodego.EntityType, action linode
 		}
 
 		return nil
+	}
+}
+
+func AnyOfTestCheckFunc(funcs ...resource.TestCheckFunc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		manyErrors := []error{}
+		for _, f := range funcs {
+			if err := f(s); err == nil {
+				return err
+			} else {
+				manyErrors = append(manyErrors, err)
+			}
+		}
+		return errors.Join(manyErrors...)
 	}
 }
 

--- a/linode/acceptance/util_test.go
+++ b/linode/acceptance/util_test.go
@@ -6,8 +6,12 @@
 package acceptance
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTestClient_noURLOverride(t *testing.T) {
@@ -62,4 +66,24 @@ func TestGetTestClient_URLOverride(t *testing.T) {
 	if apiVersion != expectedVersion {
 		t.Fatalf("expected api version to be %s, got %s", expectedVersion, apiVersion)
 	}
+}
+
+func TestAnyOfTestCheckFunc(t *testing.T) {
+	err := errors.New("")
+	checkFuncs1 := AnyOfTestCheckFunc(
+		func(s *terraform.State) error { return err },
+		func(s *terraform.State) error { return nil },
+		func(s *terraform.State) error { return err },
+	)
+	checkFuncs2 := AnyOfTestCheckFunc(
+		func(s *terraform.State) error { return nil },
+	)
+
+	checkFuncs3 := AnyOfTestCheckFunc(
+		func(s *terraform.State) error { return err },
+	)
+
+	assert.NoError(t, checkFuncs1(nil))
+	assert.NoError(t, checkFuncs2(nil))
+	assert.Error(t, checkFuncs3(nil))
 }

--- a/linode/lke/framework_datasource_schema.go
+++ b/linode/lke/framework_datasource_schema.go
@@ -1,9 +1,18 @@
 package lke
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+var taintObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"effect": types.StringType,
+		"key":    types.StringType,
+		"value":  types.StringType,
+	},
+}
 
 var frameworkDataSourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
@@ -120,6 +129,20 @@ var frameworkDataSourceSchema = schema.Schema{
 						ElementType: types.StringType,
 						Computed:    true,
 						Description: "An array of tags applied to this object. Tags are for organizational purposes only.",
+					},
+					"taints": schema.SetAttribute{
+						Computed: true,
+						Description: "Kubernetes taints to add to node pool nodes. " +
+							"Taints help control how pods are scheduled onto nodes, " +
+							"specifically allowing them to repel certain pods.",
+						ElementType: taintObjectType,
+					},
+					"labels": schema.MapAttribute{
+						Computed: true,
+						Description: "Key-value pairs added as labels to nodes in " +
+							"the node pool. Labels help classify your nodes and to " +
+							"easily select subsets of objects.",
+						ElementType: types.StringType,
 					},
 				},
 				Blocks: map[string]schema.Block{

--- a/linode/lke/framework_datasource_test.go
+++ b/linode/lke/framework_datasource_test.go
@@ -9,9 +9,57 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/v2/linode/lke/tmpl"
+	nodepooltmpl "github.com/linode/terraform-provider-linode/v2/linode/lkenodepool/tmpl"
 )
 
 const dataSourceClusterName = "data.linode_lke_cluster.test"
+
+func TestAccDataSourceLKECluster_taints_labels(t *testing.T) {
+	t.Parallel()
+
+	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+		clusterName := acctest.RandomWithPrefix("tf_test")
+		poolTag := acctest.RandomWithPrefix("tf_test_")
+		resource.Test(tRetry, resource.TestCase{
+			PreCheck:                 func() { acceptance.PreCheck(t) },
+			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: tmpl.DataTaintsLabels(
+						t, &nodepooltmpl.TemplateData{
+							K8sVersion:   k8sVersionLatest,
+							Region:       testRegion,
+							PoolNodeType: "g6-standard-1",
+							NodeCount:    1,
+							ClusterLabel: clusterName,
+							Taints: []nodepooltmpl.TaintData{
+								{
+									Effect: "PreferNoSchedule",
+									Key:    "foo",
+									Value:  "bar",
+								},
+							},
+							PoolTag: poolTag,
+							Labels:  map[string]string{"foo": "bar"},
+						},
+					),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.1.nodes.#", "1"),
+						acceptance.AnyOfTestCheckFunc(
+							resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.taints.#", "1"),
+							resource.TestCheckResourceAttr(dataSourceClusterName, "pools.1.taints.#", "1"),
+						),
+						acceptance.AnyOfTestCheckFunc(
+							resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.labels.foo", "bar"),
+							resource.TestCheckResourceAttr(dataSourceClusterName, "pools.1.labels.foo", "bar"),
+						),
+					),
+				},
+			},
+		})
+	})
+}
 
 func TestAccDataSourceLKECluster_basic(t *testing.T) {
 	t.Parallel()
@@ -66,7 +114,7 @@ func TestAccDataSourceLKECluster_autoscaler(t *testing.T) {
 						resource.TestCheckResourceAttr(dataSourceClusterName, "status", "ready"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "tags.#", "1"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.#", "1"),
-						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.type", "g6-standard-2"),
+						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.type", "g6-standard-1"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.count", "3"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "pools.0.nodes.#", "3"),
 						resource.TestCheckResourceAttrSet(dataSourceClusterName, "pools.0.id"),

--- a/linode/lke/framework_models.go
+++ b/linode/lke/framework_models.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
+	"github.com/linode/terraform-provider-linode/v2/linode/lkenodepool"
 )
 
 // LKEDataModel describes the Terraform resource data model to match the
@@ -53,13 +54,15 @@ type LKEControlPlaneACLAddresses struct {
 }
 
 type LKENodePool struct {
-	ID         types.Int64             `tfsdk:"id"`
-	Count      types.Int64             `tfsdk:"count"`
-	Type       types.String            `tfsdk:"type"`
-	Tags       types.List              `tfsdk:"tags"`
-	Disks      []LKENodePoolDisk       `tfsdk:"disks"`
-	Nodes      []LKENodePoolNode       `tfsdk:"nodes"`
-	Autoscaler []LKENodePoolAutoscaler `tfsdk:"autoscaler"`
+	ID         types.Int64                      `tfsdk:"id"`
+	Count      types.Int64                      `tfsdk:"count"`
+	Type       types.String                     `tfsdk:"type"`
+	Tags       types.List                       `tfsdk:"tags"`
+	Labels     types.Map                        `tfsdk:"labels"`
+	Disks      []LKENodePoolDisk                `tfsdk:"disks"`
+	Nodes      []LKENodePoolNode                `tfsdk:"nodes"`
+	Autoscaler []LKENodePoolAutoscaler          `tfsdk:"autoscaler"`
+	Taints     []lkenodepool.NodePoolTaintModel `tfsdk:"taints"`
 }
 
 type LKENodePoolDisk struct {
@@ -122,6 +125,12 @@ func (data *LKEDataModel) parseLKEAttributes(
 			}
 			pool.Tags = tags
 
+			labels, diags := types.MapValueFrom(ctx, types.StringType, p.Labels)
+			if diags != nil {
+				return nil, diags
+			}
+			pool.Labels = labels
+
 			pool.Nodes = make([]LKENodePoolNode, len(p.Linodes))
 			for i, linode := range p.Linodes {
 				pool.Nodes[i].ID = types.StringValue(linode.ID)
@@ -145,6 +154,13 @@ func (data *LKEDataModel) parseLKEAttributes(
 			for i, d := range p.Disks {
 				pool.Disks[i].Size = types.Int64Value(int64(d.Size))
 				pool.Disks[i].Type = types.StringValue(d.Type)
+			}
+
+			pool.Taints = make([]lkenodepool.NodePoolTaintModel, len(p.Taints))
+			for i, taint := range p.Taints {
+				pool.Taints[i].Effect = types.StringValue(string(taint.Effect))
+				pool.Taints[i].Key = types.StringValue(taint.Key)
+				pool.Taints[i].Value = types.StringValue(taint.Value)
 			}
 
 			lkePools[i] = pool

--- a/linode/lke/tmpl/autoscaler.gotf
+++ b/linode/lke/tmpl/autoscaler.gotf
@@ -10,7 +10,7 @@ resource "linode_lke_cluster" "test" {
             min = 1
             max = 5
         }
-        type  = "g6-standard-2"
+        type  = "g6-standard-1"
         count = 3
     }
 }

--- a/linode/lke/tmpl/data_taints_labels.gotf
+++ b/linode/lke/tmpl/data_taints_labels.gotf
@@ -1,0 +1,10 @@
+{{ define "lke_cluster_data_taints_labels" }}
+
+{{ template "nodepool_template" . }}
+
+data "linode_lke_cluster" "test" {
+    depends_on = [ linode_lke_node_pool.foobar ]
+    id = linode_lke_cluster.nodepool_test_cluster.id
+}
+
+{{ end }}

--- a/linode/lke/tmpl/template.go
+++ b/linode/lke/tmpl/template.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
+	nodepooltmpl "github.com/linode/terraform-provider-linode/v2/linode/lkenodepool/tmpl"
 )
 
 type TemplateData struct {
@@ -107,4 +108,8 @@ func DataControlPlane(t *testing.T, name, version, region, ipv4, ipv6 string, ha
 			IPv6:             ipv6,
 			ACLEnabled:       enabled,
 		})
+}
+
+func DataTaintsLabels(t *testing.T, data *nodepooltmpl.TemplateData) string {
+	return acceptance.ExecuteTemplate(t, "lke_cluster_data_taints_labels", *data)
 }

--- a/linode/lkenodepool/tmpl/nodepool.gotf
+++ b/linode/lkenodepool/tmpl/nodepool.gotf
@@ -45,7 +45,12 @@ resource "linode_lke_node_pool" "foobar" {
     }
 {{ end }}
 
-    type  = "{{.PoolNodeType}}"
+    {{ if .PoolNodeType }}
+    type  = "{{ .PoolNodeType }}"
+    {{ else }}
+    type  = "g6-standard-1"
+    {{ end }}
+
     tags  = ["external", "{{.PoolTag}}"]
 }
 


### PR DESCRIPTION
## 📝 Description

This is to add taints and labels support in the `linode_lke_cluster` data source.

## Testing

```bash
make int-test PKG_NAME="linode/lke" PARALLEL=4
```

```bash
make int-test PKG_NAME="linode/lkenodepool" PARALLEL=4
```


### Manual Testing

#### Step 1

Apply the following TF config.

```hcl
provider "linode" {
}

locals {
  external_pool_tag = "external"
}

resource "linode_lke_node_pool" "my-pool" {
  cluster_id = linode_lke_cluster.my-cluster.id
  type       = "g6-standard-2"
  node_count = 3
  taint {
    effect = "PreferNoSchedule"
    key    = "foo"
    value  = "bar"
  }
  labels = {
    "foo" = "bar"
  }
  tags = [local.external_pool_tag]
}

resource "linode_lke_cluster" "my-cluster" {
  label       = "my-cluster"
  k8s_version = "1.30"
  region      = "us-mia"

  external_pool_tags = [local.external_pool_tag]

  pool {
    type  = "g6-standard-1"
    count = 1
  }
}

data "linode_lke_cluster" "test" {
    depends_on = [ linode_lke_node_pool.my-pool ]
    id = linode_lke_cluster.my-cluster.id
}
```

#### Step 2

Add the following code to the existing TF config and apply again.

```hcl
output "test-taints" {
  value = data.linode_lke_cluster.test.pools[1].taints
}

output "test-labels" {
  value = data.linode_lke_cluster.test.pools[1].labels
}

```