### PR TITLE
test: Add ignore for inconsistent updated timestamp in api response

### DIFF
--- a/linode/vpcsubnet/resource_test.go
+++ b/linode/vpcsubnet/resource_test.go
@@ -93,6 +93,8 @@ func TestAccResourceVPCSubnet_update(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: resourceImportStateID,
+				// TODO:: remove when API response for updated timestamp is consistent
+				ImportStateVerifyIgnore: []string{"updated"},
 			},
 		},
 	})


### PR DESCRIPTION
## 📝 Description

There is a bug currently in API for updated timestamp which is causing `TestAccResourceVPCSubnet_update` test to fail intermittently

## ✔️ How to Test

` make PKG_NAME=linode/vpcsubnet ARGS="-run TestAccResourceVPCSubnet_update" int-test `

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**