### PR TITLE
Fix Firewall Update

### DIFF
--- a/linode/firewall/framework_models.go
+++ b/linode/firewall/framework_models.go
@@ -356,7 +356,7 @@ func (state *FirewallResourceModel) RulesAndPoliciesHaveChanges(
 func (state *FirewallResourceModel) LinodesOrNodeBalancersHaveChanges(
 	ctx context.Context, plan FirewallResourceModel,
 ) bool {
-	return !state.Linodes.Equal(plan.Linodes) || state.NodeBalancers.Equal(plan.NodeBalancers)
+	return !state.Linodes.Equal(plan.Linodes) || !state.NodeBalancers.Equal(plan.NodeBalancers)
 }
 
 func FlattenFirewallRules(

--- a/linode/firewall/framework_schema_resource.go
+++ b/linode/firewall/framework_schema_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -145,12 +146,18 @@ var frameworkResourceSchema = schema.Schema{
 			Optional:    true,
 			Computed:    true,
 			ElementType: types.Int64Type,
+			PlanModifiers: []planmodifier.Set{
+				setplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"nodebalancers": schema.SetAttribute{
 			Description: "The IDs of NodeBalancers to apply this firewall to.",
 			Optional:    true,
 			Computed:    true,
 			ElementType: types.Int64Type,
+			PlanModifiers: []planmodifier.Set{
+				setplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"devices": schema.ListAttribute{
 			Description: "The devices associated with this firewall.",


### PR DESCRIPTION
## 📝 Description

- Correct a checking logic during update
- Add `UseStateForUnknown` to prevent unexpected removals of Linode and NodeBalancers from a firewall.


## ✔️ How to Test

### Automated Testing
```bash
make int-test PKG_NAME="linode/firewall"
```

### Manual Testing
Verify any rule change won't detach the Linode from the firewall.

```hcl
resource "linode_firewall_device" "my_device" {
  firewall_id = linode_firewall.my_firewall.id
  entity_id = linode_instance.my_instance.id
}

resource "linode_firewall" "my_firewall" {
  label = "my_firewall"

  inbound {
    label    = "http"
    action = "DROP"
    protocol  = "TCP"
    ports     = "80"
    ipv4 = ["0.0.0.0/0"]
    ipv6 = ["::/0"]
  }

  inbound_policy = "DROP"
  outbound_policy = "ACCEPT"
}

resource "linode_instance" "my_instance" {
  label      = "my_instance"
  region     = "us-southeast"
  type       = "g6-standard-1"
}

```