### PR TITLE
test: Add Cloud Firewall to LKE nodes after integration test execution

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -107,8 +107,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration_tests]
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
       - name: Install Linode CLI
-        run: pip install linode-cli
+        run: |
+          pip install linode-cli
 
       - name: Create Firewall and Attach to Instances
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -119,8 +119,15 @@ jobs:
       - name: Create Firewall and Attach to Instances
         run: |
           FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
           for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
-            linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
           done
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN_USER_4 }} # only Matrix test user 4 runs LKE tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -105,7 +105,7 @@ jobs:
 
   add-fw-lke-nodes:
     runs-on: ubuntu-latest
-    needs: [ integration_tests ]
+    needs: [integration_tests]
     steps:
       - name: Install Linode CLI
         run: pip install linode-cli

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -111,13 +111,13 @@ jobs:
         run: pip install linode-cli
 
       - name: Create Firewall and Attach to Instances
-        env:
-          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN_USER_4 }} # only Matrix test user 4 runs LKE tests
         run: |
           FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
           for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
             linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode
           done
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN_USER_4 }} # only Matrix test user 4 runs LKE tests
 
   process-upload-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -77,6 +77,47 @@ jobs:
           path: '*.xml'
           retention-days: 1
 
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration_tests]
+    if: always()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE # Only Running against Matrix USER 4 which includes LKE test suite
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN_USER_4 }}
+
+  add-fw-lke-nodes:
+    runs-on: ubuntu-latest
+    needs: [ integration_tests ]
+    steps:
+      - name: Install Linode CLI
+        run: pip install linode-cli
+
+      - name: Create Firewall and Attach to Instances
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN_USER_4 }} # only Matrix test user 4 runs LKE tests
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode
+          done
 
   process-upload-report:
     runs-on: ubuntu-latest
@@ -120,38 +161,10 @@ jobs:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
 
-
-  apply-calico-rules:
-    runs-on: ubuntu-latest
-    needs: [integration_tests]
-    if: always()
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Download kubectl and calicoctl for LKE clusters
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64 kubectl
-          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
-          mv kubectl /usr/local/bin/kubectl
-
-      - name: Apply Calico Rules to LKE # Only Running against Matrix USER 4 which includes LKE test suite
-        run: |
-          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
-        env:
-          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN_USER_4 }}
-
   notify-slack:
     runs-on: ubuntu-latest
     needs: [integration_tests]
     if: always() && github.repository == 'linode/terraform-provider-linode' # Run even if integration tests fail and only on main repository
-
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1.27.0
@@ -212,3 +225,4 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -106,6 +106,8 @@ jobs:
   add-fw-lke-nodes:
     runs-on: ubuntu-latest
     needs: [integration_tests]
+    if: always()
+
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -142,8 +142,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration-fork]
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
       - name: Install Linode CLI
-        run: pip install linode-cli
+        run: |
+          pip install linode-cli
 
       - name: Create Firewall and Attach to Instances
         run: |

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -117,7 +117,7 @@ jobs:
   apply-calico-rules:
     runs-on: ubuntu-latest
     needs: [integration-fork]
-    if: always()
+    if: ${{ success() || failure() }}
 
     steps:
       - name: Checkout code
@@ -143,7 +143,7 @@ jobs:
   add-fw-lke-nodes:
     runs-on: ubuntu-latest
     needs: [integration-fork]
-    if: always()
+    if: ${{ success() || failure() }}
 
     steps:
       - name: Set up Python

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -117,8 +117,6 @@ jobs:
   apply-calico-rules:
     runs-on: ubuntu-latest
     needs: [integration-fork]
-    if: always()
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -154,8 +154,15 @@ jobs:
       - name: Create Firewall and Attach to Instances
         run: |
           FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
           for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
-            linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
           done
         env:
           LINODE_CLI_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -117,6 +117,8 @@ jobs:
   apply-calico-rules:
     runs-on: ubuntu-latest
     needs: [integration-fork]
+    if: always()
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -141,6 +143,8 @@ jobs:
   add-fw-lke-nodes:
     runs-on: ubuntu-latest
     needs: [integration-fork]
+    if: always()
+
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -55,26 +55,11 @@ jobs:
 
       - run: make deps
 
-      - name: Download kubectl and calicoctl for LKE clusters
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64 kubectl
-          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
-          mv kubectl /usr/local/bin/kubectl
-
       - run: make PKG_NAME="${{ inputs.module }}" int-test
         if: ${{ steps.disallowed-character-check.outputs.result == 'pass' }}
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           RUN_LONG_TESTS: ${{ inputs.run_long_tests }}
-
-      - name: Apply Calico Rules to LKE
-        if: always()
-        run: |
-          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
-        env:
-          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
       
       - name: Get the hash value of the latest commit from the PR branch
         uses: octokit/graphql-action@v2.x
@@ -128,3 +113,45 @@ jobs:
               conclusion: process.env.conclusion
             });
             return result;
+
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration-fork]
+    if: always()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
+
+  add-fw-lke-nodes:
+    runs-on: ubuntu-latest
+    needs: [integration-fork]
+    steps:
+      - name: Install Linode CLI
+        run: pip install linode-cli
+
+      - name: Create Firewall and Attach to Instances
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode
+          done
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}


### PR DESCRIPTION
## 📝 Description

Currently there isn't a CFW being applied to LKE nodes in integration test runs. Attaching FW to LKE cluster upon creation is currently not available which is the reason why only Calico rules were only being applied. This PR fixes that problem by going through the test account after test execution and attaching a default firewall to all remaining instances

## ✔️ How to Test

Tested on my forked - https://github.com/ykim-1/terraform-provider-linode/actions/runs/11351444139/job/31572142776 

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**