### PR TITLE
Refactor test region in image replication

### DIFF
--- a/linode/image/datasource_test.go
+++ b/linode/image/datasource_test.go
@@ -44,8 +44,6 @@ func TestAccDataSourceImage_replicate(t *testing.T) {
 
 	resourceName := "data.linode_image.foobar"
 	imageName := acctest.RandomWithPrefix("tf_test")
-	// TODO: Use random region once image gen2 works globally or with specific capabilities
-	replicateRegion := "eu-west"
 
 	file, err := createTempFile("tf-test-image-data-replicate-file", testImageBytes)
 	if err != nil {
@@ -60,7 +58,7 @@ func TestAccDataSourceImage_replicate(t *testing.T) {
 		CheckDestroy: checkImageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataReplicate(t, imageName, file.Name(), testRegion, replicateRegion),
+				Config: tmpl.DataReplicate(t, imageName, file.Name(), testRegion, testRegions[0]),
 				Check: resource.ComposeTestCheckFunc(
 					checkImageExists(resourceName, nil),
 					resource.TestCheckResourceAttr(resourceName, "label", imageName),


### PR DESCRIPTION
## 📝 Description

Remove hardcoded regions and use core regions with Object Storage capability for image replication test.

## ✔️ How to Test

```
make int-test PKG_NAME="linode/image"  
```

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**