### PR TITLE
Add TF setup action in the test workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -41,11 +41,10 @@ jobs:
         with:
           go-version: '1.x'
 
+      - uses: hashicorp/setup-terraform@v3
+
       - name: Install Dependencies
-        run: |
-          make deps
-          sudo apt-get update -y
-          sudo apt-get install -y build-essential
+        run: make deps
 
       - name: Install go-junit-report
         run: go install github.com/jstemmer/go-junit-report/v2@latest


### PR DESCRIPTION
## 📝 Description

Add the Terraform setup action prior to the test run as a workaround for [a known TF test issue](https://github.com/hashicorp/terraform-plugin-testing/issues/429) that causes intermittent errors.

## ✔️ How to Test
See the integration test run result
https://github.com/linode/terraform-provider-linode/actions/runs/14396032679

The `text file busy` intermittent error should not appear anymore.