### PR TITLE
fix: Instance state has placement groups by default

### DIFF
--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -136,8 +136,10 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		if compliantOnly, ok := d.GetOk("placement_group.0.compliant_only"); ok {
 			placementGroupMap["compliant_only"] = compliantOnly.(bool)
 		}
+		d.Set("placement_group", []map[string]interface{}{placementGroupMap})
+	} else {
+		d.Set("placement_group", nil)
 	}
-	d.Set("placement_group", []map[string]interface{}{placementGroupMap})
 
 	disks, swapSize := flattenInstanceDisks(instanceDisks)
 	d.Set("disk", disks)


### PR DESCRIPTION
## 📝 Description

Fixed issue causing an empty list of placement groups gets added to the instance state, even when none are defined.

## ✔️ How to Test

The following steps assume that you pulled down this PR locally.

First, verify that instance-related integration tests are passing, i.e.
`make PKG_NAME=linode/instance ARGS="-run TestAccDataSourceInstances_basic" int-test`

1. Generate a compliant firewall in Cloud Manager.
2. Initialize terraform in a sandbox environment, i.e. dx-devenv.
3. Create a placement group and instance resource with the firewall's id, and assign the instance to that PG
```
resource "linode_placement_group" "test" {
    label = "my-placement-group"
    region = "us-mia"
    placement_group_type = "anti_affinity:local"
}

resource "linode_instance" "foobar" {
    label = "test-tf-instance"
    type = "g6-standard-1"
    region = "us-mia"
    image = "linode/alpine3.19"
    firewall_id = <FIREWALL_ID>
    placement_group {
      id = linode_placement_group.test.id
    }
}
```
4. Go to Cloud Manager and unassign the instance from the PG
5. Run `make plan` and verify that there is an update in-place to add the instance back to the PG
6. Destroy all resources created for this test