### PR TITLE
Separate legacy and Aiven-backed database engine slug helpers

### DIFF
--- a/linode/databasemysql/framework_models.go
+++ b/linode/databasemysql/framework_models.go
@@ -61,7 +61,7 @@ func (data *DataSourceModel) parseMySQLDatabase(
 	data.Created = types.StringValue(db.Created.Format(time.RFC3339))
 	data.Updated = types.StringValue(db.Updated.Format(time.RFC3339))
 
-	data.EngineID = types.StringValue(helper.CreateDatabaseEngineSlug(db.Engine, db.Version))
+	data.EngineID = types.StringValue(helper.CreateLegacyDatabaseEngineSlug(db.Engine, db.Version))
 
 	updates, diags := helper.FlattenDatabaseMaintenanceWindow(ctx, db.Updates)
 	if diags.HasError() {

--- a/linode/databasemysql/framework_models_unit_test.go
+++ b/linode/databasemysql/framework_models_unit_test.go
@@ -53,8 +53,11 @@ func TestParseMySQLDatabase(t *testing.T) {
 	assert.Equal(t, types.StringValue("lin-123-456-mysql-primary-private.servers.linodedb.net"), data.HostSecondary)
 	assert.Equal(t, types.StringValue("us-east"), data.Region)
 	assert.Equal(t, types.StringValue("g6-dedicated-2"), data.Type)
+
 	assert.Equal(t, types.StringValue("mysql"), data.Engine)
 	assert.Equal(t, types.StringValue("8.0.26"), data.Version)
+	assert.Equal(t, types.StringValue("mysql/8.0.26"), data.EngineID)
+
 	assert.Equal(t, types.Int64Value(3), data.ClusterSize)
 	assert.Equal(t, types.StringValue("semi_synch"), data.ReplicationType)
 	assert.Equal(t, types.BoolValue(true), data.SSLConnection)

--- a/linode/databasemysql/resource.go
+++ b/linode/databasemysql/resource.go
@@ -69,7 +69,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diag.Errorf("failed to get credentials for the specified mysql database: %s", err)
 	}
 
-	d.Set("engine_id", helper.CreateDatabaseEngineSlug(db.Engine, db.Version))
+	d.Set("engine_id", helper.CreateLegacyDatabaseEngineSlug(db.Engine, db.Version))
 	d.Set("engine", db.Engine)
 	d.Set("label", db.Label)
 	d.Set("region", db.Region)

--- a/linode/databasepostgresql/framework_models.go
+++ b/linode/databasepostgresql/framework_models.go
@@ -65,7 +65,7 @@ func (data *DataSourceModel) parsePostgresDatabase(
 	data.Created = types.StringValue(db.Created.Format(time.RFC3339))
 	data.Updated = types.StringValue(db.Updated.Format(time.RFC3339))
 
-	data.EngineID = types.StringValue(helper.CreateDatabaseEngineSlug(db.Engine, db.Version))
+	data.EngineID = types.StringValue(helper.CreateLegacyDatabaseEngineSlug(db.Engine, db.Version))
 
 	updates, diags := helper.FlattenDatabaseMaintenanceWindow(ctx, db.Updates)
 	if diags.HasError() {

--- a/linode/databasepostgresql/framework_models_unit_test.go
+++ b/linode/databasepostgresql/framework_models_unit_test.go
@@ -51,6 +51,10 @@ func TestParsePostgresDatabase(t *testing.T) {
 	assert.Equal(t, types.StringValue("active"), data.Status)
 	assert.Equal(t, types.StringValue("example-db"), data.Label)
 
+	assert.Equal(t, types.StringValue("postgresql"), data.Engine)
+	assert.Equal(t, types.StringValue("13.2"), data.Version)
+	assert.Equal(t, types.StringValue("postgresql/13.2"), data.EngineID)
+
 	assert.Contains(t, data.AllowList.String(), "203.0.113.1/32")
 	assert.Contains(t, data.AllowList.String(), "192.0.1.0/24")
 

--- a/linode/databasepostgresql/resource.go
+++ b/linode/databasepostgresql/resource.go
@@ -69,7 +69,7 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diag.Errorf("failed to get credentials for the specified PostgreSQL database: %s", err)
 	}
 
-	d.Set("engine_id", helper.CreateDatabaseEngineSlug(db.Engine, db.Version))
+	d.Set("engine_id", helper.CreateLegacyDatabaseEngineSlug(db.Engine, db.Version))
 	d.Set("engine", db.Engine)
 	d.Set("label", db.Label)
 	d.Set("region", db.Region)

--- a/linode/helper/database.go
+++ b/linode/helper/database.go
@@ -83,6 +83,10 @@ func FlattenDayOfWeek(day linodego.DatabaseDayOfWeek) string {
 	return dayOfWeekKeyToStr[day]
 }
 
+func CreateLegacyDatabaseEngineSlug(engine, version string) string {
+	return fmt.Sprintf("%s/%s", engine, version)
+}
+
 func CreateDatabaseEngineSlug(engine, version string) string {
 	return fmt.Sprintf("%s/%s", engine, strings.Split(version, ".")[0])
 }


### PR DESCRIPTION
## 📝 Description

This pull request separates the `engine_id` slug helpers for the legacy and Aiven-backed DBaaS cluster resources. This is necessary because legacy clusters accept a `ENGINE/MAJOR.MINOR` slug while Aiven-backed clusters accept a `ENGINE/MAJOR` slug, where the minor version is implicitly populated by the API after provisioning is finished.

**NOTE:** At the moment we do not have a way to manually test this fix against the API because new legacy clusters cannot be provisioned. 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make test-unit
```

### Manual Testing

**NOTE: The following test steps assume you have a Python environment on your local machine.**

1. Install the `fastapi` package:

```
pip install fastapi
```

2. Run the database API mock server, taking note of the port shown in the output:

```
curl -o db_mock.py https://gist.githubusercontent.com/lgarber-akamai/97d63d2ca66d1c7e1ba9075db2bca5f1/raw/1f46cf28a1624f3234c6892485cc6be620f99912/db_mock.py && \
fastapi dev db_mock.py
```

**NOTE: Before moving to the next step, inspect the script to ensure it is legitimate.**

3. In a new session, add the following configuration to a Terraform provider sandbox environment (e.g. dx-devenv):

```

resource "linode_database_postgresql" "test" {
  region = "us-mia"
  label = "test-cluster"
  engine_id = "postgresql/15.7"
  type = "g6-nanode-1"

  allow_list = ["0.0.0.0/0"]
}

resource "linode_database_postgresql_v2" "test" {
  region = "us-mia"
  label = "test-cluster-2"
  engine_id = "postgresql/14"
  type = "g6-nanode-1"

  allow_list = ["0.0.0.0/0"]
}
```

4. Configure your environment to point to the mock server:

```
export LINODE_URL=http://localhost:8000
```

5. Import the two mock databases into your state:

```
terraform import linode_database_postgresql.test 12345
terraform import linode_database_postgresql_v2.test 54321
```

6. Run `make apply` and ensure no changes are proposed.