### PR TITLE
Adding Support for Object Storage Gen2 in Existing Resources and Data Sources

### DIFF
--- a/docs/resources/object_storage_bucket.md
+++ b/docs/resources/object_storage_bucket.md
@@ -111,6 +111,10 @@ For example, `us-mia-1` cluster can be translated into `us-mia` region. Exactly 
   * configured by [`obj_secret_key`](../index.md#configuration-reference) in the provider configuration;
   * or, generated implicitly at apply-time if [`obj_use_temp_keys`](../index.md#configuration-reference) at provider-level is set.
 
+* `endpoint_type` - (Optional) The type of `s3_endpoint` available to the user in this region. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.
+
+* `s3_endpoint` - (Optional) The user's s3 endpoint URL, based on the `endpoint_type` and `region`.
+
 * `cors_enabled` - (Optional) If true, the bucket will have CORS enabled for all origins.
 
 * `versioning` - (Optional) Whether to enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. (Requires `access_key` and `secret_key`)

--- a/docs/resources/object_storage_key.md
+++ b/docs/resources/object_storage_key.md
@@ -93,3 +93,5 @@ This resource exports the following attributes:
   * `id` - The ID of the region.
 
   * `s3_endpoint` - The S3-compatible hostname you can use to access the Object Storage buckets in this region.
+
+  * `endpoint_type` - The type of `s3_endpoint` available to the user in this region. See [Endpoint types](https://techdocs.akamai.com/cloud-computing/docs/object-storage#endpoint-type) for more information.

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -585,6 +585,57 @@ func ModifyProviderMeta(provider *schema.Provider, modifier ProviderMetaModifier
 	}
 }
 
+func GetEndpointType(e linodego.ObjectStorageEndpoint) string {
+	return string(e.EndpointType)
+}
+
+func GetEndpointRegion(e linodego.ObjectStorageEndpoint) string {
+	return e.Region
+}
+
+func GetEndpointCluster(e linodego.ObjectStorageEndpoint) (string, error) {
+	if e.S3Endpoint == nil {
+		return "", fmt.Errorf(
+			"the %q type endpoint is nil for region %q for the user",
+			e.EndpointType, e.Region,
+		)
+	}
+
+	endpointURL := *e.S3Endpoint
+	splittedURL := strings.Split(endpointURL, ".")
+	if len(splittedURL) == 0 {
+		return "", fmt.Errorf("invalid s3 endpoint received: %v", splittedURL)
+	}
+
+	return strings.Split(endpointURL, ".")[0], nil
+}
+
+// Get an Object Storage services endpoint with non-nil S3Endpoint
+func GetRandomObjectStorageEndpoint() (*linodego.ObjectStorageEndpoint, error) {
+	client, err := GetTestClient()
+	if err != nil {
+		return nil, err
+	}
+
+	endpoints, err := client.ListObjectStorageEndpoints(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rand.Shuffle(len(endpoints), func(i, j int) {
+		endpoints[i], endpoints[j] = endpoints[j], endpoints[i]
+	})
+
+	for i := range endpoints {
+		if endpoints[i].S3Endpoint != nil {
+			result := endpoints[i]
+			return &result, nil
+		}
+	}
+
+	return nil, errors.New("failed to get an object storage endpoint")
+}
+
 // GetRegionsWithCaps returns a list of region IDs that support the given capabilities
 // Parameters:
 // - capabilities: Required capabilities that the regions must support.

--- a/linode/helper/objects.go
+++ b/linode/helper/objects.go
@@ -66,7 +66,7 @@ func S3ConnectionFromData(
 	accessKey, secretKey string,
 ) (*s3.Client, error) {
 	tflog.Debug(ctx, "Creating Object Storage client from resource data")
-	endpoint := d.Get("endpoint").(string)
+	endpoint := d.Get("s3_endpoint").(string)
 	if endpoint == "" {
 		var err error
 		if endpoint, err = ComputeS3Endpoint(ctx, d, meta); err != nil {

--- a/linode/obj/framework_models.go
+++ b/linode/obj/framework_models.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -137,9 +136,7 @@ func (plan *ResourceModel) ComputeEndpointIfUnknown(ctx context.Context, client 
 		return
 	}
 
-	plan.Endpoint = types.StringValue(
-		strings.TrimPrefix(bucket.Hostname, fmt.Sprintf("%s.", bucket.Label)),
-	)
+	plan.Endpoint = types.StringValue(bucket.S3Endpoint)
 }
 
 func (data *ResourceModel) GenerateObjectStorageObjectID(apply bool, preserveKnown bool) string {

--- a/linode/obj/resource_test.go
+++ b/linode/obj/resource_test.go
@@ -26,13 +26,17 @@ var (
 )
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{"Object Storage"}, "core")
+	endpoint, err := acceptance.GetRandomObjectStorageEndpoint()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	testCluster = region + "-1"
-	testRegion = region
+	testCluster, err = acceptance.GetEndpointCluster(*endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testRegion = acceptance.GetEndpointRegion(*endpoint)
 }
 
 func TestAccResourceObject_basic_cluster(t *testing.T) {

--- a/linode/objbucket/framework_datasource.go
+++ b/linode/objbucket/framework_datasource.go
@@ -36,17 +36,21 @@ func (data *DataSourceModel) parseObjectStorageBucket(bucket *linodego.ObjectSto
 	data.Label = types.StringValue(bucket.Label)
 	data.Objects = types.Int64Value(int64(bucket.Objects))
 	data.Size = types.Int64Value(int64(bucket.Size))
+	data.EndpointType = types.StringValue(string(bucket.EndpointType))
+	data.S3Endpoint = types.StringValue(bucket.S3Endpoint)
 }
 
 type DataSourceModel struct {
-	Cluster  types.String `tfsdk:"cluster"`
-	Region   types.String `tfsdk:"region"`
-	Created  types.String `tfsdk:"created"`
-	Hostname types.String `tfsdk:"hostname"`
-	ID       types.String `tfsdk:"id"`
-	Label    types.String `tfsdk:"label"`
-	Objects  types.Int64  `tfsdk:"objects"`
-	Size     types.Int64  `tfsdk:"size"`
+	Cluster      types.String `tfsdk:"cluster"`
+	Region       types.String `tfsdk:"region"`
+	Created      types.String `tfsdk:"created"`
+	Hostname     types.String `tfsdk:"hostname"`
+	ID           types.String `tfsdk:"id"`
+	Label        types.String `tfsdk:"label"`
+	Objects      types.Int64  `tfsdk:"objects"`
+	Size         types.Int64  `tfsdk:"size"`
+	EndpointType types.String `tfsdk:"endpoint_type"`
+	S3Endpoint   types.String `tfsdk:"s3_endpoint"`
 }
 
 func (d *DataSource) Read(

--- a/linode/objbucket/framework_datasource_schema.go
+++ b/linode/objbucket/framework_datasource_schema.go
@@ -32,6 +32,14 @@ var frameworkDatasourceSchema = schema.Schema{
 				),
 			},
 		},
+		"endpoint_type": schema.StringAttribute{
+			Description: "The type of the S3 endpoint of the bucket.",
+			Computed:    true,
+		},
+		"s3_endpoint": schema.StringAttribute{
+			Description: "The S3 endpoint URL of the bucket, based on the `endpoint_type` and `region`.",
+			Computed:    true,
+		},
 		"created": schema.StringAttribute{
 			Description: "When this bucket was created.",
 			Computed:    true,

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -130,6 +130,7 @@ func readResource(
 	d.Set("acl", access.ACL)
 	d.Set("cors_enabled", access.CorsEnabled)
 	d.Set("endpoint", bucket.S3Endpoint)
+	d.Set("s3_endpoint", bucket.S3Endpoint)
 	d.Set("endpoint_type", bucket.EndpointType)
 
 	return nil
@@ -155,7 +156,7 @@ func createResource(
 		createOpts.CorsEnabled = &corsEnabledBool
 	}
 
-	if endpoint, ok := d.GetOk("endpoint"); ok {
+	if endpoint, ok := d.GetOk("s3_endpoint"); ok {
 		createOpts.S3Endpoint = endpoint.(string)
 	}
 
@@ -178,6 +179,7 @@ func createResource(
 	}
 
 	d.Set("endpoint", bucket.S3Endpoint)
+	d.Set("s3_endpoint", bucket.S3Endpoint)
 
 	if bucket.Region != "" {
 		d.SetId(fmt.Sprintf("%s:%s", bucket.Region, bucket.Label))

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -79,13 +79,10 @@ func readResource(
 	}
 
 	tflog.Debug(ctx, "getting bucket access info")
-	access, err := client.GetObjectStorageBucketAccess(ctx, regionOrCluster, label)
+	access, err := client.GetObjectStorageBucketAccessV2(ctx, regionOrCluster, label)
 	if err != nil {
 		return diag.Errorf("failed to find the access config for the specified Linode ObjectStorageBucket: %s", err)
 	}
-
-	// Functionality requiring direct S3 API access
-	endpoint := helper.ComputeS3EndpointFromBucket(ctx, *bucket)
 
 	_, versioningPresent := d.GetOk("versioning")
 	_, lifecyclePresent := d.GetOk("lifecycle_rule")
@@ -105,7 +102,7 @@ func readResource(
 			defer teardownKeysCleanUp()
 		}
 
-		s3Client, err := helper.S3Connection(ctx, endpoint, objKeys.AccessKey, objKeys.SecretKey)
+		s3Client, err := helper.S3Connection(ctx, bucket.S3Endpoint, objKeys.AccessKey, objKeys.SecretKey)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -132,7 +129,8 @@ func readResource(
 	d.Set("hostname", bucket.Hostname)
 	d.Set("acl", access.ACL)
 	d.Set("cors_enabled", access.CorsEnabled)
-	d.Set("endpoint", endpoint)
+	d.Set("endpoint", bucket.S3Endpoint)
+	d.Set("endpoint_type", bucket.EndpointType)
 
 	return nil
 }
@@ -146,18 +144,31 @@ func createResource(
 
 	label := d.Get("label").(string)
 	acl := d.Get("acl").(string)
-	corsEnabled := d.Get("cors_enabled").(bool)
 
 	createOpts := linodego.ObjectStorageBucketCreateOptions{
-		Label:       label,
-		ACL:         linodego.ObjectStorageACL(acl),
-		CorsEnabled: &corsEnabled,
+		Label: label,
+		ACL:   linodego.ObjectStorageACL(acl),
+	}
+
+	if corsEnabled, ok := d.GetOk("cors_enabled"); ok {
+		corsEnabledBool := corsEnabled.(bool)
+		createOpts.CorsEnabled = &corsEnabledBool
+	}
+
+	if endpoint, ok := d.GetOk("endpoint"); ok {
+		createOpts.S3Endpoint = endpoint.(string)
+	}
+
+	if endpointType, ok := d.GetOk("endpoint_type"); ok {
+		createOpts.EndpointType = linodego.ObjectStorageEndpointType(endpointType.(string))
 	}
 
 	if region, ok := d.GetOk("region"); ok {
 		createOpts.Region = region.(string)
-	} else {
-		createOpts.Cluster = d.Get("cluster").(string)
+	}
+
+	if cluster, ok := d.GetOk("cluster"); ok {
+		createOpts.Cluster = cluster.(string)
 	}
 
 	tflog.Debug(ctx, "client.CreateObjectStorageBucket(...)", map[string]any{"options": createOpts})
@@ -166,7 +177,7 @@ func createResource(
 		return diag.Errorf("failed to create a Linode ObjectStorageBucket: %s", err)
 	}
 
-	d.Set("endpoint", helper.ComputeS3EndpointFromBucket(ctx, *bucket))
+	d.Set("endpoint", bucket.S3Endpoint)
 
 	if bucket.Region != "" {
 		d.SetId(fmt.Sprintf("%s:%s", bucket.Region, bucket.Label))
@@ -455,7 +466,7 @@ func updateBucketCert(
 	}
 
 	uploadOptions := expandBucketCert(certSpec[0])
-	if _, err := client.UploadObjectStorageBucketCert(ctx, regionOrCluster, label, uploadOptions); err != nil {
+	if _, err := client.UploadObjectStorageBucketCertV2(ctx, regionOrCluster, label, uploadOptions); err != nil {
 		return fmt.Errorf("failed to upload new bucket cert: %s", err)
 	}
 	return nil

--- a/linode/objbucket/schema_resource.go
+++ b/linode/objbucket/schema_resource.go
@@ -39,6 +39,12 @@ var resourceSchema = map[string]*schema.Schema{
 	"endpoint": {
 		Type:        schema.TypeString,
 		Description: "The endpoint for the bucket used for s3 connections.",
+		Deprecated:  "Use `s3_endpoint` instead",
+		Computed:    true,
+	},
+	"s3_endpoint": {
+		Type:        schema.TypeString,
+		Description: "The endpoint for the bucket used for s3 connections.",
 		Optional:    true,
 		Computed:    true,
 		ForceNew:    true,

--- a/linode/objbucket/schema_resource.go
+++ b/linode/objbucket/schema_resource.go
@@ -39,7 +39,16 @@ var resourceSchema = map[string]*schema.Schema{
 	"endpoint": {
 		Type:        schema.TypeString,
 		Description: "The endpoint for the bucket used for s3 connections.",
+		Optional:    true,
 		Computed:    true,
+		ForceNew:    true,
+	},
+	"endpoint_type": {
+		Type:        schema.TypeString,
+		Description: "The type of the S3 endpoint available in this region.",
+		Optional:    true,
+		Computed:    true,
+		ForceNew:    true,
 	},
 	"label": {
 		Type:        schema.TypeString,

--- a/linode/objbucket/tmpl/endpoint_type.gotf
+++ b/linode/objbucket/tmpl/endpoint_type.gotf
@@ -1,0 +1,9 @@
+{{ define "object_bucket_endpoint_type" }}
+
+resource "linode_object_storage_bucket" "foobar" {
+    region        = "{{ .Region }}"
+    label         = "{{ .Label }}"
+    endpoint_type = "{{ .EndpointType }}"
+}
+
+{{ end }}

--- a/linode/objbucket/tmpl/endpoint_url.gotf
+++ b/linode/objbucket/tmpl/endpoint_url.gotf
@@ -1,0 +1,9 @@
+{{ define "object_bucket_endpoint_url" }}
+
+resource "linode_object_storage_bucket" "foobar" {
+    label    = "{{ .Label }}"
+    region   = "{{ .Region }}"
+    endpoint = "{{ .EndpointURL }}"
+}
+
+{{ end }}

--- a/linode/objbucket/tmpl/endpoint_url.gotf
+++ b/linode/objbucket/tmpl/endpoint_url.gotf
@@ -3,7 +3,7 @@
 resource "linode_object_storage_bucket" "foobar" {
     label    = "{{ .Label }}"
     region   = "{{ .Region }}"
-    endpoint = "{{ .EndpointURL }}"
+    s3_endpoint = "{{ .EndpointURL }}"
 }
 
 {{ end }}

--- a/linode/objbucket/tmpl/template.go
+++ b/linode/objbucket/tmpl/template.go
@@ -15,10 +15,12 @@ type TemplateData struct {
 	CORSEnabled bool
 	Versioning  bool
 
-	Cert    string
-	PrivKey string
-	Cluster string
-	Region  string
+	Cert         string
+	PrivKey      string
+	Cluster      string
+	Region       string
+	EndpointType string
+	EndpointURL  string
 }
 
 func Basic(t testing.TB, label, region string) string {
@@ -29,6 +31,26 @@ func Basic(t testing.TB, label, region string) string {
 func BasicLegacy(t testing.TB, label, cluster string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_bucket_basic", TemplateData{Label: label, Cluster: cluster})
+}
+
+func EndpointURL(t testing.TB, label, region, endpointURL string) string {
+	return acceptance.ExecuteTemplate(
+		t, "object_bucket_endpoint_url", TemplateData{
+			Label:       label,
+			Region:      region,
+			EndpointURL: endpointURL,
+		},
+	)
+}
+
+func EndpointType(t testing.TB, label, region, endpointType string) string {
+	return acceptance.ExecuteTemplate(
+		t, "object_bucket_endpoint_type", TemplateData{
+			Label:        label,
+			Region:       region,
+			EndpointType: endpointType,
+		},
+	)
 }
 
 func Updates(t testing.TB, label, region string) string {

--- a/linode/objkey/framework_model.go
+++ b/linode/objkey/framework_model.go
@@ -12,8 +12,9 @@ import (
 )
 
 type RegionDetail struct {
-	ID         types.String `tfsdk:"id"`
-	S3Endpoint types.String `tfsdk:"s3_endpoint"`
+	ID           types.String `tfsdk:"id"`
+	S3Endpoint   types.String `tfsdk:"s3_endpoint"`
+	EndpointType types.String `tfsdk:"endpoint_type"`
 }
 
 type BucketAccessModelEntry struct {
@@ -133,6 +134,7 @@ func (rm *ResourceModel) FlattenObjectStorageKey(
 func FlattenRegionDetail(region linodego.ObjectStorageKeyRegion) (regionDetail RegionDetail) {
 	regionDetail.ID = types.StringValue(region.ID)
 	regionDetail.S3Endpoint = types.StringValue(region.S3Endpoint)
+	regionDetail.EndpointType = types.StringValue(string(region.EndpointType))
 	return
 }
 

--- a/linode/objkey/framework_resource_schema.go
+++ b/linode/objkey/framework_resource_schema.go
@@ -16,8 +16,9 @@ import (
 
 var RegionDetailType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
-		"id":          types.StringType,
-		"s3_endpoint": types.StringType,
+		"id":            types.StringType,
+		"s3_endpoint":   types.StringType,
+		"endpoint_type": types.StringType,
 	},
 }
 

--- a/linode/objkey/tmpl/all_regions.gotf
+++ b/linode/objkey/tmpl/all_regions.gotf
@@ -1,0 +1,30 @@
+{{ define "object_key_all_regions" }}
+
+resource "linode_object_storage_key" "foobar" {
+    label = "{{.Label}}"
+    regions = [
+        "us-southeast",
+        "us-ord",
+        "us-lax",
+        "us-mia",
+        "us-east",
+        "us-sea",
+        "us-iad",
+        "id-cgk",
+        "in-maa",
+        "jp-osa",
+        "ap-south",
+        "sg-sin-2",
+        "eu-central",
+        "es-mad",
+        "fr-par",
+        "gb-lon",
+        "it-mil",
+        "nl-ams",
+        "se-sto",
+        "au-mel",
+        "br-gru"
+    ]
+}
+
+{{ end }}

--- a/linode/objkey/tmpl/template.go
+++ b/linode/objkey/tmpl/template.go
@@ -31,3 +31,8 @@ func Limited(t testing.TB, label, region string) string {
 	return acceptance.ExecuteTemplate(t,
 		"object_key_limited", TemplateData{Label: label, Region: region})
 }
+
+func AllRegions(t testing.TB, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"object_key_all_regions", TemplateData{Label: label})
+}


### PR DESCRIPTION
## 📝 Description

This is to add support for object storage services gen2 in existing resources and data sources.

## ✔️ How to Test

```bash
make test-int PKG_NAME="objbucket"
```

```bash
make test-int PKG_NAME="objkey"
```

```bash
make test-int PKG_NAME="obj"
```

```hcl
provider "linode" {
}

resource "linode_object_storage_bucket" "foobar" {
  region        = "sg-sin-2"
  endpoint_type = "E2"
  endpoint      = "sg-sin-1.linodeobjects.com"
  label         = "zhiweitestsigr2bk"
}

resource "linode_object_storage_key" "foo" {
    label = "mykey"
}
```