### PR TITLE
Make bucket resources compatible with legacy API

### DIFF
--- a/linode/objbucket/helpers.go
+++ b/linode/objbucket/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/helper"
 )
 
@@ -12,4 +13,13 @@ func populateLogAttributes(ctx context.Context, d *schema.ResourceData) context.
 		"bucket":  d.Get("label"),
 		"cluster": d.Get("cluster"),
 	})
+}
+
+func getS3Endpoint(ctx context.Context, bucket linodego.ObjectStorageBucket) (endpoint string) {
+	if bucket.S3Endpoint != "" {
+		endpoint = bucket.S3Endpoint
+	} else {
+		endpoint = helper.ComputeS3EndpointFromBucket(ctx, bucket)
+	}
+	return
 }

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -102,7 +102,8 @@ func readResource(
 			defer teardownKeysCleanUp()
 		}
 
-		s3Client, err := helper.S3Connection(ctx, bucket.S3Endpoint, objKeys.AccessKey, objKeys.SecretKey)
+		endpoint := getS3Endpoint(ctx, *bucket)
+		s3Client, err := helper.S3Connection(ctx, endpoint, objKeys.AccessKey, objKeys.SecretKey)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -123,14 +124,16 @@ func readResource(
 		d.SetId(fmt.Sprintf("%s:%s", bucket.Cluster, bucket.Label))
 	}
 
+	endpoint := getS3Endpoint(ctx, *bucket)
+
 	d.Set("cluster", bucket.Cluster)
 	d.Set("region", bucket.Region)
 	d.Set("label", bucket.Label)
 	d.Set("hostname", bucket.Hostname)
 	d.Set("acl", access.ACL)
 	d.Set("cors_enabled", access.CorsEnabled)
-	d.Set("endpoint", bucket.S3Endpoint)
-	d.Set("s3_endpoint", bucket.S3Endpoint)
+	d.Set("endpoint", endpoint)
+	d.Set("s3_endpoint", endpoint)
 	d.Set("endpoint_type", bucket.EndpointType)
 
 	return nil
@@ -178,8 +181,10 @@ func createResource(
 		return diag.Errorf("failed to create a Linode ObjectStorageBucket: %s", err)
 	}
 
-	d.Set("endpoint", bucket.S3Endpoint)
-	d.Set("s3_endpoint", bucket.S3Endpoint)
+	endpoint := getS3Endpoint(ctx, *bucket)
+
+	d.Set("endpoint", endpoint)
+	d.Set("s3_endpoint", endpoint)
 
 	if bucket.Region != "" {
 		d.SetId(fmt.Sprintf("%s:%s", bucket.Region, bucket.Label))


### PR DESCRIPTION
## 📝 Description

Ensure compatibility with legacy OBJ APIs.

## ✔️ How to Test

Add the legacy API tag to you account and then:

```hcl
provider "linode" {
  obj_use_temp_keys = true
}

data "linode_object_storage_cluster" "region" {
  id = "us-mia-1"
}

resource "linode_object_storage_bucket" "storage_bucket" {
  cluster = data.linode_object_storage_cluster.region.id
  label   = "aran-test"
  acl     = "private"

  lifecycle_rule {
    id      = "retention_rule"
    enabled = true
    expiration {
      days = 90
    }
  }
}
```