### PR TITLE
Avoid sending invalid nodepool create options

### DIFF
--- a/linode/lkenodepool/framework_models.go
+++ b/linode/lkenodepool/framework_models.go
@@ -160,8 +160,12 @@ func (pool *NodePoolModel) SetNodePoolCreateOptions(
 	pool.Labels.ElementsAs(ctx, &p.Labels, false)
 
 	if tier == "enterprise" {
-		p.K8sVersion = pool.K8sVersion.ValueStringPointer()
-		p.UpdateStrategy = linodego.Pointer(linodego.LKENodePoolUpdateStrategy(pool.UpdateStrategy.ValueString()))
+		if !pool.K8sVersion.IsNull() && !pool.K8sVersion.IsUnknown() {
+			p.K8sVersion = pool.K8sVersion.ValueStringPointer()
+		}
+		if !pool.UpdateStrategy.IsNull() && !pool.K8sVersion.IsUnknown() {
+			p.UpdateStrategy = linodego.Pointer(linodego.LKENodePoolUpdateStrategy(pool.UpdateStrategy.ValueString()))
+		}
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

The previous implementation sending a pointer to "" when k8s_version or update_strategy is unknown value. Make sure empty string is not sent to the request which is invalid to the API. 

## ✔️ How to Test

1. In a sandbox environment, create node pool under an enterprise cluster without the two fields. Make sure it doesn't cause any issue.
```
provider "linode" {
  api_version="v4beta"
}

resource "linode_lke_cluster" "nodepool_test_cluster" {
  label       = "lke-e-nodepool-test-cluster"
  region      = "us-lax"
  k8s_version = "v1.31.1+lke4"
  tags        = ["nodepool_test_cluster"]
  external_pool_tags  = ["external"]
  tier = "enterprise"

  pool {
      type  = "g6-standard-1"
      count = 1
  }
}

resource "linode_lke_node_pool" "foobar" {
    cluster_id = linode_lke_cluster.nodepool_test_cluster.id
    node_count = 2
    type  = "g6-standard-2"
    # k8s_version = linode_lke_cluster.nodepool_test_cluster.k8s_version
    # update_strategy = "rolling_update"
    tags  = ["external", "my-pool"]
}
```