### PR TITLE
Add alp_enabled variable to LKEClusterModel struct

### DIFF
--- a/linode/lkeclusters/framework_models.go
+++ b/linode/lkeclusters/framework_models.go
@@ -31,7 +31,7 @@ type LKEClusterModel struct {
 	Tags         types.Set            `tfsdk:"tags"`
 	ControlPlane LKEControlPlaneModel `tfsdk:"control_plane"`
 	Tier         types.String         `tfsdk:"tier"`
-	AplEnabled   types.Bool           `tfsdk:"apl_enabled"`
+	APLEnabled   types.Bool           `tfsdk:"apl_enabled"`
 }
 
 type LKEControlPlaneModel struct {

--- a/linode/lkeclusters/framework_models.go
+++ b/linode/lkeclusters/framework_models.go
@@ -31,6 +31,7 @@ type LKEClusterModel struct {
 	Tags         types.Set            `tfsdk:"tags"`
 	ControlPlane LKEControlPlaneModel `tfsdk:"control_plane"`
 	Tier         types.String         `tfsdk:"tier"`
+	AplEnabled   types.Bool           `tfsdk:"apl_enabled"`
 }
 
 type LKEControlPlaneModel struct {


### PR DESCRIPTION
## 📝 Description

Add alp_enabled variable to LKEClusterModel struct to address gap and test failure

## ✔️ How to Test

`make test-int PKG_NAME=lkeclusters TEST_CASE=TestAccDataSourceLKEClusters_basic`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**