### PR TITLE
Increase root pass length to 64 in tests

### DIFF
--- a/linode/backup/datasource_test.go
+++ b/linode/backup/datasource_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceInstanceBackups_basic(t *testing.T) {
 
 	resourceName := "data.linode_instance_backups.foobar"
 
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	var instance linodego.Instance
 	var snapshot *linodego.InstanceSnapshot

--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 
 	resName := "data.linode_instances.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -94,7 +94,7 @@ func TestAccDataSourceInstances_multipleInstances(t *testing.T) {
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	tagName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -70,7 +70,7 @@ func TestAccResourceInstance_basic_smoke(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(16)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -107,7 +107,7 @@ func TestAccResourceInstance_watchdogDisabled(t *testing.T) {
 
 	resName := "linode_instance.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -136,7 +136,7 @@ func TestAccResourceInstance_authorizedUsers(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
@@ -169,7 +169,7 @@ func TestAccResourceInstance_validateAuthorizedKeys(t *testing.T) {
 	t.Parallel()
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -335,7 +335,7 @@ func TestAccResourceInstance_configInterfaces(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -405,7 +405,7 @@ func TestAccResourceInstance_configInterfacesNoReboot(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -521,7 +521,7 @@ func TestAccResourceInstance_diskImage(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -561,7 +561,7 @@ func TestAccResourceInstance_diskPair(t *testing.T) {
 	var instance linodego.Instance
 	var instanceDisk linodego.InstanceDisk
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -602,7 +602,7 @@ func TestAccResourceInstance_diskAndConfig(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -646,7 +646,7 @@ func TestAccResourceInstance_disksAndConfigs(t *testing.T) {
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -698,7 +698,7 @@ func TestAccResourceInstance_volumeAndConfig(t *testing.T) {
 	var instanceDisk linodego.InstanceDisk
 	var volume linodego.Volume
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -814,7 +814,7 @@ func TestAccResourceInstance_updateSimple(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -991,7 +991,7 @@ func TestAccResourceInstance_upsizeWithoutDisk(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1164,7 +1164,7 @@ func TestAccResourceInstance_diskResize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1207,7 +1207,7 @@ func TestAccResourceInstance_withDiskLinodeUpsize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1250,7 +1250,7 @@ func TestAccResourceInstance_withDiskLinodeDownsize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1294,7 +1294,7 @@ func TestAccResourceInstance_downsizeWithoutDisk(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1328,7 +1328,7 @@ func TestAccResourceInstance_fullDiskSwapUpsize(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	stackScriptName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1392,7 +1392,7 @@ func TestAccResourceInstance_swapUpsize(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1431,7 +1431,7 @@ func TestAccResourceInstance_swapDownsize(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
 
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1468,7 +1468,7 @@ func TestAccResourceInstance_diskResizeAndExpanded(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1517,7 +1517,7 @@ func TestAccResourceInstance_diskSlotReorder(t *testing.T) {
 	)
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1574,7 +1574,7 @@ func TestAccResourceInstance_privateNetworking(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1675,7 +1675,7 @@ func TestAccResourceInstance_stackScriptDisk(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1901,7 +1901,7 @@ func TestAccResourceInstance_powerStateConfigUpdates(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1943,7 +1943,7 @@ func TestAccResourceInstance_powerStateConfigBooted(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2068,7 +2068,7 @@ func TestAccResourceInstance_userData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2112,7 +2112,7 @@ func TestAccResourceInstance_requestQuantity(t *testing.T) {
 
 	provider, providerMap := acceptance.CreateTestProvider()
 
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	acceptance.ModifyProviderMeta(provider,
 		func(ctx context.Context, config *helper.ProviderMeta) error {
@@ -2166,7 +2166,7 @@ func TestAccResourceInstance_firewallOnCreation(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
 	region, err := acceptance.GetRandomRegionWithCaps([]string{"Cloud Firewall"}, "core")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2321,7 +2321,7 @@ func TestAccResourceInstance_migration(t *testing.T) {
 
 	t.Parallel()
 
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
@@ -2519,7 +2519,7 @@ func TestAccResourceInstance_diskEncryption(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(16)
+	rootPass := acctest.RandString(64)
 
 	// Resolve a region that supports disk encryption
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(

--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -62,7 +62,7 @@ func TestAccResourceInstanceConfig_deviceBlock(t *testing.T) {
 
 	resName := "linode_instance_config.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	devicesCheck := resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttrSet(resName, "devices.0.sda.0.disk_id"),
@@ -129,7 +129,7 @@ func TestAccResourceInstanceConfig_complex(t *testing.T) {
 	resName := "linode_instance_config.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -213,7 +213,7 @@ func TestAccResourceInstanceConfig_booted(t *testing.T) {
 
 	resName := "linode_instance_config.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -272,7 +272,7 @@ func TestAccResourceInstanceConfig_bootedSwap(t *testing.T) {
 		config1Name := "linode_instance_config.foobar1"
 		config2Name := "linode_instance_config.foobar2"
 		instanceName := acctest.RandomWithPrefix("tf_test")
-		rootPass := acctest.RandString(12)
+		rootPass := acctest.RandString(64)
 
 		resource.Test(retryT, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -326,7 +326,7 @@ func TestAccResourceInstanceConfig_provisioner(t *testing.T) {
 
 	resName := "linode_instance_config.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -358,7 +358,7 @@ func TestAccResourceInstanceConfig_vpcInterface(t *testing.T) {
 	resName := "linode_instance_config.foobar"
 	networkDSName := "data.linode_instance_networking.foobar"
 	instanceName := acctest.RandomWithPrefix("tf-test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -457,7 +457,7 @@ func TestAccResourceInstanceConfig_rescueBooted(t *testing.T) {
 	instanceResName := "linode_instance.foobar"
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },

--- a/linode/instancedisk/resource_test.go
+++ b/linode/instancedisk/resource_test.go
@@ -127,7 +127,7 @@ func TestAccResourceInstanceDisk_bootedResize(t *testing.T) {
 
 	resName := "linode_instance_disk.foobar"
 	label := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	var instance linodego.Instance
 

--- a/linode/nbnode/datasource_test.go
+++ b/linode/nbnode/datasource_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceNodeBalancerNode_basic(t *testing.T) {
 
 	resName := "data.linode_nodebalancer_node.foonode"
 	nodebalancerName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },

--- a/linode/nbnode/resource_test.go
+++ b/linode/nbnode/resource_test.go
@@ -34,7 +34,7 @@ func TestAccResourceNodeBalancerNode_basic(t *testing.T) {
 
 	resName := "linode_nodebalancer_node.foonode"
 	nodeName := acctest.RandomWithPrefix("tf_test")
-	config := tmpl.Basic(t, nodeName, testRegion, acctest.RandString(12))
+	config := tmpl.Basic(t, nodeName, testRegion, acctest.RandString(64))
 
 	resource.Test(t, resource.TestCase{
 		PreventPostDestroyRefresh: true,
@@ -68,7 +68,7 @@ func TestAccResourceNodeBalancerNode_update(t *testing.T) {
 
 	resName := "linode_nodebalancer_node.foonode"
 	nodeName := acctest.RandomWithPrefix("tf_test")
-	rootPass := acctest.RandString(12)
+	rootPass := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },


### PR DESCRIPTION
## 📝 Description

- Some errors emerged saying password length requirement was not satisfied in my local testing.
  - I couldn't reproduce it... but the bottom line is that we can always increase security with a stronger password.

## ✔️ How to Test
(As usual, you might see unrelated and intermittent test failures)
```bash
make int-test PKG_NAME="linode/instance" PARALLEL=5
```