### PR TITLE
Fallback to cluster when region is not available in setting obj bucket resource ID

### DIFF
--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -57,7 +57,7 @@ func readResource(
 	client := meta.(*helper.ProviderMeta).Client
 	config := meta.(*helper.ProviderMeta).Config
 
-	regionOrCluster, label, err := DecodeBucketID(ctx, d.Id())
+	regionOrCluster, label, err := DecodeBucketID(ctx, d.Id(), d)
 	if err != nil {
 		return diag.Errorf("failed to parse Linode ObjectStorageBucket id %s: %s", d.Id(), err.Error())
 	}
@@ -253,7 +253,7 @@ func deleteResource(
 
 	config := meta.(*helper.ProviderMeta).Config
 	client := meta.(*helper.ProviderMeta).Client
-	regionOrCluster, label, err := DecodeBucketID(ctx, d.Id())
+	regionOrCluster, label, err := DecodeBucketID(ctx, d.Id(), d)
 	if err != nil {
 		return diag.Errorf("Error parsing Linode ObjectStorageBucket id %s", d.Id())
 	}
@@ -469,15 +469,36 @@ func expandBucketCert(v any) linodego.ObjectStorageBucketCertUploadOptions {
 	}
 }
 
-func DecodeBucketID(ctx context.Context, id string) (regionOrCluster, label string, err error) {
+func DecodeBucketID(ctx context.Context, id string, d *schema.ResourceData) (regionOrCluster, label string, err error) {
 	tflog.Debug(ctx, "decoding bucket ID")
 	parts := strings.Split(id, ":")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		err = fmt.Errorf("Linode Object Storage Bucket ID must be of the form <ClusterOrRegion>:<Label>, was provided: %s", id)
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		regionOrCluster = parts[0]
+		label = parts[1]
 		return
 	}
-	regionOrCluster = parts[0]
-	label = parts[1]
+	tflog.Warn(ctx, "Corrupted bucket ID detected, trying to recover it from cluster and label attributes.")
+
+	recoveredCluster, clusterOk := d.GetOk("cluster")
+	recoveredLabel, labelOk := d.GetOk("label")
+
+	if clusterOk {
+		regionOrCluster = recoveredCluster.(string)
+	}
+	if labelOk {
+		label = recoveredLabel.(string)
+	}
+
+	if clusterOk && labelOk {
+		d.SetId(fmt.Sprintf("%s:%s", regionOrCluster, label))
+	} else {
+		err = fmt.Errorf(
+			"Linode Object Storage Bucket ID must be of the form <ClusterOrRegion>:<Label>, "+
+				"but a corrupted ID %q, is in the state. Attempt to recover them from `cluster` "+
+				"and `label` attributes was also failed.", id,
+		)
+	}
+
 	return
 }
 

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -637,7 +638,7 @@ func checkBucketExists(s *terraform.State) error {
 			continue
 		}
 
-		cluster, label, err := objbucket.DecodeBucketID(context.Background(), rs.Primary.ID)
+		cluster, label, err := objbucket.DecodeBucketID(context.Background(), rs.Primary.ID, &schema.ResourceData{})
 		if err != nil {
 			return fmt.Errorf("Error parsing %s, %s", rs.Primary.ID, err)
 		}
@@ -659,7 +660,7 @@ func checkBucketHasSSL(expected bool) func(*terraform.State) error {
 				continue
 			}
 
-			cluster, label, err := objbucket.DecodeBucketID(context.Background(), rs.Primary.ID)
+			cluster, label, err := objbucket.DecodeBucketID(context.Background(), rs.Primary.ID, &schema.ResourceData{})
 			if err != nil {
 				return fmt.Errorf("could not parse bucket ID %s: %s", rs.Primary.ID, err)
 			}
@@ -685,7 +686,7 @@ func checkBucketDestroy(s *terraform.State) error {
 		}
 
 		id := rs.Primary.ID
-		cluster, label, err := objbucket.DecodeBucketID(context.Background(), id)
+		cluster, label, err := objbucket.DecodeBucketID(context.Background(), id, &schema.ResourceData{})
 		if err != nil {
 			return fmt.Errorf("Error parsing %s", id)
 		}


### PR DESCRIPTION
## 📝 Description
Resolves #1557

Fallback to cluster when region is not available (i.e. legacy API in use).

## ✔️ How to Test

### Test Creation

```hcl
data "linode_object_storage_cluster" "region" {  
  id = "us-mia-1"
}

resource "linode_object_storage_bucket" "storage_bucket" {
  cluster = data.linode_object_storage_cluster.region.id
  label = "some-bucket-yourname"
}

```

### Test Recovery

Same TF config as above.

After applying, manually remove the first half (cluster ID) of the  bucket resource ID in the state file:
`"id": "us-mia-1:some-bucket-zhiwei",` ==> `"id": ":some-bucket-zhiwei",`

Verify that an execution of `terraform refresh` or `tofu refresh` will bring the first half of the ID back.