### PR TITLE
Preserve booted status from state if instance is booted but boot event is unresolvable

### DIFF
--- a/linode/instanceconfig/helper.go
+++ b/linode/instanceconfig/helper.go
@@ -332,6 +332,14 @@ func isConfigBooted(
 	//
 	// In this case, we want to preserve the existing booted value from state.
 	if currentConfig == 0 {
+		tflog.Info(
+			ctx,
+			"booted: The instance is online but a boot event could not be resolved. "+
+				"The previous value from state will be used.",
+			map[string]any{
+				"assumed_value": previousValue,
+			},
+		)
 		return previousValue, nil
 	}
 

--- a/linode/instanceconfig/resource.go
+++ b/linode/instanceconfig/resource.go
@@ -96,7 +96,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("failed to get instance networking: %s", err)
 	}
 
-	configBooted, err := isConfigBooted(ctx, &client, inst, cfg.ID)
+	configBooted, err := isConfigBooted(ctx, &client, inst, cfg.ID, d.Get("booted").(bool))
 	if err != nil {
 		return diag.Errorf("failed to check instance boot status: %s", err)
 	}
@@ -346,7 +346,7 @@ func deleteResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	// Shutdown the instance if the config is in use
-	if booted, err := isConfigBooted(ctx, &client, inst, id); err != nil {
+	if booted, err := isConfigBooted(ctx, &client, inst, id, d.Get("booted").(bool)); err != nil {
 		return diag.Errorf("failed to check if config is booted: %s", err)
 	} else if booted {
 		tflog.Info(ctx, "Shutting down instance for config deletion")


### PR DESCRIPTION
## 📝 Description

This pull request adds logic to the `linode_instance_config` resource to preserve the `booted` field's value from state if:

* The instance is currently running
* No `linode_boot` or `linode_reboot` event could be found for the instance

This resolves an issue that would cause a config to be incorrectly treated as not booted when:

* The last boot event was > 90 days ago (due to event expiration)
* The instance has been transferred between accounts

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make PKG_NAME=linode/instanceconfig int-test
```

### Manual Testing

**NOTE: These test steps require that you have two Linode accounts.**

1. Export the following environment variables using PATs for two separate Linode accounts:

```shell
export LINODE_TOKEN_1=MYFIRSTACCOUNTSTOKEN
export LINODE_TOKEN_2=MYSECONDACCOUNTSTOKEN
```

2. Run the following to configure your shell for the first account:

```shell
export LINODE_TOKEN=$LINODE_TOKEN_1
export LINODE_CLI_TOKEN=$LINODE_TOKEN
```

3. Using a terraform-provider-linode sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
resource "linode_instance" "test" {
  label      = "test-instance"
  region     = "us-mia"
  type       = "g6-nanode-1"
  private_ip = true
}

resource "linode_instance_disk" "boot_disk" {
  label     = "boot"
  linode_id = linode_instance.test.id
  size  = 4000
  image = "linode/ubuntu24.04"
  root_pass        = "terr4form-tes!!!!!!t!!"
}

resource "linode_instance_config" "boot_config" {
  label     = "boot_config"
  linode_id = linode_instance.test.id

  device {
    device_name = "sda"
    disk_id     = linode_instance_disk.boot_disk.id
  }

  root_device = "/dev/sda"
  kernel      = "linode/latest-64bit"
  booted      = true
}
```

4. Initiate a service transfer for the newly created instance:

```shell
linode-cli service-transfers create --entities.linodes MYINSTANCEID
```

5. Run the following to switch your environment to the second account:

```shell
export LINODE_TOKEN=$LINODE_TOKEN_2
export LINODE_CLI_TOKEN=$LINODE_TOKEN
```

6. Accept the service transfer on the second account:

```shell
linode-cli service-transfers accept MYSERVICETRANSFERTOKEN
```

7. Wait for the service transfer to complete.

8. Re-apply the Terraform configuration and ensure no changes are proposed.