### PR TITLE
Added additional examples to `lkeversions` datasource docs

### DIFF
--- a/docs/data-sources/lke_versions.md
+++ b/docs/data-sources/lke_versions.md
@@ -15,6 +15,14 @@ The following example shows how one might use this data source to access informa
 
 ```hcl
 data "linode_lke_versions" "example" {}
+
+output "example_output" {
+  value = data.linode_lke_versions.example
+}
+
+output "example_output_first_version" {
+  value = data.linode_lke_versions.example.versions[0]
+}
 ```
 
 The following example shows how one might use this data source to access information about a Linode LKE Version
@@ -23,7 +31,15 @@ with additional information about the Linode LKE Version's tier (`enterprise` or
 > **_NOTE:_**  This functionality may not be currently available to all users and can only be used with v4beta.
 
 ```hcl
-data "linode_lke_versions" "example" {tier = "enterprise"}
+data "linode_lke_versions" "example_enterprise" {tier = "enterprise"}
+
+output "example_enterprise_output" {
+  value = data.linode_lke_versions.example_enterprise
+}
+
+output "example_enterprise_output_first_version" {
+  value = data.linode_lke_versions.example_enterprise.versions[0]
+}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
## 📝 Description

Added an example of accessing the version id strings (i.e. `1.32`, `v1.31.1+lke1`) from the datasource to avoid confusion with the TF resource's id.