### PR TITLE
Allow white space characters in the label of an SSH key

### DIFF
--- a/linode/helper/regex.go
+++ b/linode/helper/regex.go
@@ -1,21 +1,14 @@
 package helper
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-func StringToRegex(pattern string) (regExp *regexp.Regexp) {
-	regExp, err := regexp.Compile(pattern)
-	if err != nil {
-		fmt.Println("Error compiling regex:", err)
-		return
-	}
-
-	return regExp
+func StringToRegex(pattern string) *regexp.Regexp {
+	return regexp.MustCompile(pattern)
 }
 
 func RegexMatches(pattern string, errorMessage string) validator.String {

--- a/linode/sshkey/framework_datasource_schema.go
+++ b/linode/sshkey/framework_datasource_schema.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	SSHKeyLabelRegex        = "^[a-zA-Z0-9_-]*$"
+	SSHKeyLabelRegex        = "^[a-zA-Z0-9_\\-\\s]*$"
 	SSHKeyLabelErrorMessage = "Labels may only contain letters, number, dashes, and underscores."
 )
 

--- a/linode/sshkey/resource_test.go
+++ b/linode/sshkey/resource_test.go
@@ -78,6 +78,33 @@ func TestAccResourceSSHKey_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceSSHKey_space_in_label(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_sshkey.foobar"
+	sshkeyName := acctest.RandomWithPrefix("tf_test") + " "
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
+		CheckDestroy:             checkSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Basic(t, sshkeyName, acceptance.PublicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					checkSSHKeyExists,
+					resource.TestCheckResourceAttr(resName, "label", sshkeyName),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceSSHKey_update(t *testing.T) {
 	t.Parallel()
 	resName := "linode_sshkey.foobar"


### PR DESCRIPTION
## 📝 Description

This is to allow white spaces in the label of an SSH key resource, as it's allowed by the API.

## ✔️ How to Test

```bash
make int-test PKG_NAME="linode/sshkey"
```