### PR TITLE
Ignored updated field DBaaS v2 tests

### DIFF
--- a/linode/databasemysqlv2/resource_test.go
+++ b/linode/databasemysqlv2/resource_test.go
@@ -125,9 +125,10 @@ func TestAccResource_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated"},
 			},
 		},
 	})
@@ -257,9 +258,10 @@ func TestAccResource_complex(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated"},
 			},
 		},
 	})

--- a/linode/databasepostgresqlv2/resource_test.go
+++ b/linode/databasepostgresqlv2/resource_test.go
@@ -125,9 +125,10 @@ func TestAccResource_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated"},
 			},
 		},
 	})


### PR DESCRIPTION
## 📝 Description

Added `updated` to `ImportStateVerifyIgnore` in some DBaaS V2 tests.

## ✔️ How to Test

`make test-int TEST_SUITE="databasemysqlv2"`
`make test-int TEST_SUITE="databasepostgresqlv2"`