### PR TITLE
Add missing post-AddError(...) returns where necessary

### DIFF
--- a/linode/databasemysqlv2/framework_resource.go
+++ b/linode/databasemysqlv2/framework_resource.go
@@ -118,6 +118,7 @@ func (r *Resource) Create(
 			"Failed to wait for MySQL database to finish creating",
 			err.Error(),
 		)
+		return
 	}
 
 	// Sometimes the creation event finishes before the status becomes `active`
@@ -357,6 +358,7 @@ func (r *Resource) Update(
 				"Cannot update engine component of engine_id",
 				fmt.Sprintf("%s != %s", engine, state.Engine.ValueString()),
 			)
+			return
 		}
 
 		shouldUpdate = true

--- a/linode/databasepostgresqlv2/framework_resource.go
+++ b/linode/databasepostgresqlv2/framework_resource.go
@@ -117,6 +117,7 @@ func (r *Resource) Create(
 			"Failed to wait for PostgreSQL database to finish creating",
 			err.Error(),
 		)
+		return
 	}
 
 	// Sometimes the creation event finishes before the status becomes `active`
@@ -356,6 +357,7 @@ func (r *Resource) Update(
 				"Cannot update engine component of engine_id",
 				fmt.Sprintf("%s != %s", engine, state.Engine.ValueString()),
 			)
+			return
 		}
 
 		shouldUpdate = true

--- a/linode/firewall/helpers.go
+++ b/linode/firewall/helpers.go
@@ -129,6 +129,7 @@ func disableFirewall(
 	firewall, err := client.UpdateFirewall(ctx, firewallID, updateOpts)
 	if err != nil {
 		diags.AddError("Failed to Disable Fireall", err.Error())
+		return nil
 	}
 	return firewall
 }

--- a/linode/framework_provider_config.go
+++ b/linode/framework_provider_config.go
@@ -288,6 +288,7 @@ func (fp *FrameworkProvider) InitLinodeClient(
 		configPathExpanded, err := helper.ExpandPath(configPath)
 		if err != nil {
 			diags.AddError("Failed to expand config path", err.Error())
+			return nil
 		}
 
 		err = client.LoadConfig(&linodego.LoadConfigOptions{

--- a/linode/helper/framework_import.go
+++ b/linode/helper/framework_import.go
@@ -54,6 +54,7 @@ func ImportStatePassthroughInt64ID(
 			"Invalid Integer Value for Import ID",
 			fmt.Sprintf("\"%s\" is not a valid integer value", req.ID),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, attrPath, intID)...)

--- a/linode/image/framework_resource.go
+++ b/linode/image/framework_resource.go
@@ -614,6 +614,7 @@ func waitForImageToBeAvailable(
 	)
 	if err != nil {
 		diags.AddError("Failed to Wait for Image to be Available", err.Error())
+		return nil
 	}
 
 	return image

--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -132,6 +132,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Failed to Wait for the Disk Creation Event on Linode Disk (%d)", diskID),
 			err.Error(),
 		)
+		return
 	}
 
 	if _, err := client.WaitForInstanceDiskStatus(
@@ -140,6 +141,7 @@ func (r *Resource) Create(
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed to Wait for Disk (%d) to be Ready", diskID), err.Error(),
 		)
+		return
 	}
 
 	// get latest status of the disk
@@ -150,6 +152,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Failed to Get Disk %d of Linode Instance %d", diskID, linodeID),
 			err.Error(),
 		)
+		return
 	}
 
 	// IDs should always be overridden during creation (see #1085)
@@ -285,6 +288,7 @@ func (r *Resource) Update(
 			fmt.Sprintf("Failed to Find the Disk (%d)", id),
 			err.Error(),
 		)
+		return
 	}
 
 	plan.FlattenDisk(disk, true)

--- a/linode/nb/framework_datasource.go
+++ b/linode/nb/framework_datasource.go
@@ -56,6 +56,7 @@ func (d *DataSource) Read(
 			fmt.Sprintf("Failed to get nodebalancer %d", nodeBalancerID),
 			err.Error(),
 		)
+		return
 	}
 
 	tflog.Trace(ctx, "client.ListNodeBalancerFirewalls(...)")
@@ -66,6 +67,7 @@ func (d *DataSource) Read(
 			fmt.Sprintf("Failed to list firewalls assgiend to nodebalancer %d", nodeBalancerID),
 			err.Error(),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(data.flattenNodeBalancer(ctx, nodeBalancer, firewalls)...)

--- a/linode/nb/framework_resource.go
+++ b/linode/nb/framework_resource.go
@@ -97,6 +97,7 @@ func (r *Resource) Create(
 			fmt.Sprintf("Failed to list firewalls assigned to NodeBalancer %d", nodebalancer.ID),
 			err.Error(),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(data.FlattenNodeBalancer(ctx, nodebalancer, firewalls, true)...)
@@ -162,6 +163,7 @@ func (r *Resource) Read(
 			fmt.Sprintf("Failed to list firewalls assigned to NodeBalancer %d", id),
 			err.Error(),
 		)
+		return
 	}
 
 	resp.Diagnostics.Append(data.FlattenNodeBalancer(ctx, nodeBalancer, firewalls, false)...)
@@ -238,6 +240,7 @@ func (r *Resource) Update(
 				fmt.Sprintf("Failed to list firewalls assigned to NodeBalancer %d", id),
 				err.Error(),
 			)
+			return
 		}
 
 		resp.Diagnostics.Append(plan.FlattenNodeBalancer(ctx, nodeBalancer, firewalls, true)...)

--- a/linode/obj/framework_models.go
+++ b/linode/obj/framework_models.go
@@ -66,6 +66,7 @@ func (data ResourceModel) getObjectBody(diags *diag.Diagnostics) (body *s3manage
 		contentBytes, err = base64.StdEncoding.DecodeString(data.ContentBase64.ValueString())
 		if err != nil {
 			diags.AddError("Failed to Decode the base64 Content", err.Error())
+			return nil
 		}
 	} else if !data.Content.IsNull() && !data.Content.IsUnknown() {
 		contentBytes = []byte(data.Content.ValueString())

--- a/linode/obj/framework_resource.go
+++ b/linode/obj/framework_resource.go
@@ -116,6 +116,7 @@ func RefreshObject(
 			)
 		}
 		diags.AddError("Failed to Refresh the Object", err.Error())
+		return
 	}
 
 	data.FlattenObject(*headOutput, preserveKnown)

--- a/linode/obj/helpers.go
+++ b/linode/obj/helpers.go
@@ -112,6 +112,7 @@ func fwCreateTempKeys(
 	keys, err := client.CreateObjectStorageKey(ctx, createOpts)
 	if err != nil {
 		diags.AddError("Failed to Create Object Storage Key", err.Error())
+		return nil
 	}
 
 	return keys

--- a/linode/objquota/datasource_test.go
+++ b/linode/objquota/datasource_test.go
@@ -95,5 +95,4 @@ func TestAccDataSourceObjQuota_basic(t *testing.T) {
 			},
 		},
 	})
-
 }

--- a/linode/volume/framework_datasource.go
+++ b/linode/volume/framework_datasource.go
@@ -54,7 +54,9 @@ func (r *DataSource) Read(
 	volume, err := client.GetVolume(ctx, volumeID)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get the volume.", err.Error())
+		return
 	}
+
 	data.ParseComputedAttributes(ctx, volume)
 	data.ParseNonComputedAttributes(ctx, volume)
 

--- a/linode/volume/framework_resource.go
+++ b/linode/volume/framework_resource.go
@@ -255,6 +255,7 @@ func (r *Resource) CreateVolume(
 			diags.AddError(
 				"Failed to Wait for Created Volume be Active", err.Error(),
 			)
+			return nil
 		}
 	}
 	return volume
@@ -284,6 +285,7 @@ func (r *Resource) Create(
 	timeoutSeconds, err := helper.SafeFloat64ToInt(createTimeout.Seconds())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to Convert Timeout to int", err.Error())
+		return
 	}
 
 	var volume *linodego.Volume
@@ -383,6 +385,7 @@ func HandleResize(
 			fmt.Sprintf("Failed to Wait for Volume %d Ready from Resizing", volumeID),
 			err.Error(),
 		)
+		return nil
 	}
 
 	return volume


### PR DESCRIPTION
## 📝 Description

This pull request implements excluded returns after `resp.Diagnostics.AddError(...)` calls wherever necessary, which will prevent segmentation faults and data synchronization errors when certain errors occur.

Integration test run (in progress at time of writing): https://github.com/linode/terraform-provider-linode/actions/runs/15004686402/job/42160213562

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int
```

### Manual Testing

**N/A**