### PR TITLE
fix: Allow disks to be resized/deleted on instances that have been running for > 90 days

### DIFF
--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -412,7 +412,7 @@ func (r *Resource) Delete(
 
 	// Reboot the instance if necessary
 	if shouldShutdown && !diskInConfig {
-		if err := instance.BootInstanceSync(
+		if err := helper.BootInstanceSync(
 			ctx, client, linodeID, configID, timeoutSeconds,
 		); err != nil {
 			resp.Diagnostics.AddError(

--- a/linode/instancedisk/helper.go
+++ b/linode/instancedisk/helper.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
@@ -25,17 +26,96 @@ func getLinodeIDAndDiskID(data ResourceModel, diags *diag.Diagnostics) (int, int
 	return linodeID, id
 }
 
-func handleDiskResize(
+// resizeDiskSync resizes the instance with the given ID to the given size,
+// shutting down/booting the instance if necessary.
+func resizeDiskSync(
 	ctx context.Context,
 	client *linodego.Client,
 	meta *helper.FrameworkProviderMeta,
-	instID,
+	linodeID,
 	diskID,
 	newSize,
 	timeoutSeconds int,
+) diag.Diagnostics {
+	return runDiskOperation(
+		ctx, client, meta, linodeID, timeoutSeconds,
+		func() (resultDiag diag.Diagnostics) {
+			disk, err := client.GetInstanceDisk(ctx, linodeID, diskID)
+			if err != nil {
+				resultDiag.AddError("Failed to get Linode instance disk", err.Error())
+				return
+			}
+
+			tflog.Info(ctx, "Resizing instance disk", map[string]any{
+				"old_size": disk.Size,
+				"new_size": newSize,
+			})
+
+			p, err := client.NewEventPollerWithSecondary(
+				ctx,
+				linodeID,
+				linodego.EntityLinode,
+				diskID,
+				linodego.ActionDiskResize)
+			if err != nil {
+				resultDiag.AddError("Failed to create event poller", err.Error())
+				return
+			}
+
+			tflog.Debug(ctx, "client.ResizeInstanceDisk(...)", map[string]any{
+				"new_size": newSize,
+			})
+			if err := client.ResizeInstanceDisk(ctx, linodeID, diskID, newSize); err != nil {
+				resultDiag.AddError("Failed to resize Linode instance disk", err.Error())
+				return
+			}
+
+			// Wait for the resize event to complete
+			if _, err := p.WaitForFinished(ctx, timeoutSeconds); err != nil {
+				resultDiag.AddError(
+					"Failed to wait for Linode instance disk resize to complete",
+					err.Error(),
+				)
+				return
+			}
+
+			// Check to see if the resize operation worked
+			if updatedDisk, err := client.WaitForInstanceDiskStatus(
+				ctx,
+				linodeID,
+				disk.ID,
+				linodego.DiskReady,
+				timeoutSeconds,
+			); err != nil {
+				resultDiag.AddError(
+					"Failed to wait for Linode instance disk to be ready",
+					err.Error(),
+				)
+				return
+			} else if updatedDisk.Size != newSize {
+				resultDiag.AddError(
+					"Failed to resize Linode instance disk",
+					fmt.Sprintf("Disk %d has size %d, expected %d", disk.ID, disk.Size, newSize),
+				)
+				return
+			}
+
+			tflog.Debug(ctx, "Resize operation complete")
+			return
+		},
+	)
+}
+
+func runDiskOperation(
+	ctx context.Context,
+	client *linodego.Client,
+	meta *helper.FrameworkProviderMeta,
+	linodeID int,
+	timeoutSeconds int,
+	callOperation func() diag.Diagnostics,
 ) (resultDiag diag.Diagnostics) {
 	originalStatus, err := helper.WaitForInstanceNonTransientStatus(
-		ctx, client, instID, timeoutSeconds,
+		ctx, client, linodeID, timeoutSeconds,
 	)
 	if err != nil {
 		resultDiag.AddError("Failed to wait for instance to exit transient status", err.Error())
@@ -45,85 +125,29 @@ func handleDiskResize(
 	if originalStatus == linodego.InstanceRunning {
 		if meta.Config.SkipImplicitReboots.ValueBool() {
 			resultDiag.AddError(
-				"Linode instance shutdown is required to delete this disk.",
+				"Linode instance shutdown is required to complete this operation",
 				"Please consider setting 'skip_implicit_reboots' "+
 					"to true in the Linode provider config.",
 			)
 			return
 		}
 
-		if err := helper.ShutDownInstanceSync(ctx, client, instID, timeoutSeconds); err != nil {
+		if err := helper.ShutDownInstanceSync(ctx, client, linodeID, timeoutSeconds); err != nil {
 			resultDiag.AddError("Failed to shutdown Linode instance", err.Error())
 			return
 		}
 	}
 
-	disk, err := client.GetInstanceDisk(ctx, instID, diskID)
-	if err != nil {
-		resultDiag.AddError("Failed to get Linode instance disk", err.Error())
+	// Run the operation
+	resultDiag.Append(callOperation()...)
+	if resultDiag.HasError() {
 		return
 	}
-
-	tflog.Info(ctx, "Resizing Instance disk", map[string]any{
-		"old_size": disk.Size,
-		"new_size": newSize,
-	})
-
-	p, err := client.NewEventPollerWithSecondary(
-		ctx,
-		instID,
-		linodego.EntityLinode,
-		diskID,
-		linodego.ActionDiskResize)
-	if err != nil {
-		resultDiag.AddError("Failed to create event poller", err.Error())
-		return
-	}
-
-	tflog.Debug(ctx, "client.ResizeInstanceDisk(...)", map[string]any{
-		"new_size": newSize,
-	})
-	if err := client.ResizeInstanceDisk(ctx, instID, diskID, newSize); err != nil {
-		resultDiag.AddError("Failed to resize Linode instance disk", err.Error())
-		return
-	}
-
-	// Wait for the resize event to complete
-	if _, err := p.WaitForFinished(ctx, timeoutSeconds); err != nil {
-		resultDiag.AddError(
-			"Failed to wait for Linode instance disk resize to complete",
-			err.Error(),
-		)
-		return
-	}
-
-	// Check to see if the resize operation worked
-	if updatedDisk, err := client.WaitForInstanceDiskStatus(
-		ctx,
-		instID,
-		disk.ID,
-		linodego.DiskReady,
-		timeoutSeconds,
-	); err != nil {
-		resultDiag.AddError(
-			"Failed to wait for Linode instance disk to be ready",
-			err.Error(),
-		)
-		return
-	} else if updatedDisk.Size != newSize {
-		resultDiag.AddError(
-			"Failed to resize Linode instance disk",
-			fmt.Sprintf("Disk %d has size %d, expected %d", disk.ID, disk.Size, newSize),
-		)
-		return
-	}
-
-	tflog.Debug(ctx, "Resize operation complete")
 
 	// Boot the instance back up if necessary
 	if originalStatus == linodego.InstanceRunning {
 		// NOTE: A config ID of 0 will boot the instance into its previously booted config
-		if err := helper.BootInstanceSync(ctx, client, instID, 0, timeoutSeconds); err != nil {
+		if err := helper.BootInstanceSync(ctx, client, linodeID, 0, timeoutSeconds); err != nil {
 			resultDiag.AddError("Failed to boot Linode instance", err.Error())
 			return
 		}


### PR DESCRIPTION
## 📝 Description

This pull request resolves an issue that prevented disks from being resized and deleted on instances that have been running for more than 90 days. This is achieved by removing the booted config resolution logic from the `linode_instance_disk` resize logic and instead deferring it to the API during the subsequent boot.

Additionally, this PR moves the `BootInstanceSync` and `ShutdownInstanceSync` helper functions to the `helper package`, and adds a new `WaitForInstanceNonTransientStatus` helper.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make int-test PKG_NAME=linode/instance
make int-test PKG_NAME=linode/instancedisk
make int-test PKG_NAME=linode/instanceconfig
```

### Manual Testing

1. In a terraform-provider-linode sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
resource "linode_instance" "test" {
  label  = "test-instance"
  region = "us-mia"
  type   = "g6-nanode-1"
}

resource "linode_instance_disk" "test" {
  label     = "test"
  linode_id = linode_instance.test.id

  size  = 4000
  image = "linode/ubuntu22.04"

  root_pass = "terr4form-t3$t!!!!!!!"
}

resource "linode_instance_config" "test" {
  label     = "test"
  linode_id = linode_instance.test.id

  device {
    device_name = "sda"
    disk_id     = linode_instance_disk.test.id
  }

  root_device = "/dev/sda"
  kernel      = "linode/latest-64bit"
  booted      = true
}
```

2. Ensure the apply completes successfully
3. Change the size of the disk and re-apply the configuration.
4. Ensure the apply completes successfully.
5. Ensure the disk has been properly resized.