### PR TITLE
Update prefix in instance.md ipv6 example

### DIFF
--- a/docs/data-sources/instances.md
+++ b/docs/data-sources/instances.md
@@ -101,7 +101,7 @@ Each Linode instance will be stored in the `instances` attribute and will export
 
 * `private_ip_address` - This Linode's Private IPv4 Address, if enabled.  The regional private IP address range, 192.168.128.0/17, is shared by all Linode Instances in a region.
 
-* `ipv6` - This Linode's IPv6 SLAAC addresses. This address is specific to a Linode, and may not be shared.  The prefix (`/64`) is included in this attribute.
+* `ipv6` - This Linode's IPv6 SLAAC addresses. This address is specific to a Linode, and may not be shared.  The prefix (`/128`) is included in this attribute.
 
 * `ipv4` - This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to open a support ticket to get additional IPv4 addresses.
 

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -361,7 +361,7 @@ This Linode Instance resource exports the following attributes:
 
 * `private_ip_address` - This Linode's Private IPv4 Address, if enabled.  The regional private IP address range, 192.168.128.0/17, is shared by all Linode Instances in a region.
 
-* `ipv6` - This Linode's IPv6 SLAAC addresses. This address is specific to a Linode, and may not be shared.  The prefix (`/64`) is included in this attribute.
+* `ipv6` - This Linode's IPv6 SLAAC addresses. This address is specific to a Linode, and may not be shared.  The prefix (`/128`) is included in this attribute.
 
 * `ipv4` - This Linode's IPv4 Addresses. Each Linode is assigned a single public IPv4 address upon creation, and may get a single private IPv4 address if needed. You may need to open a support ticket to get additional IPv4 addresses.
 

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -102,6 +102,7 @@ func TestAccResourceInstance_basic_smoke(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
 					resource.TestCheckResourceAttr(resName, "swap_size", "256"),
 					resource.TestCheckResourceAttrSet(resName, "host_uuid"),
+					resource.TestMatchResourceAttr(resName, "ipv6", regexp.MustCompile(`/128$`)),
 				),
 			},
 


### PR DESCRIPTION
## 📝 Description

Prefix /64 has been updated to /128 hence reflecting it in `instance.md`. In addition add assertion for this specific attribute and prefix in smoke test

## ✔️ How to Test

`make test-int PKG_NAME=instance TEST_CASE="TestAccResourceInstance_basic_smoke"`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**