### PR TITLE
Add validation for the accepted values of `device_name` attribute of instance config resource

### DIFF
--- a/linode/instanceconfig/schema_resource.go
+++ b/linode/instanceconfig/schema_resource.go
@@ -172,6 +172,15 @@ var deviceV2Schema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Required:    true,
 		Description: "The Disk ID to map to this disk slot",
+		ValidateDiagFunc: validation.ToDiagFunc(
+			validation.StringInSlice(
+				[]string{
+					"sda", "sdb", "sdc", "sdd",
+					"sde", "sdf", "sdg", "sdh",
+				},
+				false,
+			),
+		),
 	},
 	"disk_id": {
 		Type:        schema.TypeInt,


### PR DESCRIPTION
## 📝 Description

Validate the input attribute value against accepted values before proceeding to processing it. This is necessary because the provider may panic when invalid input passed in.

Resolves https://github.com/linode/terraform-provider-linode/issues/1536 

## ✔️ How to Test
```bash
make int-test PKG_NAME="linode/instanceconfig" PARALLEL=5
```

Verifying an error will be reported when the invalid `device_name` passed in:

```hcl
resource "linode_instance" "test" {
  label            = "testinstance"
  image            = "linode/ubuntu24.04"
  region           = "us-mia"
  type             = "g6-nanode-1"
}

resource "linode_instance_config" "test" {
  linode_id = linode_instance.test.id
  label     = "my-config"
  device {
    device_name = "invalid-device-name"
    volume_id   = linode_volume.test.id
  }
}

resource "linode_volume" "test" {
    label = "foo-volume"
    region = linode_instance.test.region
    linode_id = linode_instance.test.id
}
```