### PR TITLE
test: Update outdated alpine test images and stabilize intermittent failures related to instance

### DIFF
--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -109,7 +109,7 @@ func TestAccResourceInstance_basic_smoke(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "migration_type", "firewall_id"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_keys", "image", "resize_disk", "migration_type", "firewall_id", "capabilities"},
 			},
 		},
 	})
@@ -172,7 +172,7 @@ func TestAccResourceInstance_authorizedUsers(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_pass", "authorized_users", "image", "resize_disk", "migration_type", "firewall_id"},
+				ImportStateVerifyIgnore: []string{"root_pass", "authorized_users", "image", "resize_disk", "migration_type", "firewall_id", "capabilities"},
 			},
 		},
 	})

--- a/linode/instance/tmpl/templates/private_image.gotf
+++ b/linode/instance/tmpl/templates/private_image.gotf
@@ -7,7 +7,7 @@ resource "linode_instance" "foobar-orig" {
     group = "tf_test"
     type = "g6-nanode-1"
     region = "{{ .Region }}"
-    image = "linode/alpine3.19"
+    image = "linode/alpine3.20"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/instanceconfig/tmpl/instance_disk.gotf
+++ b/linode/instanceconfig/tmpl/instance_disk.gotf
@@ -5,7 +5,7 @@ resource "linode_instance_disk" "foobar" {
   linode_id = linode_instance.foobar.id
   size = linode_instance.foobar.specs.0.disk
 
-  image = "linode/alpine3.18"
+  image = "linode/alpine3.20"
   root_pass = "{{ .RootPass }}"
 }
 

--- a/linode/networkingip/tmpl/data_basic.gotf
+++ b/linode/networkingip/tmpl/data_basic.gotf
@@ -10,7 +10,7 @@ provider "linode" {
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.16"
+    image = "linode/ubuntu24.10"
     type = "g6-standard-1"
     region = "{{ .Region }}"
     firewall_id = linode_firewall.e2e_test_firewall.id

--- a/linode/rdns/tmpl/basic.gotf
+++ b/linode/rdns/tmpl/basic.gotf
@@ -5,7 +5,7 @@
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.18"
+    image = "linode/alpine3.20"
     type = "g6-standard-1"
     region = "{{ .Region }}"
     firewall_id = linode_firewall.e2e_test_firewall.id

--- a/linode/rdns/tmpl/changed.gotf
+++ b/linode/rdns/tmpl/changed.gotf
@@ -5,7 +5,7 @@
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.18"
+    image = "linode/alpine3.20"
     type = "g6-standard-1"
     region = "{{ .Region }}"
     firewall_id = linode_firewall.e2e_test_firewall.id

--- a/linode/rdns/tmpl/deleted.gotf
+++ b/linode/rdns/tmpl/deleted.gotf
@@ -5,7 +5,7 @@
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
     group = "tf_test"
-    image = "linode/alpine3.18"
+    image = "linode/alpine3.20"
     type = "g6-standard-1"
     region = "{{ .Region }}"
     firewall_id = linode_firewall.e2e_test_firewall.id

--- a/linode/rdns/tmpl/with_timeout.gotf
+++ b/linode/rdns/tmpl/with_timeout.gotf
@@ -4,7 +4,7 @@
 
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
-    image = "linode/alpine3.19"
+    image = "linode/alpine3.20"
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     firewall_id = linode_firewall.e2e_test_firewall.id

--- a/linode/rdns/tmpl/with_timeout_updated.gotf
+++ b/linode/rdns/tmpl/with_timeout_updated.gotf
@@ -4,7 +4,7 @@
 
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
-    image = "linode/alpine3.19"
+    image = "linode/alpine3.20"
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     firewall_id = linode_firewall.e2e_test_firewall.id


### PR DESCRIPTION
Test image alpine 3.16 is deprecated hence updating the test images to something more recent. Also fix intermittent test failures caused by 
```
Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import. map[string]string{ - "capabilities.#": "1", + "capabilities.#": "2", - "capabilities.0": "SMTP Enabled", + "capabilities.0": "Block Storage Encryption", + "capabilities.1": "SMTP Enabled", }
```

## ✔️ How to Test

PR Run - https://github.com/linode/terraform-provider-linode/actions/runs/12146231475

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**