### PR TITLE
Fix label update and minor bug in LKE node pool resource

### DIFF
--- a/linode/lkenodepool/framework_models.go
+++ b/linode/lkenodepool/framework_models.go
@@ -163,7 +163,7 @@ func (pool *NodePoolModel) SetNodePoolCreateOptions(
 		if !pool.K8sVersion.IsNull() && !pool.K8sVersion.IsUnknown() {
 			p.K8sVersion = pool.K8sVersion.ValueStringPointer()
 		}
-		if !pool.UpdateStrategy.IsNull() && !pool.K8sVersion.IsUnknown() {
+		if !pool.UpdateStrategy.IsNull() && !pool.UpdateStrategy.IsUnknown() {
 			p.UpdateStrategy = linodego.Pointer(linodego.LKENodePoolUpdateStrategy(pool.UpdateStrategy.ValueString()))
 		}
 	}
@@ -223,6 +223,7 @@ func (pool *NodePoolModel) SetNodePoolUpdateOptions(
 
 	if !state.Labels.Equal(pool.Labels) {
 		pool.Labels.ElementsAs(ctx, &p.Labels, false)
+		shouldUpdate = true
 	}
 
 	if tier == "enterprise" {


### PR DESCRIPTION
## 📝 Description

Fixed that updating label request is not sent to API. Fixed a typo in update strategy create options build.

## ✔️ How to Test

1. In a sandbox environment, use the following config to create a cluster and a node pool:
```
resource "linode_lke_cluster" "nodepool_cluster" {
  label       = "lke-nodepool-test-cluster"
  region      = "us-central"
  k8s_version = "1.32"
  tags        = ["nodepool_test_cluster"]
  external_pool_tags  = ["external"]

  pool {
      type  = "g6-standard-1"
      count = 1
  }
}

resource "linode_lke_node_pool" "foobar" {
    cluster_id = linode_lke_cluster.nodepool_cluster.id
    node_count = 2
    type  = "g6-standard-2"
    tags  = ["external", "my-pool"]
    labels = {"qq": "ww"}
}
```
2. Only change the labels under the node pool
```
resource "linode_lke_node_pool" "foobar" {
    cluster_id = linode_lke_cluster.nodepool_cluster.id
    node_count = 2
    type  = "g6-standard-2"
    tags  = ["external", "my-pool"]
    labels = {"qq": "change"}
}
```
3. Observe it's changed in the plan and applied successfully in the state.

