### PR TITLE
test: ignore updated field assertions in firewall resource tests

### DIFF
--- a/linode/firewall/framework_resource_test.go
+++ b/linode/firewall/framework_resource_test.go
@@ -118,7 +118,7 @@ func TestAccLinodeFirewall_basic(t *testing.T) {
 				ResourceName:            testFirewallResName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"created"},
+				ImportStateVerifyIgnore: []string{"created", "updated"},
 			},
 		},
 	})
@@ -154,7 +154,7 @@ func TestAccLinodeFirewall_minimum(t *testing.T) {
 				ResourceName:            testFirewallResName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"created"},
+				ImportStateVerifyIgnore: []string{"created", "updated"},
 			},
 		},
 	})
@@ -225,7 +225,7 @@ func TestAccLinodeFirewall_multipleRules(t *testing.T) {
 				ResourceName:            testFirewallResName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"created"},
+				ImportStateVerifyIgnore: []string{"created", "updated"},
 			},
 		},
 	})
@@ -263,7 +263,7 @@ func TestAccLinodeFirewall_no_device(t *testing.T) {
 				ResourceName:            testFirewallResName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"created"},
+				ImportStateVerifyIgnore: []string{"created", "updated"},
 			},
 		},
 	})
@@ -462,9 +462,10 @@ func TestAccLinodeFirewall_noIPv6(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      testFirewallResName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            testFirewallResName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"created", "updated"},
 			},
 		},
 	})
@@ -496,7 +497,7 @@ func TestAccLinodeFirewall_noRules(t *testing.T) {
 				ResourceName:            testFirewallResName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"created"},
+				ImportStateVerifyIgnore: []string{"created", "updated"},
 			},
 		},
 	})


### PR DESCRIPTION
## 📝 Description

Fix intermittent failures caused due to the API issue.

## ✔️ How to Test

`make PKG_NAME=linode/firewall int-test`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**