### PR TITLE
Simplify test retry system; fix hang when certain retryable tests fail

### DIFF
--- a/linode/acceptance/test_retry.go
+++ b/linode/acceptance/test_retry.go
@@ -1,136 +1,20 @@
 package acceptance
 
 import (
-	"errors"
-	"fmt"
-	"runtime"
 	"testing"
 )
 
-// RunTestRetry attempts to retry the given test if an intermittent error occurs.
+// RunTestWithRetries attempts to retry the given test if an intermittent error occurs.
 // This function wraps the given testing.T and handles errors accordingly.
 // This should only be used for flapping API tests.
-func RunTestRetry(t *testing.T, maxAttempts int, f func(t *TRetry)) {
+func RunTestWithRetries(t *testing.T, maxAttempts int, f func(*testing.T)) {
 	for i := 0; i < maxAttempts; i++ {
-		newT := NewTRetry(t)
-		t.Cleanup(newT.Close)
-
-		go func() {
-			f(newT)
-
-			newT.SuccessChannel <- true
-		}()
-
-		select {
-		case err := <-newT.ErrorChannel:
-			t.Logf("Retrying on test failure: %s\n", err)
-		case <-newT.SuccessChannel:
+		if t.Run(t.Name(), f) {
 			return
 		}
+
+		t.Logf("Retrying %s due to failure. (Attempt %d)", t.Name(), i+1)
 	}
 
 	t.Fatalf("Test failed after %d attempts", maxAttempts)
 }
-
-// TRetry implements testing.T with additional retry logic
-type TRetry struct {
-	t *testing.T
-
-	ErrorChannel   chan error
-	SuccessChannel chan bool
-}
-
-func NewTRetry(t *testing.T) *TRetry {
-	return &TRetry{
-		t:              t,
-		ErrorChannel:   make(chan error, 0),
-		SuccessChannel: make(chan bool, 0),
-	}
-}
-
-func (t *TRetry) Close() {
-	close(t.ErrorChannel)
-	close(t.SuccessChannel)
-}
-
-func (t *TRetry) Cleanup(f func()) {
-	t.t.Cleanup(f)
-}
-
-func (t *TRetry) Error(args ...any) {
-	t.ErrorChannel <- errors.New(fmt.Sprint(args...))
-}
-
-func (t *TRetry) Errorf(format string, args ...any) {
-	t.ErrorChannel <- fmt.Errorf(format, args...)
-}
-
-func (t *TRetry) Fail() {
-	runtime.Goexit()
-}
-
-func (t *TRetry) Failed() bool {
-	// We wrap this logic using channels
-	return false
-}
-
-func (t *TRetry) Fatal(args ...any) {
-	t.ErrorChannel <- errors.New(fmt.Sprint(args...))
-	t.Fail()
-}
-
-func (t *TRetry) Fatalf(format string, args ...any) {
-	t.ErrorChannel <- fmt.Errorf(format, args...)
-	t.Fail()
-}
-
-func (t *TRetry) Helper() {
-	t.t.Helper()
-}
-
-func (t *TRetry) Log(args ...any) {
-	t.t.Log(args...)
-}
-
-func (t *TRetry) Logf(format string, args ...any) {
-	t.t.Logf(format, args...)
-}
-
-func (t *TRetry) Name() string {
-	return t.t.Name()
-}
-
-func (t *TRetry) Setenv(key, value string) {
-	t.t.Setenv(key, value)
-}
-
-func (t *TRetry) Skip(args ...any) {
-	t.t.Skip(args...)
-}
-
-func (t *TRetry) SkipNow() {
-	t.t.SkipNow()
-}
-
-func (t *TRetry) Skipf(format string, args ...any) {
-	t.t.Skipf(format, args...)
-}
-
-func (t *TRetry) Skipped() bool {
-	return t.t.Skipped()
-}
-
-func (t *TRetry) TempDir() string {
-	return t.t.TempDir()
-}
-
-func (t *TRetry) FailNow() {
-	t.Fail()
-}
-
-func (t *TRetry) Parallel() {
-	t.t.Parallel()
-}
-
-//lint:ignore U1000 Ignore unused function
-func (t *TRetry) private() {}

--- a/linode/domains/datasource_test.go
+++ b/linode/domains/datasource_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceDomains_basic(t *testing.T) {
 
 	domainName := acctest.RandomWithPrefix("tf-test") + ".example"
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
-		resource.Test(tRetry, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			Steps: []resource.TestStep{

--- a/linode/domains/datasource_test.go
+++ b/linode/domains/datasource_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceDomains_basic(t *testing.T) {
 	domainName := acctest.RandomWithPrefix("tf-test") + ".example"
 
 	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
-		resource.Test(t, resource.TestCase{
+		resource.Test(tRetry, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			Steps: []resource.TestStep{

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -861,8 +861,8 @@ func TestAccResourceInstance_configUpdate(t *testing.T) {
 	resName := "linode_instance.foobar"
 
 	// This test can occasionally fail while running the entire test suite in parallel
-	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 3, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckInstanceDestroy,

--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -266,7 +266,7 @@ func TestAccResourceInstanceConfig_booted(t *testing.T) {
 func TestAccResourceInstanceConfig_bootedSwap(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 3, func(t *testing.T) {
 		var instance linodego.Instance
 
 		config1Name := "linode_instance_config.foobar1"
@@ -274,7 +274,7 @@ func TestAccResourceInstanceConfig_bootedSwap(t *testing.T) {
 		instanceName := acctest.RandomWithPrefix("tf_test")
 		rootPass := acctest.RandString(64)
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkDestroy,

--- a/linode/ipv6range/resource_test.go
+++ b/linode/ipv6range/resource_test.go
@@ -24,11 +24,11 @@ const testRegion = "eu-central"
 func TestAccIPv6Range_basic(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 3, func(t *testing.T) {
 		resName := "linode_ipv6_range.foobar"
 		instLabel := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkIPv6RangeDestroy,
@@ -62,11 +62,11 @@ func TestAccIPv6Range_basic(t *testing.T) {
 func TestAccIPv6Range_routeTarget(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 3, func(t *testing.T) {
 		resName := "linode_ipv6_range.foobar"
 		instLabel := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkIPv6RangeDestroy,
@@ -115,7 +115,7 @@ func TestAccIPv6Range_noID(t *testing.T) {
 func TestAccIPv6Range_reassignment(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 3, func(t *testing.T) {
 		resName := "linode_ipv6_range.foobar"
 		instance1ResName := "linode_instance.foobar"
 		instance2ResName := "linode_instance.foobar2"
@@ -125,7 +125,7 @@ func TestAccIPv6Range_reassignment(t *testing.T) {
 		var instance1 linodego.Instance
 		var instance2 linodego.Instance
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkIPv6RangeDestroy,
@@ -180,10 +180,10 @@ func TestAccIPv6Range_raceCondition(t *testing.T) {
 	t.Parallel()
 
 	// Occasionally IPv6 range deletions take a bit to replicate
-	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 3, func(t *testing.T) {
 		instLabel := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkIPv6RangeDestroy,

--- a/linode/ipv6range/resource_test.go
+++ b/linode/ipv6range/resource_test.go
@@ -183,7 +183,7 @@ func TestAccIPv6Range_raceCondition(t *testing.T) {
 	acceptance.RunTestRetry(t, 3, func(retryT *acceptance.TRetry) {
 		instLabel := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(t, resource.TestCase{
+		resource.Test(retryT, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkIPv6RangeDestroy,

--- a/linode/lke/framework_datasource_test.go
+++ b/linode/lke/framework_datasource_test.go
@@ -16,9 +16,9 @@ const dataSourceClusterName = "data.linode_lke_cluster.test"
 func TestAccDataSourceLKECluster_taints_labels(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -48,9 +48,9 @@ func TestAccDataSourceLKECluster_taints_labels(t *testing.T) {
 func TestAccDataSourceLKECluster_basic(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -83,9 +83,9 @@ func TestAccDataSourceLKECluster_basic(t *testing.T) {
 func TestAccDataSourceLKECluster_autoscaler(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -118,12 +118,12 @@ func TestAccDataSourceLKECluster_autoscaler(t *testing.T) {
 func TestAccDataSourceLKECluster_controlPlane(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
 		testIPv4 := "0.0.0.0/0"
 		testIPv6 := "2001:db8::/32"
 
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,

--- a/linode/lke/framework_resource_test.go
+++ b/linode/lke/framework_resource_test.go
@@ -180,9 +180,9 @@ func TestSmokeTests_lke(t *testing.T) {
 func TestAccResourceLKECluster_basic_smoke(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -229,9 +229,9 @@ func TestAccResourceLKECluster_k8sUpgrade(t *testing.T) {
 
 	var cluster linodego.LKECluster
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -295,10 +295,10 @@ func TestAccResourceLKECluster_basicUpdates(t *testing.T) {
 			return nil
 		})
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
 		newClusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:  func() { acceptance.PreCheck(t) },
 			Providers: providerMap,
 			Steps: []resource.TestStep{
@@ -332,10 +332,10 @@ func TestAccResourceLKECluster_basicUpdates(t *testing.T) {
 func TestAccResourceLKECluster_poolUpdates(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
 		newClusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -379,9 +379,9 @@ func TestAccResourceLKECluster_removeUnmanagedPool(t *testing.T) {
 
 	var cluster linodego.LKECluster
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -425,10 +425,10 @@ func TestAccResourceLKECluster_removeUnmanagedPool(t *testing.T) {
 func TestAccResourceLKECluster_autoScaler(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
 		// newClusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -500,14 +500,14 @@ func TestAccResourceLKECluster_autoScaler(t *testing.T) {
 func TestAccResourceLKECluster_controlPlane(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
 		testIPv4 := "0.0.0.0/0"
 		testIPv6 := "2001:db8::/32"
 		testIPv4Updated := "203.0.113.1"
 		testIPv6Updated := "2001:db8:1234:abcd::/64"
 
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
@@ -606,9 +606,9 @@ func TestAccResourceLKECluster_implicitCount(t *testing.T) {
 func TestAccResourceLKEClusterNodePoolTaintsLabels(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,

--- a/linode/lkeclusters/datasource_test.go
+++ b/linode/lkeclusters/datasource_test.go
@@ -57,9 +57,9 @@ func TestAccDataSourceLKEClusters_basic(t *testing.T) {
 
 	dataSourceName := "data.linode_lke_clusters.test"
 
-	acceptance.RunTestRetry(t, 2, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 2, func(t *testing.T) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,

--- a/linode/obj/resource_test.go
+++ b/linode/obj/resource_test.go
@@ -60,11 +60,11 @@ func TestAccResourceObject_basic_cluster(t *testing.T) {
 	contentSource := acceptance.CreateTempFile(t, "tf-test-obj-source", content)
 	contentSourceUpdated := acceptance.CreateTempFile(t, "tf-test-obj-source-updated", contentUpdated)
 
-	acceptance.RunTestRetry(t, 6, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 6, func(t *testing.T) {
 		bucketName := acctest.RandomWithPrefix("tf-test")
 		keyName := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkObjectDestroy,
@@ -115,11 +115,11 @@ func TestAccResourceObject_basic(t *testing.T) {
 	contentSource := acceptance.CreateTempFile(t, "tf-test-obj-source", content)
 	contentSourceUpdated := acceptance.CreateTempFile(t, "tf-test-obj-source-updated", contentUpdated)
 
-	acceptance.RunTestRetry(t, 6, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 6, func(t *testing.T) {
 		bucketName := acctest.RandomWithPrefix("tf-test")
 		keyName := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkObjectDestroy,
@@ -150,11 +150,11 @@ func TestAccResourceObject_credsConfiged(t *testing.T) {
 
 	content := "test_creds_configed"
 
-	acceptance.RunTestRetry(t, 6, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 6, func(t *testing.T) {
 		bucketName := acctest.RandomWithPrefix("tf-test")
 		keyName := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkObjectDestroy,
@@ -175,11 +175,11 @@ func TestAccResourceObject_tempKeys(t *testing.T) {
 
 	content := "test_temp_keys"
 
-	acceptance.RunTestRetry(t, 6, func(tRetry *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 6, func(t *testing.T) {
 		bucketName := acctest.RandomWithPrefix("tf-test")
 		keyName := acctest.RandomWithPrefix("tf_test")
 
-		resource.Test(tRetry, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkObjectDestroy,

--- a/linode/objbucket/datasource_test.go
+++ b/linode/objbucket/datasource_test.go
@@ -17,8 +17,8 @@ func TestAccDataSourceBucket_basic(t *testing.T) {
 	resourceName := "data.linode_object_storage_bucket.foobar"
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -47,8 +47,8 @@ func TestAccDataSourceBucket_basic_cluster(t *testing.T) {
 	resourceName := "data.linode_object_storage_bucket.foobar"
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -188,11 +188,11 @@ func TestSmokeTests_objbucket(t *testing.T) {
 func TestAccResourceBucket_basic_legacy_smoke(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
 		resName := "linode_object_storage_bucket.foobar"
 		objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -218,11 +218,11 @@ func TestAccResourceBucket_basic_legacy_smoke(t *testing.T) {
 func TestAccResourceBucket_basic_smoke(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
 		resName := "linode_object_storage_bucket.foobar"
 		objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -248,11 +248,11 @@ func TestAccResourceBucket_basic_smoke(t *testing.T) {
 func TestAccResourceBucket_access(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
 		resName := "linode_object_storage_bucket.foobar"
 		objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -283,12 +283,12 @@ func TestAccResourceBucket_access(t *testing.T) {
 func TestAccResourceBucket_versioning(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
 		resName := "linode_object_storage_bucket.foobar"
 		objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 		objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -317,12 +317,12 @@ func TestAccResourceBucket_versioning(t *testing.T) {
 func TestAccResourceBucket_lifecycle(t *testing.T) {
 	t.Parallel()
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
 		resName := "linode_object_storage_bucket.foobar"
 		objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 		objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
 
-		resource.Test(retryT, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -378,8 +378,8 @@ func TestAccResourceBucket_lifecycleNoID(t *testing.T) {
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 	objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -424,8 +424,8 @@ func TestAccResourceBucket_cert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -469,8 +469,8 @@ func TestAccResourceBucket_dataSource(t *testing.T) {
 	resName := "linode_object_storage_bucket.foobar"
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -498,8 +498,8 @@ func TestAccResourceBucket_update(t *testing.T) {
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 	resName := "linode_object_storage_bucket.foobar"
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -530,8 +530,8 @@ func TestAccResourceBucket_credsConfiged(t *testing.T) {
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 	objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -557,8 +557,8 @@ func TestAccResourceBucket_tempKeys(t *testing.T) {
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 	objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -584,8 +584,8 @@ func TestAccResourceBucket_forceDelete(t *testing.T) {
 	objectStorageBucketName := acctest.RandomWithPrefix("tf-test")
 	objectStorageKeyName := acctest.RandomWithPrefix("tf-test")
 
-	acceptance.RunTestRetry(t, 5, func(retryT *acceptance.TRetry) {
-		resource.Test(retryT, resource.TestCase{
+	acceptance.RunTestWithRetries(t, 5, func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { acceptance.PreCheck(t) },
 			ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 			CheckDestroy:             checkBucketDestroy,
@@ -612,19 +612,19 @@ func TestAccResourceBucket_forceDelete(t *testing.T) {
 
 						keys, err := client.CreateObjectStorageKey(context.Background(), createOpts)
 						if err != nil {
-							retryT.Errorf("error creating obj keys in PreConfig func: %v", err)
+							t.Errorf("error creating obj keys in PreConfig func: %v", err)
 						}
 						defer client.DeleteObjectStorageKey(context.Background(), keys.ID)
 
 						bucket, err := client.GetObjectStorageBucket(context.Background(), testRegion, objectStorageBucketName)
 						if err != nil {
-							retryT.Errorf("error getting obj bucket in PreConfig func: %v", err)
+							t.Errorf("error getting obj bucket in PreConfig func: %v", err)
 						}
 
 						endpoint := helper.ComputeS3EndpointFromBucket(context.Background(), *bucket)
 						s3client, err := helper.S3Connection(context.Background(), endpoint, keys.AccessKey, keys.SecretKey)
 						if err != nil {
-							retryT.Errorf("error connecting s3 in PreConfig func: %v", err)
+							t.Errorf("error connecting s3 in PreConfig func: %v", err)
 						}
 
 						contentBytes := []byte("delete test")


### PR DESCRIPTION
## 📝 Description

This pull request simplifies the test failure retry system using Go's subtest system and resolves an issue that was causing certain retryable tests (e.g. `TestAccIPv6Range_raceCondition`) to hang indefinitely on failure.

## ✔️ How to Test
The following test steps assume you have pulled down this PR locally.

### Integration Testing 

#### Running All Tests

```
make int-test
```

#### Verifying the Hanging Tests Fix

1. Ensure the number of resources provisioned in the `ipv6range_route_target` test template (located in `linode/ipv6range/tmpl/route_target.gotf`) is greater than your account's allowed IPv6 limit.

2. Run the `TestAccIPv6Range_raceCondition` test:

```
make PKG_NAME=linode/ipv6range ARGS="-run TestAccIPv6Range_raceCondition" int-test
```

3. Ensure the test fails after 3 attempts without hanging.