### PR TITLE
Add `.terraform.lock.hcl` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ modules-dev/
 terraform-provider-linode
 
 dist/**
+
+.terraform.lock.hcl


### PR DESCRIPTION
## 📝 Description

This is to add the `.terraform.lock.hcl` file to `.gitignore`.