### PR TITLE
fix: Refresh placement group assignment in linode instance resource

### DIFF
--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -136,8 +136,8 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		if compliantOnly, ok := d.GetOk("placement_group.0.compliant_only"); ok {
 			placementGroupMap["compliant_only"] = compliantOnly.(bool)
 		}
-		d.Set("placement_group", []map[string]interface{}{placementGroupMap})
 	}
+	d.Set("placement_group", []map[string]interface{}{placementGroupMap})
 
 	disks, swapSize := flattenInstanceDisks(instanceDisks)
 	d.Set("disk", disks)


### PR DESCRIPTION
## 📝 Description

Fixed a bug that when a linode is unassigned from a placement group outside of terraform (i.e. using cloud manager), we still can identify that change when refresh the state.

## ✔️ How to Test

Test steps:
1. Pull this PR and initialize terraform in a sandbox environment, i.e. dx-devenv
2. Create a placement group and instance resource, and assign the instance to that PG
```
resource "linode_placement_group" "test" {
    label = "my-placement-group"
    region = "us-mia"
    placement_group_type = "anti_affinity:local"
}

resource "linode_instance" "foobar" {
    label = "test-tf-instance"
    type = "g6-standard-1"
    region = "us-mia"
    image = "linode/alpine3.19"
    placement_group {
      id = linode_placement_group.test.id
    }
}
```
3. Now go to Cloud Manager and unassign the instance from the PG
4. Run `terraform plan` or `make plan` again. Notice that there is an update in-place and terraform will add the instance back to the PG
5. Destroy the resources created for clean up
