### PR TITLE
Maintain consistency of `ip_address` when additional addresses are added to the instance

### DIFF
--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -35,6 +35,14 @@ func getDeadlineSeconds(ctx context.Context, d *schema.ResourceData) int {
 	return int(duration.Seconds())
 }
 
+func setPublicIPAddress(d *schema.ResourceData, ip string) {
+	d.Set("ip_address", ip)
+	d.SetConnInfo(map[string]string{
+		"type": "ssh",
+		"host": ip,
+	})
+}
+
 func createInstanceConfigsFromSet(
 	ctx context.Context,
 	client linodego.Client,


### PR DESCRIPTION
## 📝 Description

This change ensures the TF resource won't change the value of the `ip_address` attribute unless the initial IP address assigned to the Linode no longer exists.

## ✔️ How to Test

### Automated Testing
```bash
make int-test PKG_NAME="linode/instance"
```
(you might need some customer tags for some LA projects to pass every test)

### Manual Testing

#### Step 1

Record the state value of the `ip_address` attribute of the instance resource after applying.

```hcl
resource "linode_instance" "foo" {
    image = "linode/ubuntu24.04"
    label = "foobar-test"
    type = "g6-standard-1"
    region = "us-mia"
}
```

```bash
tofu apply --auto-approve
```

#### Step 2

Verify that the new value of the `ip_address` attribute of the instance resource matches the value recorded above after applying and refreshing.

```hcl
resource "linode_instance" "foo" {
    image = "linode/ubuntu24.04"
    label = "foobar-test"
    type = "g6-standard-1"
    region = "us-lax"
}

resource "linode_instance_ip" "foo" {
    linode_id = linode_instance.foo.id
    public = true
}

resource "linode_instance_ip" "bar" {
    linode_id = linode_instance.foo.id
    public = true
}

resource "linode_instance_ip" "baz" {
    linode_id = linode_instance.foo.id
    public = true
}

resource "linode_instance_ip" "qux" {
    linode_id = linode_instance.foo.id
    public = true
}
```

```bash
tofu apply --auto-approve
tofu refresh
```