### PR TITLE
Manually compute CRC32 sum in PutObject helper

### DIFF
--- a/linode/helper/objects.go
+++ b/linode/helper/objects.go
@@ -51,6 +51,8 @@ func S3Connection(ctx context.Context, endpoint, accessKey, secretKey string) (*
 	}
 	s3Client := s3.NewFromConfig(awsSDKConfig, func(opts *s3.Options) {
 		opts.BaseEndpoint = aws.String("https://" + endpoint)
+
+		opts.DisableLogOutputChecksumValidationSkipped = true
 	})
 	return s3Client, nil
 }


### PR DESCRIPTION
## 📝 Description

This pull request manually computes the CRC32 sum of the object body for use in PutObjectInput struct. In theory this hash should be computed implicitly by the AWS SDK, but for some reason that functionality isn't working in the latest version.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make PKG_NAME=linode/obj int-test
```
