### PR TITLE
Deprecate `ip_address` attribute of `linode_instance` resource

### DIFF
--- a/docs/data-sources/instances.md
+++ b/docs/data-sources/instances.md
@@ -97,7 +97,7 @@ Each Linode instance will be stored in the `instances` attribute and will export
 
 * `status` - The status of the instance, indicating the current readiness state. (`running`, `offline`, ...)
 
-* `ip_address` - A string containing the Linode's public IP address.
+* `ip_address` - (Deprecated) A string containing the Linode's public IP address.
 
 * `private_ip_address` - This Linode's Private IPv4 Address, if enabled.  The regional private IP address range, 192.168.128.0/17, is shared by all Linode Instances in a region.
 

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -317,6 +317,9 @@ var resourceSchema = map[string]*schema.Schema{
 		Description: "This Linode's Public IPv4 Address. If there are multiple public IPv4 addresses on this " +
 			"Instance, an arbitrary address will be used for this field.",
 		Computed: true,
+		Deprecated: "The `ip_address` attribute in linode_instance resource is deprecated. " +
+			"Please consider using the `ipv4` set attribute in the same resource or a " +
+			"`linode_instance_networking` data source instead.",
 	},
 	"ipv6": {
 		Type:        schema.TypeString,


### PR DESCRIPTION
## 📝 Description

Since we plan to remove this attribute in the next major version of the provider, add deprecate warning now.