### PR TITLE
Fix nil pointer issue in disk resource when failed to wait for a disk

### DIFF
--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -128,7 +128,7 @@ func (r *Resource) Create(
 	_, err = p.WaitForFinished(ctx, timeoutSeconds)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to Wait for the Instance Shutdown Event on Linode Disk (%d)", disk.ID),
+			fmt.Sprintf("Failed to Wait for the Disk Creation Event on Linode Disk (%d)", disk.ID),
 			err.Error(),
 		)
 	}

--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -125,10 +125,10 @@ func (r *Resource) Create(
 
 	ctx = tflog.SetField(ctx, "disk_id", disk.ID)
 
-	event, err := p.WaitForFinished(ctx, timeoutSeconds)
+	_, err = p.WaitForFinished(ctx, timeoutSeconds)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Failed to Wait for the Instance Shutdown Event (%d)", event.ID),
+			fmt.Sprintf("Failed to Wait for the Instance Shutdown Event on Linode Disk (%d)", disk.ID),
 			err.Error(),
 		)
 	}


### PR DESCRIPTION
## 📝 Description
This is to fix a nil pointer issue in the Linode Disk resource.