### PR TITLE
Support configuring a provider-level Linode API CA file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,10 @@ This section outlines commonly used provider configuration options.
 
   The Linode API version can also be specified using the `LINODE_API_VERSION` environment variable.
 
+* `api_ca_path` (Optional) The path to a CA file to trust when making API requests.
+
+  The Linode API CA file path can also be specified using the `LINODE_CA` environment variable.
+
 * `obj_access_key` - (Optional) The access key to be used in [linode_object_storage_bucket](/docs/resources/object_storage_bucket.md) and [linode_object_storage_object](/docs/resources/object_storage_object.md).
 
   The Object Access Key can also be specified using the `LINODE_OBJ_ACCESS_KEY` shell environment variable.

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -140,6 +140,10 @@ func (p *FrameworkProvider) Schema(
 				Optional:    true,
 				Description: "The version of Linode API.",
 			},
+			"api_ca_path": schema.StringAttribute{
+				Optional:    true,
+				Description: "The path to a Linode API CA file to trust.",
+			},
 			"skip_instance_ready_poll": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Skip waiting for a linode_instance resource to be running.",

--- a/linode/framework_provider_config.go
+++ b/linode/framework_provider_config.go
@@ -285,8 +285,14 @@ func (fp *FrameworkProvider) InitProvider(
 		tflog.Info(ctx, "Using Linode profile", map[string]any{
 			"config_path": lpm.ConfigPath,
 		})
+
+		configPathExpanded, err := helper.ExpandPath(configPath)
+		if err != nil {
+			diags.AddError("Failed to expand config path", err.Error())
+		}
+
 		err = client.LoadConfig(&linodego.LoadConfigOptions{
-			Path:    configPath,
+			Path:    configPathExpanded,
 			Profile: configProfile,
 		})
 		if err != nil {

--- a/linode/framework_provider_config.go
+++ b/linode/framework_provider_config.go
@@ -258,7 +258,13 @@ func (fp *FrameworkProvider) InitProvider(
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if !lpm.APICAPath.IsNull() {
-		if err := helper.AddRootCAToTransport(lpm.APICAPath.ValueString(), httpTransport); err != nil {
+		caPath, err := helper.ExpandPath(lpm.APICAPath.ValueString())
+		if err != nil {
+			diags.AddError("Failed to expand api_ca_path", err.Error())
+			return
+		}
+
+		if err := helper.AddRootCAToTransport(caPath, httpTransport); err != nil {
 			diags.AddError("Failed to add root CA to HTTP transport", err.Error())
 			return
 		}

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -59,7 +59,12 @@ func (c *Config) Client(ctx context.Context) (*linodego.Client, error) {
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if c.APICAPath != "" {
-		if err := AddRootCAToTransport(c.APICAPath, httpTransport); err != nil {
+		caPath, err := ExpandPath(c.APICAPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand api_ca_path: %w", err)
+		}
+
+		if err := AddRootCAToTransport(caPath, httpTransport); err != nil {
 			return nil, fmt.Errorf("failed to add root CA %s to HTTP transport: %w", c.APICAPath, err)
 		}
 	}

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -84,11 +84,16 @@ func (c *Config) Client(ctx context.Context) (*linodego.Client, error) {
 
 	// Load the config file if it exists
 	if _, err := os.Stat(c.ConfigPath); err == nil {
+		configPath, err := ExpandPath(c.ConfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand config path: %w", err)
+		}
+
 		tflog.Info(ctx, "Using Linode profile", map[string]any{
 			"config_path": c.ConfigPath,
 		})
 		err = client.LoadConfig(&linodego.LoadConfigOptions{
-			Path:    c.ConfigPath,
+			Path:    configPath,
 			Profile: c.ConfigProfile,
 		})
 		if err != nil {

--- a/linode/helper/config.go
+++ b/linode/helper/config.go
@@ -68,7 +68,7 @@ func (c *Config) Client(ctx context.Context) (*linodego.Client, error) {
 		Transport: NewAPILoggerTransport(
 			logging.NewSubsystemLoggingHTTPTransport(
 				APILoggerSubsystem,
-				http.DefaultTransport,
+				httpTransport,
 			),
 		),
 	}

--- a/linode/helper/filepath.go
+++ b/linode/helper/filepath.go
@@ -7,27 +7,20 @@ import (
 	"strings"
 )
 
-// ExpandPath expands the given path, replacing any ~'s with the user's
+// ExpandPath expands the given path, replacing ~'s with the user's
 // home directory.
+// NOTE: This does not implement feature-complete tilde expansion.
 func ExpandPath(path string) (string, error) {
-	homePath, homePathErr := os.UserHomeDir()
-
 	segments := strings.Split(path, string(os.PathSeparator))
-	result := make([]string, len(segments))
 
-	for i, segment := range segments {
-		if segment == "~" {
-			// We don't check this error above because we don't want to raise a home resolution error
-			// if the user isn't using ~'s.
-			if homePathErr != nil {
-				return "", fmt.Errorf("could not expand home path: %w", homePathErr)
-			}
-
-			segment = homePath
+	if segments[0] == "~" {
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("could not expand home path: %w", err)
 		}
 
-		result[i] = segment
+		segments[0] = homePath
 	}
 
-	return filepath.Join(result...), nil
+	return filepath.Join(segments...), nil
 }

--- a/linode/helper/filepath.go
+++ b/linode/helper/filepath.go
@@ -1,0 +1,33 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPath expands the given path, replacing any ~'s with the user's
+// home directory.
+func ExpandPath(path string) (string, error) {
+	homePath, homePathErr := os.UserHomeDir()
+
+	segments := strings.Split(path, string(os.PathSeparator))
+	result := make([]string, len(segments))
+
+	for i, segment := range segments {
+		if segment == "~" {
+			// We don't check this error above because we don't want to raise a home resolution error
+			// if the user isn't using ~'s.
+			if homePathErr != nil {
+				return "", fmt.Errorf("could not expand home path: %w", homePathErr)
+			}
+
+			segment = homePath
+		}
+
+		result[i] = segment
+	}
+
+	return filepath.Join(result...), nil
+}

--- a/linode/helper/filepath_test.go
+++ b/linode/helper/filepath_test.go
@@ -1,0 +1,21 @@
+//go:build unit
+
+package helper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandPath(t *testing.T) {
+	homePath, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	expandedPath, err := ExpandPath(filepath.Join("~", "foo", "bar"))
+	require.NoError(t, err)
+
+	require.Equal(t, filepath.Join(homePath, "foo", "bar"), expandedPath)
+}

--- a/linode/helper/filepath_test.go
+++ b/linode/helper/filepath_test.go
@@ -18,4 +18,8 @@ func TestExpandPath(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, filepath.Join(homePath, "foo", "bar"), expandedPath)
+
+	expandedPath, err = ExpandPath("")
+	require.NoError(t, err)
+	require.Equal(t, "", expandedPath)
 }

--- a/linode/helper/framework_provider_model.go
+++ b/linode/helper/framework_provider_model.go
@@ -11,6 +11,7 @@ func GetFrameworkProviderModelFromSDKv2ProviderConfig(config *Config) *Framework
 		AccessToken:                  types.StringValue(config.AccessToken),
 		APIURL:                       types.StringValue(config.APIURL),
 		APIVersion:                   types.StringValue(config.APIVersion),
+		APICAPath:                    types.StringValue(config.APICAPath),
 		UAPrefix:                     types.StringValue(config.UAPrefix),
 		ConfigPath:                   types.StringValue(config.ConfigPath),
 		ConfigProfile:                types.StringValue(config.ConfigProfile),
@@ -34,6 +35,7 @@ type FrameworkProviderModel struct {
 	AccessToken types.String `tfsdk:"token"`
 	APIURL      types.String `tfsdk:"url"`
 	APIVersion  types.String `tfsdk:"api_version"`
+	APICAPath   types.String `tfsdk:"api_ca_path"`
 	UAPrefix    types.String `tfsdk:"ua_prefix"`
 
 	ConfigPath    types.String `tfsdk:"config_path"`

--- a/linode/helper/http.go
+++ b/linode/helper/http.go
@@ -6,18 +6,21 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 )
 
 // AddRootCAToTransport applies the cert file at the given path to the given *http.Transport
 func AddRootCAToTransport(cert string, transport *http.Transport) error {
-	certData, err := os.ReadFile(cert)
+	certData, err := os.ReadFile(filepath.Clean(cert))
 	if err != nil {
 		return fmt.Errorf("failed to read cert file %s: %w", cert, err)
 	}
 
 	tlsConfig := transport.TLSClientConfig
 	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
+		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 
 	if tlsConfig.RootCAs == nil {

--- a/linode/helper/http.go
+++ b/linode/helper/http.go
@@ -1,0 +1,30 @@
+package helper
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// AddRootCAToTransport applies the cert file at the given path to the given *http.Transport
+func AddRootCAToTransport(cert string, transport *http.Transport) error {
+	certData, err := os.ReadFile(cert)
+	if err != nil {
+		return fmt.Errorf("failed to read cert file %s: %w", cert, err)
+	}
+
+	tlsConfig := transport.TLSClientConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+
+	if tlsConfig.RootCAs == nil {
+		tlsConfig.RootCAs = x509.NewCertPool()
+	}
+
+	tlsConfig.RootCAs.AppendCertsFromPEM(certData)
+
+	return nil
+}

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -36,8 +36,10 @@ var testImageBytesNew = []byte{
 	0xe4, 0x02, 0x00, 0x7a, 0x7a, 0x6f, 0xed, 0x03, 0x00, 0x00, 0x00,
 }
 
-var testRegion string
-var testRegions []string
+var (
+	testRegion  string
+	testRegions []string
+)
 
 func init() {
 	resource.AddTestSweepers("linode_image", &resource.Sweeper{

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -61,6 +61,11 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "The version of Linode API.",
 			},
+			"api_ca_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The path to a Linode API CA file to trust.",
+			},
 
 			"skip_instance_ready_poll": {
 				Type:        schema.TypeBool,
@@ -180,6 +185,12 @@ func handleDefault(config *helper.Config, d *schema.ResourceData) diag.Diagnosti
 		config.APIVersion = v.(string)
 	} else {
 		config.APIVersion = os.Getenv("LINODE_API_VERSION")
+	}
+
+	if v, ok := d.GetOk("api_ca_path"); ok {
+		config.APICAPath = v.(string)
+	} else {
+		config.APICAPath = os.Getenv(linodego.APIHostCert)
 	}
 
 	if v, ok := d.GetOk("config_path"); ok {

--- a/linode/provider_test.go
+++ b/linode/provider_test.go
@@ -20,6 +20,7 @@ func TestAccProvider_Overrides(t *testing.T) {
 token = 54321
 api_url = https://cool.linode.com
 api_version = v4reallycoolapiversion
+api_cert_path = cert.pem
 
 [cool]
 token = %s


### PR DESCRIPTION
## 📝 Description

This pull request adds support for configuring a custom trusted Linode API CA file directly through a new provider config `api_ca_path` field or through the `LINODE_CA` environment variable. This also resolves an issue where the `LINODE_CA` environment was not respected in linodego because the Terraform provider wraps the default HTTP transport for logging purposes.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Manual Testing

1. Configure your shell's environment to output HTTP request debug information:

```
export TF_LOG=JSON
export TF_LOG_PATH=logs.jsonl
export TF_LOG_PROVIDER_LINODE_REQUESTS=DEBUG
```

2. Apply the following configuration using a terraform-provider-linode sandbox environment (e.g. dx-devenv):

```terraform
provider "linode" {
  # NOTE: To properly test this functionality, the cert for this
  # API instance should not be trusted in your system's keychain.
  url = "https://api.foobar.linode.com"

  # cert.pem should be a downloaded cert for the environment you want to
  # test against.
  api_ca_path = "./cert.pem"
}

# Framework resource
data "linode_account" "test" {}

# SDKv2 resource
resource "linode_instance" "test" {
  region = "us-mia"
  type = "g6-nanode-1"
  label = "tf-test"
}
```

3. Ensure the apply finishes successfully.
4. Ensure all HTTP requests in logs.json are made to the expected Linode API URL.
5. Remove the `api_ca_path` provider configuration line and re-apply the configuration.
6. Ensure the apply fails with a TLS-related error.