### PR TITLE
Fix LKE integration tests for `tier`

### DIFF
--- a/linode/lke/schema_resource.go
+++ b/linode/lke/schema_resource.go
@@ -66,6 +66,7 @@ var resourceSchema = map[string]*schema.Schema{
 	"tier": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "The desired Kubernetes tier.",
 		ForceNew:    true,
 	},


### PR DESCRIPTION
## 📝 Description

Mark LKE `tier` field as computed to accommodate the default value `standard` from API. 
 
## ✔️ How to Test

```
make PKG_NAME=lkenodepool
```