### PR TITLE
Use filter framework for linode_networking_ips data source

### DIFF
--- a/linode/networkingips/famework_datasource_schema.go
+++ b/linode/networkingips/famework_datasource_schema.go
@@ -1,82 +1,86 @@
 package networkingips
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
 )
 
-var updatedIPObjectType = types.ObjectType{
-	AttrTypes: map[string]attr.Type{
-		"address":     types.StringType,
-		"region":      types.StringType,
-		"gateway":     types.StringType,
-		"subnet_mask": types.StringType,
-		"prefix":      types.Int64Type,
-		"type":        types.StringType,
-		"public":      types.BoolType,
-		"rdns":        types.StringType,
-		"linode_id":   types.Int64Type,
-		"reserved":    types.BoolType,
-	},
+var filterConfig = frameworkfilter.Config{
+	"type":    {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"region":  {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"rdns":    {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"address": {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"prefix":  {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeInt},
+
+	"gateway":     {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+	"subnet_mask": {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+	"public":      {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+	"linode_id":   {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeInt},
+	"reserved":    {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeBool},
 }
 
 var frameworkDatasourceSchema = schema.Schema{
 	Attributes: map[string]schema.Attribute{
-		"address": schema.StringAttribute{
-			Description: "The IP address.",
-			// Required:    true,
-			Optional: true,
-		},
-		"gateway": schema.StringAttribute{
-			Description: "The default gateway for this address.",
-			Computed:    true,
-		},
-		"subnet_mask": schema.StringAttribute{
-			Description: "The mask that separates host bits from network bits for this address.",
-			Computed:    true,
-		},
-		"prefix": schema.Int64Attribute{
-			Description: "The number of bits set in the subnet mask.",
-			Computed:    true,
-		},
-		"type": schema.StringAttribute{
-			Description: "The type of address this is (ipv4, ipv6, ipv6/pool, ipv6/range).",
-			Computed:    true,
-		},
-		"public": schema.BoolAttribute{
-			Description: "Whether this is a public or private IP address.",
-			Computed:    true,
-		},
-		"rdns": schema.StringAttribute{
-			Description: "The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to " +
-				"a default value provided by Linode if not explicitly set.",
-			Computed: true,
-		},
-		"linode_id": schema.Int64Attribute{
-			Description: "The ID of the Linode this address currently belongs to.",
-			Computed:    true,
-		},
-		"region": schema.StringAttribute{
-			Description: "The Region this IP address resides in.",
-			Computed:    true,
-		},
 		"id": schema.StringAttribute{
-			Description: "A unique identifier for this datasource.",
+			Description: "The data source's unique ID.",
 			Computed:    true,
 		},
-		"reserved": schema.BoolAttribute{
-			Computed:    true,
-			Description: "Whether this IP is reserved or not.",
-		},
-		"ip_addresses": schema.ListAttribute{
-			Description: "A list of all IPs.",
-			Computed:    true,
-			ElementType: updatedIPObjectType,
-		},
-		"filter_reserved": schema.BoolAttribute{
-			Description: "Filter IPs by reserved status.",
-			Optional:    true,
+		"order":    filterConfig.OrderSchema(),
+		"order_by": filterConfig.OrderBySchema(),
+	},
+	Blocks: map[string]schema.Block{
+		"filter": filterConfig.Schema(),
+		"ip_addresses": schema.ListNestedBlock{
+			Description: "The returned list of Images.",
+			NestedObject: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"address": schema.StringAttribute{
+						Description: "The IP address.",
+						Computed:    true,
+					},
+					"gateway": schema.StringAttribute{
+						Description: "The default gateway for this address.",
+						Computed:    true,
+					},
+					"subnet_mask": schema.StringAttribute{
+						Description: "The mask that separates host bits from network bits for this address.",
+						Computed:    true,
+					},
+					"prefix": schema.Int64Attribute{
+						Description: "The number of bits set in the subnet mask.",
+						Computed:    true,
+					},
+					"type": schema.StringAttribute{
+						Description: "The type of address this is (ipv4, ipv6, ipv6/pool, ipv6/range).",
+						Computed:    true,
+					},
+					"public": schema.BoolAttribute{
+						Description: "Whether this is a public or private IP address.",
+						Computed:    true,
+					},
+					"rdns": schema.StringAttribute{
+						Description: "The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to " +
+							"a default value provided by Linode if not explicitly set.",
+						Computed: true,
+					},
+					"linode_id": schema.Int64Attribute{
+						Description: "The ID of the Linode this address currently belongs to.",
+						Computed:    true,
+					},
+					"region": schema.StringAttribute{
+						Description: "The Region this IP address resides in.",
+						Computed:    true,
+					},
+					"id": schema.StringAttribute{
+						Description: "A unique identifier for this datasource.",
+						Computed:    true,
+					},
+					"reserved": schema.BoolAttribute{
+						Computed:    true,
+						Description: "Whether this IP is reserved or not.",
+					},
+				},
+			},
 		},
 	},
 }

--- a/linode/networkingips/famework_datasource_schema.go
+++ b/linode/networkingips/famework_datasource_schema.go
@@ -71,10 +71,6 @@ var frameworkDatasourceSchema = schema.Schema{
 						Description: "The Region this IP address resides in.",
 						Computed:    true,
 					},
-					"id": schema.StringAttribute{
-						Description: "A unique identifier for this datasource.",
-						Computed:    true,
-					},
 					"reserved": schema.BoolAttribute{
 						Computed:    true,
 						Description: "Whether this IP is reserved or not.",

--- a/linode/networkingips/framework_datasource_models.go
+++ b/linode/networkingips/framework_datasource_models.go
@@ -17,7 +17,7 @@ type IPAddressModel struct {
 	SubnetMask types.String `tfsdk:"subnet_mask"`
 	Public     types.Bool   `tfsdk:"public"`
 	LinodeID   types.Int64  `tfsdk:"linode_id"`
-	Reserved   types.Bool   `tsdk:"reserved"`
+	Reserved   types.Bool   `tfsdk:"reserved"`
 }
 
 func (m *IPAddressModel) ParseIP(ip linodego.InstanceIP) {

--- a/linode/networkingips/framework_datasource_models.go
+++ b/linode/networkingips/framework_datasource_models.go
@@ -1,0 +1,60 @@
+package networkingips
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v2/linode/helper/frameworkfilter"
+)
+
+type IPAddressModel struct {
+	Address    types.String `tfsdk:"address"`
+	Type       types.String `tfsdk:"type"`
+	Region     types.String `tfsdk:"region"`
+	RDNS       types.String `tfsdk:"rdns"`
+	Prefix     types.Int64  `tfsdk:"prefix"`
+	Gateway    types.String `tfsdk:"gateway"`
+	SubnetMask types.String `tfsdk:"subnet_mask"`
+	Public     types.Bool   `tfsdk:"public"`
+	LinodeID   types.Int64  `tfsdk:"linode_id"`
+	Reserved   types.Bool   `tsdk:"reserved"`
+}
+
+func (m *IPAddressModel) ParseIP(ip linodego.InstanceIP) {
+	m.Address = types.StringValue(ip.Address)
+	m.Type = types.StringValue(string(ip.Type))
+	m.Region = types.StringValue(ip.Region)
+	m.RDNS = types.StringValue(ip.RDNS)
+	m.Prefix = types.Int64Value(int64(ip.Prefix))
+	m.Gateway = types.StringValue(ip.Gateway)
+	m.SubnetMask = types.StringValue(ip.SubnetMask)
+	m.Public = types.BoolValue(ip.Public)
+	m.LinodeID = types.Int64Value(int64(ip.LinodeID))
+	m.Reserved = types.BoolValue(ip.Reserved)
+}
+
+// FilterModel describes the Terraform resource data model to match the
+// resource schema.
+type FilterModel struct {
+	ID          types.String                     `tfsdk:"id"`
+	Filters     frameworkfilter.FiltersModelType `tfsdk:"filter"`
+	Order       types.String                     `tfsdk:"order"`
+	OrderBy     types.String                     `tfsdk:"order_by"`
+	IPAddresses []IPAddressModel                 `tfsdk:"ip_addresses"`
+}
+
+func (data *FilterModel) parseIPAddresses(
+	ips []linodego.InstanceIP,
+) diag.Diagnostics {
+	result := make([]IPAddressModel, len(ips))
+
+	for i := range ips {
+		var data IPAddressModel
+		data.ParseIP(ips[i])
+		result[i] = data
+	}
+
+	data.IPAddresses = result
+
+	return nil
+}

--- a/linode/networkingips/tmpl/data_filter.gotf
+++ b/linode/networkingips/tmpl/data_filter.gotf
@@ -1,7 +1,10 @@
 {{ define "networking_ip_data_filtered" }}
 
 data "linode_networking_ips" "filtered" {
-  filter_reserved = true
+    filter {
+        name = "reserved"
+        values = ["true"]
+    }
 }
 
 {{ end }}

--- a/linode/networkingips/tmpl/data_filter.gotf
+++ b/linode/networkingips/tmpl/data_filter.gotf
@@ -1,6 +1,15 @@
 {{ define "networking_ip_data_filtered" }}
 
+resource "linode_networking_ip" "test" {
+    type = "ipv4"
+    region = "us-mia"
+    reserved = true
+    public = true
+}
+
 data "linode_networking_ips" "filtered" {
+    depends_on = [linode_networking_ip.test]
+
     filter {
         name = "reserved"
         values = ["true"]

--- a/linode/networkingips/tmpl/data_list.gotf
+++ b/linode/networkingips/tmpl/data_list.gotf
@@ -1,6 +1,15 @@
 {{ define "networking_ip_data_list" }}
 
+resource "linode_networking_ip" "test" {
+    type = "ipv4"
+    region = "us-mia"
+    reserved = true
+    public = true
+
+}
+
 data "linode_networking_ips" "list" {
+    depends_on = [linode_networking_ip.test]
 }
 
 {{ end }}


### PR DESCRIPTION
## 📝 Description

This pull request makes use of the filter framework in the `linode_networking_ips` data source and corrects the templates for the integration test cases. This is technically a breaking change but shouldn't cause any problems since this data source hasn't been released yet.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make PKG_NAME=linode/networkingips int-test
```

### Manual Testing

TODO