### PR TITLE
Misc Fixes and Improvements

### DIFF
--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -38,7 +38,7 @@ func (r *Resource) Create(
 	req resource.CreateRequest,
 	resp *resource.CreateResponse,
 ) {
-	tflog.Debug(ctx, "Create linode_nodebalancer")
+	tflog.Debug(ctx, "Create "+r.Config.Name)
 	var data NodeBalancerModel
 	client := r.Meta.Client
 
@@ -116,7 +116,7 @@ func (r *Resource) Read(
 	req resource.ReadRequest,
 	resp *resource.ReadResponse,
 ) {
-	tflog.Debug(ctx, "Read linode_nodebalancer")
+	tflog.Debug(ctx, "Read "+r.Config.Name)
 
 	var data NodeBalancerModel
 	client := r.Meta.Client
@@ -177,7 +177,7 @@ func (r *Resource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
-	tflog.Debug(ctx, "Update linode_nodebalancer")
+	tflog.Debug(ctx, "Update "+r.Config.Name)
 
 	var plan, state NodeBalancerModel
 	client := r.Meta.Client
@@ -260,7 +260,7 @@ func (r *Resource) Delete(
 	req resource.DeleteRequest,
 	resp *resource.DeleteResponse,
 ) {
-	tflog.Debug(ctx, "Delete linode_nodebalancer")
+	tflog.Debug(ctx, "Delete "+r.Config.Name)
 
 	var data NodeBalancerModel
 	client := r.Meta.Client

--- a/linode/nbnode/framework_resource.go
+++ b/linode/nbnode/framework_resource.go
@@ -32,6 +32,8 @@ type Resource struct {
 
 func AddNodeResource(ctx context.Context, node linodego.NodeBalancerNode, resp *resource.CreateResponse, plan ResourceModel) {
 	resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(strconv.Itoa(node.ID)))
+	resp.State.SetAttribute(ctx, path.Root("nodebalancer_id"), types.StringValue(strconv.Itoa(node.NodeBalancerID)))
+	resp.State.SetAttribute(ctx, path.Root("config_id"), types.StringValue(strconv.Itoa(node.ConfigID)))
 }
 
 func (r *Resource) Create(
@@ -112,7 +114,7 @@ func (r *Resource) Read(
 			resp.Diagnostics.AddWarning(
 				"The NodeBalancer Node No Longer Exists",
 				fmt.Sprintf(
-					"Removing Linode Token with ID %v from state because it no longer exists", id,
+					"Removing NodeBalancer Node with ID %v from state because it no longer exists", id,
 				),
 			)
 			resp.State.RemoveResource(ctx)

--- a/linode/token/framework_resource_schema.go
+++ b/linode/token/framework_resource_schema.go
@@ -2,7 +2,6 @@ package token
 
 import (
 	"context"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -72,10 +71,9 @@ var frameworkResourceSchema = schema.Schema{
 						sr planmodifier.StringRequest,
 						rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse,
 					) {
-						rrifr.RequiresReplace = !helper.CompareTimeStrings(
+						rrifr.RequiresReplace = !helper.CompareRFC3339TimeStrings(
 							sr.PlanValue.ValueString(),
 							sr.StateValue.ValueString(),
-							time.RFC3339,
 						)
 					},
 					RequireReplacementWhenScopesChangedDescription,


### PR DESCRIPTION
## 📝 Description

- Use `r.Config.Name` as the SSoT for resource name in log in `linode_nodebalancer` resource.
- Use a simplified time comparison function in the schema of `linode_token` resource.
- Fix `AddNodeResource` function for `linode_nodebalancer_node` resource to add all required attributes for a `Read` function call (during `terraform refresh`).
- Fix an error message in `linode_nodebalancer_node` resource code.

## ✔️ How to Test
```bash
make int-test PKG_NAME="linode/token"
```

```bash
make int-test PKG_NAME="linode/nbnode"
```

```bash
make int-test PKG_NAME="linode/nb"
```