### PR TITLE
Remove the validation function for `purpose` attribute for interfaces

### DIFF
--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -114,9 +114,6 @@ var InterfaceSchema = &schema.Resource{
 			Type:        schema.TypeString,
 			Description: "The type of interface.",
 			Required:    true,
-			ValidateDiagFunc: validation.ToDiagFunc(
-				validation.StringInSlice([]string{"public", "vlan", "vpc"}, true),
-			),
 		},
 		"ipam_address": {
 			Type: schema.TypeString,


### PR DESCRIPTION
## 📝 Description

As the number of purposes increase, it would be better to delay the validation to the API to keep the consistency.

## Testing

Verifying that the API will return an error when an invalid purpose is provided.

```hcl
locals {
  akamai_firewall_id = 12345 # change to your firewall ID
}

resource "linode_instance_config" "my-config" {
  linode_id = linode_instance.my-instance.id
  label     = "my-config"

  device {
    device_name = "sda"
    disk_id     = linode_instance_disk.boot.id
  }

  interface {
    purpose = "invalid"
  }

  booted = true
}

resource "linode_instance_disk" "boot" {
  label     = "boot"
  linode_id = linode_instance.my-instance.id
  size      = linode_instance.my-instance.specs.0.disk

  image     = "linode/ubuntu22.04"
  root_pass = "myc00leefewfdwqdfe32dwqepass!"
}

resource "linode_instance" "my-instance" {
  label       = "my-instance"
  type        = "g6-standard-1"
  region      = "us-mia"
  firewall_id = local.akamai_firewall_id
}

```