### PR TITLE
fix: Instance disk nil pointer issue

### DIFF
--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -122,7 +122,7 @@ func (r *Resource) Create(
 	diskID := disk.ID
 	// Add resource to TF states earlier to prevent
 	// dangling resources (resources created but not managed by TF)
-	AddDiskResource(ctx, diskID, resp, plan)
+	AddDiskResource(ctx, *disk, resp, plan)
 
 	ctx = tflog.SetField(ctx, "disk_id", diskID)
 

--- a/linode/instancedisk/helper.go
+++ b/linode/instancedisk/helper.go
@@ -15,8 +15,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
-func AddDiskResource(ctx context.Context, diskID int, resp *resource.CreateResponse, plan ResourceModel) {
-	resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(strconv.Itoa(diskID)))
+func AddDiskResource(ctx context.Context, disk linodego.InstanceDisk, resp *resource.CreateResponse, plan ResourceModel) {
+	resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(strconv.Itoa(disk.ID)))
 	resp.State.SetAttribute(ctx, path.Root("linode_id"), plan.LinodeID)
 }
 

--- a/linode/instancedisk/helper.go
+++ b/linode/instancedisk/helper.go
@@ -15,8 +15,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
-func AddDiskResource(ctx context.Context, disk linodego.InstanceDisk, resp *resource.CreateResponse, plan ResourceModel) {
-	resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(strconv.Itoa(disk.ID)))
+func AddDiskResource(ctx context.Context, diskID int, resp *resource.CreateResponse, plan ResourceModel) {
+	resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(strconv.Itoa(diskID)))
 	resp.State.SetAttribute(ctx, path.Root("linode_id"), plan.LinodeID)
 }
 


### PR DESCRIPTION
## 📝 Description

When we try to refresh the latest disk status, it may fail and cause the refreshed disk id to be nil. Use a local variable to store the disk id value and prevent the nil pointer issue. 

## ✔️ How to Test

```
make PKG_NAME=linode/instancedisk int-test
```
