### PR TITLE
Add `interfaces_for_new_linodes` attribute in the account settings resource and data source

### DIFF
--- a/linode/accountsettings/datasource_test.go
+++ b/linode/accountsettings/datasource_test.go
@@ -4,10 +4,12 @@ package accountsettings_test
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/v2/linode/accountsettings/tmpl"
 )
@@ -45,13 +47,14 @@ func TestAccDataSourceLinodeAccountSettings_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmpl.DataBasic(t),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "backups_enabled", strconv.FormatBool(settings.BackupsEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "managed", strconv.FormatBool(settings.Managed)),
-					resource.TestCheckResourceAttr(resourceName, "network_helper", strconv.FormatBool(settings.NetworkHelper)),
-					resource.TestCheckResourceAttr(resourceName, "object_storage", objectStorageVal),
-					resource.TestCheckResourceAttr(resourceName, "longview_subscription", longviewVal),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("backups_enabled"), knownvalue.Bool(settings.BackupsEnabled)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed"), knownvalue.Bool(settings.Managed)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("network_helper"), knownvalue.Bool(settings.NetworkHelper)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("object_storage"), knownvalue.StringExact(objectStorageVal)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("longview_subscription"), knownvalue.StringExact(longviewVal)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interfaces_for_new_linodes"), knownvalue.StringExact(string(settings.InterfacesForNewLinodes))),
+				},
 			},
 		},
 	})

--- a/linode/accountsettings/framework_datasource_schema.go
+++ b/linode/accountsettings/framework_datasource_schema.go
@@ -30,5 +30,9 @@ var frameworkDataSourceSchema = schema.Schema{
 			Description: "A string describing the status of this account's Object Storage service enrollment.",
 			Computed:    true,
 		},
+		"interfaces_for_new_linodes": schema.StringAttribute{
+			Description: "What kind of interfaces are allowed for new Linode instances.",
+			Computed:    true,
+		},
 	},
 }

--- a/linode/accountsettings/framework_model.go
+++ b/linode/accountsettings/framework_model.go
@@ -9,12 +9,13 @@ import (
 // AccountSettingsModel describes the Terraform resource data model to match the
 // resource schema.
 type AccountSettingsModel struct {
-	ID                   types.String `tfsdk:"id"`
-	LongviewSubscription types.String `tfsdk:"longview_subscription"`
-	ObjectStorage        types.String `tfsdk:"object_storage"`
-	BackupsEnabled       types.Bool   `tfsdk:"backups_enabled"`
-	Managed              types.Bool   `tfsdk:"managed"`
-	NetworkHelper        types.Bool   `tfsdk:"network_helper"`
+	ID                      types.String `tfsdk:"id"`
+	LongviewSubscription    types.String `tfsdk:"longview_subscription"`
+	ObjectStorage           types.String `tfsdk:"object_storage"`
+	InterfacesForNewLinodes types.String `tfsdk:"interfaces_for_new_linodes"`
+	BackupsEnabled          types.Bool   `tfsdk:"backups_enabled"`
+	Managed                 types.Bool   `tfsdk:"managed"`
+	NetworkHelper           types.Bool   `tfsdk:"network_helper"`
 }
 
 func (data *AccountSettingsModel) FlattenAccountSettings(
@@ -36,6 +37,11 @@ func (data *AccountSettingsModel) FlattenAccountSettings(
 		helper.GetStringPtrWithDefault(settings.ObjectStorage, ""),
 		preserveKnown,
 	)
+	data.InterfacesForNewLinodes = helper.KeepOrUpdateString(
+		data.InterfacesForNewLinodes,
+		string(settings.InterfacesForNewLinodes),
+		preserveKnown,
+	)
 
 	data.Managed = helper.KeepOrUpdateBool(data.Managed, settings.Managed, preserveKnown)
 	data.BackupsEnabled = helper.KeepOrUpdateBool(
@@ -53,6 +59,9 @@ func (data *AccountSettingsModel) CopyFrom(other AccountSettingsModel, preserveK
 	)
 	data.ObjectStorage = helper.KeepOrUpdateValue(
 		data.ObjectStorage, other.ObjectStorage, preserveKnown,
+	)
+	data.InterfacesForNewLinodes = helper.KeepOrUpdateValue(
+		data.InterfacesForNewLinodes, other.InterfacesForNewLinodes, preserveKnown,
 	)
 	data.BackupsEnabled = helper.KeepOrUpdateValue(
 		data.BackupsEnabled, other.BackupsEnabled, preserveKnown,

--- a/linode/accountsettings/framework_model_unit_test.go
+++ b/linode/accountsettings/framework_model_unit_test.go
@@ -20,11 +20,12 @@ func TestFlattenAccountSettings(t *testing.T) {
 	networkHelperValue := false
 
 	mockSettings := &linodego.AccountSettings{
-		BackupsEnabled:       backupsEnabledValue,
-		Managed:              managedValue,
-		NetworkHelper:        networkHelperValue,
-		LongviewSubscription: &longviewSubscriptionValue,
-		ObjectStorage:        &objectStorageValue,
+		BackupsEnabled:          backupsEnabledValue,
+		Managed:                 managedValue,
+		NetworkHelper:           networkHelperValue,
+		LongviewSubscription:    &longviewSubscriptionValue,
+		ObjectStorage:           &objectStorageValue,
+		InterfacesForNewLinodes: linodego.LinodeDefaultButLegacyConfigAllowed,
 	}
 
 	// Create a mock AccountSettingsModel instance
@@ -44,6 +45,10 @@ func TestFlattenAccountSettings(t *testing.T) {
 
 	if model.ObjectStorage != types.StringValue("active") {
 		t.Errorf("Expected ObjectStorage to be %s, but got %s", "active", model.ObjectStorage)
+	}
+
+	if model.InterfacesForNewLinodes != types.StringValue(string(linodego.LinodeDefaultButLegacyConfigAllowed)) {
+		t.Errorf("Expected InterfacesForNewLinodes to be %s, but got %s", string(linodego.LinodeDefaultButLegacyConfigAllowed), model.InterfacesForNewLinodes)
 	}
 
 	if model.BackupsEnabled != types.BoolValue(true) {

--- a/linode/accountsettings/framework_resource.go
+++ b/linode/accountsettings/framework_resource.go
@@ -43,9 +43,7 @@ func (r *Resource) Create(
 	}
 
 	// Update the account
-	resp.Diagnostics.Append(
-		r.updateAccountSettings(ctx, &plan)...,
-	)
+	r.createOrUpdateAccountSettings(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -117,9 +115,7 @@ func (r *Resource) Update(
 	}
 
 	// Update the account
-	resp.Diagnostics.Append(
-		r.updateAccountSettings(ctx, &plan)...,
-	)
+	r.createOrUpdateAccountSettings(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -145,12 +141,22 @@ func (r *Resource) Delete(
 	tflog.Debug(ctx, "Delete "+r.Config.Name)
 }
 
-func (r *Resource) updateAccountSettings(
+func (r *Resource) createOrUpdateAccountSettings(
 	ctx context.Context,
 	plan *AccountSettingsModel,
-) diag.Diagnostics {
+	diags *diag.Diagnostics,
+) {
 	client := r.Meta.Client
-	var diagnostics diag.Diagnostics
+
+	account, err := client.GetAccount(ctx)
+	if err != nil {
+		diags.AddError(
+			"Failed to get Linode Account",
+			err.Error(),
+		)
+		return
+	}
+	email := account.Email
 
 	// Longview Plan update functionality has been moved
 	if !plan.LongviewSubscription.IsNull() {
@@ -164,17 +170,26 @@ func (r *Resource) updateAccountSettings(
 
 		_, err := client.UpdateLongviewPlan(ctx, options)
 		if err != nil {
-			diagnostics.AddError(
+			diags.AddError(
 				"Failed to update Linode Longview Plan",
 				err.Error(),
 			)
-			return diagnostics
+			return
 		}
 	}
 
-	updateOpts := linodego.AccountSettingsUpdateOptions{
-		BackupsEnabled: plan.BackupsEnabled.ValueBoolPointer(),
-		NetworkHelper:  plan.NetworkHelper.ValueBoolPointer(),
+	updateOpts := linodego.AccountSettingsUpdateOptions{}
+
+	if !plan.BackupsEnabled.IsUnknown() {
+		updateOpts.BackupsEnabled = plan.BackupsEnabled.ValueBoolPointer()
+	}
+
+	if !plan.NetworkHelper.IsUnknown() {
+		updateOpts.NetworkHelper = plan.NetworkHelper.ValueBoolPointer()
+	}
+
+	if !plan.InterfacesForNewLinodes.IsUnknown() {
+		updateOpts.InterfacesForNewLinodes = (*linodego.InterfacesForNewLinodes)(plan.InterfacesForNewLinodes.ValueStringPointer())
 	}
 
 	tflog.Debug(ctx, "client.UpdateAccountSettings(...)", map[string]any{
@@ -183,10 +198,9 @@ func (r *Resource) updateAccountSettings(
 
 	settings, err := client.UpdateAccountSettings(ctx, updateOpts)
 	if err != nil {
-		diagnostics.AddError("Failed to update Linode Account Settings", err.Error())
-		return diagnostics
+		diags.AddError("Failed to update Linode Account Settings", err.Error())
+		return
 	}
 
-	plan.FlattenAccountSettings(plan.ID.ValueString(), settings, true)
-	return diagnostics
+	plan.FlattenAccountSettings(email, settings, true)
 }

--- a/linode/accountsettings/framework_resource_schema.go
+++ b/linode/accountsettings/framework_resource_schema.go
@@ -1,10 +1,12 @@
 package accountsettings
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 var frameworkResourceSchema = schema.Schema{
@@ -40,7 +42,20 @@ var frameworkResourceSchema = schema.Schema{
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
-
+		"interfaces_for_new_linodes": schema.StringAttribute{
+			Description: "Account-wide backups default.",
+			Computed:    true,
+			Optional:    true,
+			Validators: []validator.String{stringvalidator.OneOf(
+				"legacy_config_only",
+				"legacy_config_default_but_linode_allowed",
+				"linode_default_but_legacy_config_allowed",
+				"linode_only",
+			)},
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
 		"managed": schema.BoolAttribute{
 			Description: "Enables monitoring for connectivity, response, and total request time.",
 			Computed:    true,

--- a/linode/accountsettings/resource_test.go
+++ b/linode/accountsettings/resource_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v2/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/v2/linode/accountsettings/tmpl"
 )
@@ -23,12 +27,13 @@ func TestAccResourceAccountSettings_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmpl.Basic(t),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "backups_enabled"),
-					resource.TestCheckResourceAttrSet(resourceName, "managed"),
-					resource.TestCheckResourceAttrSet(resourceName, "network_helper"),
-					resource.TestCheckResourceAttrSet(resourceName, "object_storage"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("backups_enabled"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("managed"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("network_helper"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("object_storage"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("interfaces_for_new_linodes"), knownvalue.NotNull()),
+				},
 			},
 		},
 	})
@@ -51,10 +56,18 @@ func TestAccResourceAccountSettings_update(t *testing.T) {
 	currLongviewPlan := longviewSettings.ID
 	currBackupsEnabled := accountSettings.BackupsEnabled
 	currNetworkHelper := accountSettings.NetworkHelper
+	currInterfacesForNewLinodes := accountSettings.InterfacesForNewLinodes
 
 	updatedLongviewPlan := "longview-10"
 	updatedBackupsEnabled := !currBackupsEnabled
 	updatedNetworkHelper := !currNetworkHelper
+
+	var updatedInterfacesForNewLinodes string
+	if currInterfacesForNewLinodes == linodego.LegacyConfigDefaultButLinodeAllowed {
+		updatedInterfacesForNewLinodes = string(linodego.LinodeDefaultButLegacyConfigAllowed)
+	} else {
+		updatedInterfacesForNewLinodes = string(linodego.LegacyConfigDefaultButLinodeAllowed)
+	}
 
 	if currLongviewPlan == "" || currLongviewPlan == "longview-10" {
 		updatedLongviewPlan = "longview-3"
@@ -65,20 +78,31 @@ func TestAccResourceAccountSettings_update(t *testing.T) {
 		ProtoV5ProviderFactories: acceptance.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Updates(t, updatedLongviewPlan, updatedBackupsEnabled, updatedNetworkHelper),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "longview_subscription", updatedLongviewPlan),
-					resource.TestCheckResourceAttr(resourceName, "backups_enabled", strconv.FormatBool(updatedBackupsEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "network_helper", strconv.FormatBool(updatedNetworkHelper)),
-				),
+				Config: tmpl.Updates(t, updatedLongviewPlan, updatedInterfacesForNewLinodes, updatedBackupsEnabled, updatedNetworkHelper),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("longview_subscription"), knownvalue.StringExact(updatedLongviewPlan)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("backups_enabled"), knownvalue.Bool(updatedBackupsEnabled)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("network_helper"), knownvalue.Bool(updatedNetworkHelper)),
+					statecheck.ExpectKnownValue(
+						resourceName, tfjsonpath.New("interfaces_for_new_linodes"), knownvalue.StringExact(updatedInterfacesForNewLinodes),
+					),
+				},
 			},
 			{
-				Config: tmpl.Updates(t, currLongviewPlan, currBackupsEnabled, currNetworkHelper),
+				Config: tmpl.Updates(t, currLongviewPlan, string(currInterfacesForNewLinodes), currBackupsEnabled, currNetworkHelper),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "longview_subscription", currLongviewPlan),
 					resource.TestCheckResourceAttr(resourceName, "backups_enabled", strconv.FormatBool(currBackupsEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "network_helper", strconv.FormatBool(currNetworkHelper)),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("longview_subscription"), knownvalue.StringExact(currLongviewPlan)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("backups_enabled"), knownvalue.Bool(currBackupsEnabled)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("network_helper"), knownvalue.Bool(currNetworkHelper)),
+					statecheck.ExpectKnownValue(
+						resourceName, tfjsonpath.New("interfaces_for_new_linodes"), knownvalue.StringExact(string(currInterfacesForNewLinodes)),
+					),
+				},
 			},
 		},
 	})

--- a/linode/accountsettings/tmpl/template.go
+++ b/linode/accountsettings/tmpl/template.go
@@ -7,9 +7,10 @@ import (
 )
 
 type TemplateData struct {
-	LongviewSubscription string
-	BackupsEnabled       bool
-	NetworkHelper        bool
+	LongviewSubscription    string
+	BackupsEnabled          bool
+	NetworkHelper           bool
+	InterfacesForNewLinodes string
 }
 
 func Basic(t testing.TB) string {
@@ -22,10 +23,12 @@ func DataBasic(t testing.TB) string {
 		"account_settings_data_basic", nil)
 }
 
-func Updates(t testing.TB, longviewSubscription string, backupsEnabled, networkHelper bool) string {
+func Updates(t testing.TB, longviewSubscription, interfacesForNewLinodes string, backupsEnabled, networkHelper bool) string {
 	return acceptance.ExecuteTemplate(t,
 		"account_settings_updates", TemplateData{
-			LongviewSubscription: longviewSubscription,
-			BackupsEnabled:       backupsEnabled, NetworkHelper: networkHelper,
+			LongviewSubscription:    longviewSubscription,
+			BackupsEnabled:          backupsEnabled,
+			NetworkHelper:           networkHelper,
+			InterfacesForNewLinodes: interfacesForNewLinodes,
 		})
 }

--- a/linode/accountsettings/tmpl/updates.gotf
+++ b/linode/accountsettings/tmpl/updates.gotf
@@ -4,6 +4,7 @@ resource "linode_account_settings" "foobar" {
     longview_subscription = "{{ .LongviewSubscription }}"
     backups_enabled = "{{ .BackupsEnabled }}"
     network_helper = "{{ .NetworkHelper }}"
+    interfaces_for_new_linodes = "{{ .InterfacesForNewLinodes }}"
 }
 
 {{ end }}


### PR DESCRIPTION
## 📝 Description

This is to update the account settings resource and data source with new API spec from the enhanced Linode interfaces project.

Apparently, the `linode_account_settings` resource never worked as expected... fix it in this PR as well.

Test check functions have been migrated to be the state checks.

## ✔️ How to Test
```bash
ACC_OPT_IN_TESTS=TestAccResourceAccountSettings_basic,TestAccResourceAccountSettings_update,TestAccDataSourceLinodeAccountSettings_basic make test-int PKG_NAME="accountsettings"
```