### PR TITLE
Deprecate legacy DBaaS resources

### DIFF
--- a/docs/data-sources/database_backups.md
+++ b/docs/data-sources/database_backups.md
@@ -6,6 +6,8 @@ description: |-
 
 # Data Source: linode\_database\_backups
 
+~> **DEPRECATION NOTICE:** This data source has been deprecated.
+
 Provides information about Linode Database Backups that match a set of filters.
 For more information, see the Linode APIv4 docs for [MySQL](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-backups) and [PostgreSQL](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-backups).
 

--- a/docs/data-sources/database_mysql.md
+++ b/docs/data-sources/database_mysql.md
@@ -6,6 +6,8 @@ description: |-
 
 # Data Source: linode\_database\_mysql
 
+~> **DEPRECATION NOTICE:** This data source has been deprecated. Please use [linode_database_mysql_v2](database_mysql_v2.html.markdown) for all future implementations.
+
 Provides information about a Linode MySQL Database.
 For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-instances).
 

--- a/docs/data-sources/database_mysql_backups.md
+++ b/docs/data-sources/database_mysql_backups.md
@@ -6,10 +6,10 @@ description: |-
 
 # Data Source: linode\_database\_mysql\_backups
 
+~> **DEPRECATION NOTICE:** This data source has been deprecated.
+
 Provides information about Linode MySQL Database Backups that match a set of filters.
 For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-mysql-instance-backups).
-
-~> **NOTICE:** This data source has been deprecated in favor of `linode_database_backups`.
 
 ## Example Usage
 

--- a/docs/data-sources/database_postgresql.md
+++ b/docs/data-sources/database_postgresql.md
@@ -6,6 +6,8 @@ description: |-
 
 # Data Source: linode\_database\_postgresql
 
+~> **DEPRECATION NOTICE:** This data source has been deprecated. Please use [linode_database_postgresql_v2](database_postgresql_v2.html.markdown) for all future implementations.
+
 Provides information about a Linode PostgreSQL Database.
 For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-postgre-sql-instance-backups).
 

--- a/docs/resources/database_mysql.md
+++ b/docs/resources/database_mysql.md
@@ -6,6 +6,8 @@ description: |-
 
 # linode\_database\_mysql
 
+~> **DEPRECATION NOTICE:** This resource has been deprecated. Please use [linode_database_mysql_v2](database_mysql_v2.html.markdown) for all future implementations.
+
 Provides a Linode MySQL Database resource. This can be used to create, modify, and delete Linode MySQL Databases.
 For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-databases-instances).
 

--- a/docs/resources/database_postgresql.md
+++ b/docs/resources/database_postgresql.md
@@ -6,6 +6,8 @@ description: |-
 
 # linode\_database\_postgresql
 
+~> **DEPRECATION NOTICE:** This resource has been deprecated. Please use [linode_database_postgresql_v2](database_postgresql_v2.html.markdown) for all future implementations.
+
 Provides a Linode PostgreSQL Database resource. This can be used to create, modify, and delete Linode PostgreSQL Databases.
 For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/post-databases-postgre-sql-instances).
 

--- a/linode/databasebackups/framework_datasource_schema.go
+++ b/linode/databasebackups/framework_datasource_schema.go
@@ -38,6 +38,7 @@ var backupSchema = schema.NestedBlockObject{
 }
 
 var frameworkDataSourceSchema = schema.Schema{
+	DeprecationMessage: "This resource has been deprecated.",
 	Attributes: map[string]schema.Attribute{
 		"database_id": schema.Int64Attribute{
 			Description: "The ID of the Managed Database.",

--- a/linode/databasebackups/framework_datasource_schema.go
+++ b/linode/databasebackups/framework_datasource_schema.go
@@ -38,7 +38,7 @@ var backupSchema = schema.NestedBlockObject{
 }
 
 var frameworkDataSourceSchema = schema.Schema{
-	DeprecationMessage: "This resource has been deprecated.",
+	DeprecationMessage: "This data source has been deprecated.",
 	Attributes: map[string]schema.Attribute{
 		"database_id": schema.Int64Attribute{
 			Description: "The ID of the Managed Database.",

--- a/linode/databasemysql/framework_datasource_schema.go
+++ b/linode/databasemysql/framework_datasource_schema.go
@@ -10,7 +10,7 @@ import (
 )
 
 var frameworkDatasourceSchema = schema.Schema{
-	DeprecationMessage: "This resource has been deprecated. " +
+	DeprecationMessage: "This data source has been deprecated. " +
 		"Please use linode_database_mysql_v2 for all future implementations.",
 	Attributes: map[string]schema.Attribute{
 		"database_id": schema.Int64Attribute{

--- a/linode/databasemysql/framework_datasource_schema.go
+++ b/linode/databasemysql/framework_datasource_schema.go
@@ -10,6 +10,8 @@ import (
 )
 
 var frameworkDatasourceSchema = schema.Schema{
+	DeprecationMessage: "This resource has been deprecated. " +
+		"Please use linode_database_mysql_v2 for all future implementations.",
 	Attributes: map[string]schema.Attribute{
 		"database_id": schema.Int64Attribute{
 			DeprecationMessage: "Configure `id` instead. This attribute will be removed " +

--- a/linode/databasemysql/resource.go
+++ b/linode/databasemysql/resource.go
@@ -36,6 +36,8 @@ func Resource() *schema.Resource {
 			Update: schema.DefaultTimeout(updateDBTimeout),
 			Delete: schema.DefaultTimeout(deleteDBTimeout),
 		},
+		DeprecationMessage: "This resource has been deprecated. " +
+			"Please use linode_database_mysql_v2 for all future implementations.",
 	}
 }
 

--- a/linode/databasemysqlbackups/datasource.go
+++ b/linode/databasemysqlbackups/datasource.go
@@ -11,8 +11,9 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		Schema:      dataSourceSchema,
-		ReadContext: readDataSource,
+		DeprecationMessage: "This resource has been deprecated.",
+		Schema:             dataSourceSchema,
+		ReadContext:        readDataSource,
 	}
 }
 

--- a/linode/databasemysqlbackups/datasource.go
+++ b/linode/databasemysqlbackups/datasource.go
@@ -11,7 +11,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "This resource has been deprecated.",
+		DeprecationMessage: "This data source has been deprecated.",
 		Schema:             dataSourceSchema,
 		ReadContext:        readDataSource,
 	}

--- a/linode/databasepostgresql/framework_datasource_schema.go
+++ b/linode/databasepostgresql/framework_datasource_schema.go
@@ -10,7 +10,7 @@ import (
 )
 
 var frameworkDatasourceSchema = schema.Schema{
-	DeprecationMessage: "This resource has been deprecated. " +
+	DeprecationMessage: "This data source has been deprecated. " +
 		"Please use linode_database_postgresql_v2 for all future implementations.",
 	Attributes: map[string]schema.Attribute{
 		"database_id": schema.Int64Attribute{

--- a/linode/databasepostgresql/framework_datasource_schema.go
+++ b/linode/databasepostgresql/framework_datasource_schema.go
@@ -10,6 +10,8 @@ import (
 )
 
 var frameworkDatasourceSchema = schema.Schema{
+	DeprecationMessage: "This resource has been deprecated. " +
+		"Please use linode_database_postgresql_v2 for all future implementations.",
 	Attributes: map[string]schema.Attribute{
 		"database_id": schema.Int64Attribute{
 			DeprecationMessage: "Configure `id` instead. This attribute will be removed " +

--- a/linode/databasepostgresql/resource.go
+++ b/linode/databasepostgresql/resource.go
@@ -36,6 +36,8 @@ func Resource() *schema.Resource {
 			Update: schema.DefaultTimeout(updateDBTimeout),
 			Delete: schema.DefaultTimeout(deleteDBTimeout),
 		},
+		DeprecationMessage: "This resource has been deprecated. " +
+			"Please use linode_database_postgresql_v2 for all future implementations.",
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

This pull request deprecates the following resources in favor of their DBaaS v2 counterparts:

* linode_database_mysql
* data.linode_database_mysql
* linode_database_postgresql
* data.linode_database_postgresql
* data.linode_database_backups

Depends on #1680 and #1701 