### PR TITLE
test: Enable disk encryption tests

### DIFF
--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -30,9 +30,8 @@ func init() {
 		F:    sweep,
 	})
 
-	// TODO:: Add linodego.CapabilityDiskEncryption back when it is enabled
 	region, err := acceptance.GetRandomRegionWithCaps([]string{
-		linodego.CapabilityVlans, linodego.CapabilityVPCs,
+		linodego.CapabilityVlans, linodego.CapabilityVPCs, linodego.CapabilityDiskEncryption,
 	}, "core")
 	if err != nil {
 		log.Fatal(err)
@@ -2527,10 +2526,7 @@ func TestAccResourceInstance_pgAssignment(t *testing.T) {
 	})
 }
 
-// TODO:: Un-skip this test once diskencryption is enabled
 func TestAccResourceInstance_diskEncryption(t *testing.T) {
-	t.Skip("Skip disk encryption tests until it is enabled in region")
-
 	t.Parallel()
 
 	resName := "linode_instance.foobar"


### PR DESCRIPTION
## 📝 Description

Un-skipping disk encryption tests 

## ✔️ How to Test

```
make PKG_NAME=linode/instance ARGS="-run TestAccResourceInstance_diskEncryption" int-test
make PKG_NAME=linode/instance ARGS="-run TestAccResourceInstance_basic_smoke" int-test
```


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**