### PR TITLE
Fix Issue #1643 Update nodebalancer_config.md

### DIFF
--- a/docs/resources/nodebalancer_config.md
+++ b/docs/resources/nodebalancer_config.md
@@ -41,8 +41,6 @@ The following arguments are supported:
 
 * `nodebalancer_id` - (Required) The ID of the NodeBalancer to access.
 
-* `region` - (Required) The region where this nodebalancer_config will be deployed.  Examples are `"us-east"`, `"us-west"`, `"ap-south"`, etc. See all regions [here](https://api.linode.com/v4/regions). *Changing `region` forces the creation of a new Linode NodeBalancer Config.*.
-
 - - -
 
 * `protocol` - (Optional) The protocol this port is configured to serve. If this is set to https you must include an ssl_cert and an ssl_key. (`http`, `https`, `tcp`) (Defaults to `http`)


### PR DESCRIPTION
Fix issue #1643 - "region" is not a required argument

## 📝 Description

**What does this PR do and why is this change necessary?**

Update document to accurately reflect argument for ["linode_nodebalancer_config"](https://registry.terraform.io/providers/linode/linode/latest/docs/resources/nodebalancer_config)

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

Document change, no unit or integration tests needed.