### PR TITLE
linode_lke_node_pool: Resolve LKE node pool autoscaler disable error when using explicit node_count

### DIFF
--- a/linode/lkenodepool/framework_models.go
+++ b/linode/lkenodepool/framework_models.go
@@ -287,6 +287,10 @@ func (pool *NodePoolModel) shouldUpdateLKENodePoolAutoscaler(
 		// These values are discarded by the API when autoscaling is disabled,
 		// so we can just use the plan's count since it should meet the validation requirements.
 		planNodeCount := helper.FrameworkSafeInt64ToInt(pool.Count.ValueInt64(), diags)
+		if diags.HasError() {
+			return nil, false
+		}
+
 		autoscaler.Min = planNodeCount
 		autoscaler.Max = planNodeCount
 

--- a/linode/lkenodepool/tmpl/nodepool.gotf
+++ b/linode/lkenodepool/tmpl/nodepool.gotf
@@ -22,13 +22,15 @@ resource "linode_lke_node_pool" "foobar" {
     cluster_id = linode_lke_cluster.nodepool_test_cluster.id
 {{ end }}
 
+{{ if gt .NodeCount 0}}
+    node_count = {{ .NodeCount }}
+{{ end }}
+
 {{ if .AutoscalerEnabled }}
     autoscaler {
         min = {{.AutoscalerMin}}
         max = {{.AutoscalerMax}}
     }
-{{ else }}
-    node_count = {{ .NodeCount }}
 {{ end }}
 
 {{ range $taint := .Taints }}


### PR DESCRIPTION
## 📝 Description

This pull request resolves an issue that caused the following validation error when attempting to disable the autoscaler of an existing LKE node pool:

```
[400] [autoscaler.min] Must be 1-500; [autoscaler.max] Must be 1-500
```

This error occurred because the PUT request body specifies a zero value for the `min` and `max` fields alongside `enabled: false`. This pull request resolves the issue by setting those values to the plan's node count if necessary.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make PKG_NAME=lkenodepool TEST_ARGS="-run TestAccResourceNodePool_disableAutoscalingExplicitNodeCount" test-int
```

### Manual Testing

1. In a terraform-provider-linode sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform
resource "linode_lke_cluster" "test" {
  label = "tf-test-manual"
  region = "us-mia"
  k8s_version = "1.32"

  pool {
    count = 1
    type  = "g6-standard-1"
  }

  external_pool_tags = ["external_pool"]
}

resource "linode_lke_node_pool" "test" {
  cluster_id = linode_lke_cluster.test.id
  type = "g6-standard-1"
  tags = linode_lke_cluster.test.external_pool_tags
  node_count = 2

  autoscaler {
    min = 2
    max = 4
  }
}
```

2. Ensure the apply finishes successfully and all relevant resources have been created.
3. Comment out the autoscaler block:

```terraform
...

  # autoscaler {
  #   min = 2
  #   max = 4
  # }

...
```

4. Re-apply the configuration and ensure autoscaling has successfully been disabled on the externally managed node pool.