### PR TITLE
doc: Remove Image Services Gen2 LA notice #628

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -63,7 +63,6 @@ resource "linode_image" "foobar" {
     file_path = "path/to/image.img.gz"
     file_hash = filemd5("path/to/image.img.gz")
     
-    // Note: Image replication may not be available to all users.
     replica_regions = ["us-southeast", "us-east", "eu-west"]
 }
 ```
@@ -78,7 +77,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A list of customized tags.
 
-* `replica_regions` - (Optional) A list of regions that customer wants to replicate this image in. At least one valid region is required and only core regions allowed. Existing images in the regions not passed will be removed. **Note:** Image replication may not be available to all users. See Replicate an Image [here](https://techdocs.akamai.com/linode-api/reference/post-replicate-image) for more details.
+* `replica_regions` - (Optional) A list of regions that customer wants to replicate this image in. At least one valid region is required and only core regions allowed. Existing images in the regions not passed will be removed. See Replicate an Image [here](https://techdocs.akamai.com/linode-api/reference/post-replicate-image) for more details.
 
 * `wait_for_replications` - (Optional) Whether to wait for all image replications become `available`. Default to false.
 


### PR DESCRIPTION
## 📝 Description

Image Services Gen2 goes generally available 🎉