### PR TITLE
Support reconstructing absolute paths in ExpandPath(...)

### DIFF
--- a/linode/helper/filepath.go
+++ b/linode/helper/filepath.go
@@ -3,15 +3,16 @@ package helper
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
+
+const pathSeparatorString = string(os.PathSeparator)
 
 // ExpandPath expands the given path, replacing ~'s with the user's
 // home directory.
 // NOTE: This does not implement feature-complete tilde expansion.
 func ExpandPath(path string) (string, error) {
-	segments := strings.Split(path, string(os.PathSeparator))
+	segments := strings.Split(path, pathSeparatorString)
 
 	if segments[0] == "~" {
 		homePath, err := os.UserHomeDir()
@@ -22,5 +23,7 @@ func ExpandPath(path string) (string, error) {
 		segments[0] = homePath
 	}
 
-	return filepath.Join(segments...), nil
+	// We don't use filepath.Join(...) here because it does not
+	// support rebuilding paths starting with `/`.
+	return strings.Join(segments, pathSeparatorString), nil
 }

--- a/linode/helper/filepath_test.go
+++ b/linode/helper/filepath_test.go
@@ -5,6 +5,7 @@ package helper
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,10 +17,16 @@ func TestExpandPath(t *testing.T) {
 
 	expandedPath, err := ExpandPath(filepath.Join("~", "foo", "bar"))
 	require.NoError(t, err)
-
 	require.Equal(t, filepath.Join(homePath, "foo", "bar"), expandedPath)
 
 	expandedPath, err = ExpandPath("")
 	require.NoError(t, err)
 	require.Equal(t, "", expandedPath)
+
+	// /foo/bar
+	absPath := strings.Join([]string{"", "foo", "bar"}, string(os.PathSeparator))
+
+	expandedPath, err = ExpandPath(absPath)
+	require.NoError(t, err)
+	require.Equal(t, absPath, expandedPath)
 }


### PR DESCRIPTION
## 📝 Description

This pull request resolves a minor issue in `helper.ExpandPath(...)` that caused absolute paths to be reconstructed as relative paths.

e.g. `/foo/bar` would become `foo/bar`.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make unit-test
```

### Integration Testing

```
make PKG_NAME=linode int-test
```

### Manual Testing

N/A
