### PR TITLE
Fixed DB Engine Config tests to reflect API changes

### DIFF
--- a/linode/databasemysqlconfig/datasource_test.go
+++ b/linode/databasemysqlconfig/datasource_test.go
@@ -30,7 +30,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("connect_timeout").AtMapKey("description"),
-						knownvalue.StringExact("The number of seconds that the mysqld server waits for a connect packet before responding with Bad handshake"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -60,7 +60,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("default_time_zone").AtMapKey("description"),
-						knownvalue.StringExact("Default server time zone as an offset from UTC (from -12:00 to +12:00), a time zone name, or 'SYSTEM' to use the MySQL server default."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -95,7 +95,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("group_concat_max_len").AtMapKey("description"),
-						knownvalue.StringExact("The maximum permitted result length in bytes for the GROUP_CONCAT() function."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -125,7 +125,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("information_schema_stats_expiry").AtMapKey("description"),
-						knownvalue.StringExact("The time, in seconds, before cached statistics expire"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -155,7 +155,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_change_buffer_max_size").AtMapKey("description"),
-						knownvalue.StringExact("Maximum size for the InnoDB change buffer, as a percentage of the total size of the buffer pool. Default is 25"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -185,7 +185,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_flush_neighbors").AtMapKey("description"),
-						knownvalue.StringExact("Specifies whether flushing a page from the InnoDB buffer pool also flushes other dirty pages in the same extent (default is 1): 0 - dirty pages in the same extent are not flushed, 1 - flush contiguous dirty pages in the same extent, 2 - flush dirty pages in the same extent"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -215,7 +215,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_ft_min_token_size").AtMapKey("description"),
-						knownvalue.StringExact("Minimum length of words that are stored in an InnoDB FULLTEXT index. Changing this parameter will lead to a restart of the MySQL service."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -245,7 +245,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_ft_server_stopword_table").AtMapKey("description"),
-						knownvalue.StringExact("This option is used to specify your own InnoDB FULLTEXT index stopword list for all InnoDB tables."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -278,7 +278,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_lock_wait_timeout").AtMapKey("description"),
-						knownvalue.StringExact("The length of time in seconds an InnoDB transaction waits for a row lock before giving up. Default is 120."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -308,7 +308,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_log_buffer_size").AtMapKey("description"),
-						knownvalue.StringExact("The size in bytes of the buffer that InnoDB uses to write to the log files on disk."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -338,7 +338,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_online_alter_log_max_size").AtMapKey("description"),
-						knownvalue.StringExact("The upper limit in bytes on the size of the temporary log files used during online DDL operations for InnoDB tables."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -368,7 +368,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_read_io_threads").AtMapKey("description"),
-						knownvalue.StringExact("The number of I/O threads for read operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -398,7 +398,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_rollback_on_timeout").AtMapKey("description"),
-						knownvalue.StringExact("When enabled a transaction timeout causes InnoDB to abort and roll back the entire transaction. Changing this parameter will lead to a restart of the MySQL service."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -418,7 +418,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_thread_concurrency").AtMapKey("description"),
-						knownvalue.StringExact("Defines the maximum number of threads permitted inside of InnoDB. Default is 0 (infinite concurrency - no limit)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -448,7 +448,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("innodb_write_io_threads").AtMapKey("description"),
-						knownvalue.StringExact("The number of I/O threads for write operations in InnoDB. Default is 4. Changing this parameter will lead to a restart of the MySQL service."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -478,7 +478,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("interactive_timeout").AtMapKey("description"),
-						knownvalue.StringExact("The number of seconds the server waits for activity on an interactive connection before closing it."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -509,7 +509,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("internal_tmp_mem_storage_engine").AtMapKey("description"),
-						knownvalue.StringExact("The storage engine for in-memory internal temporary tables."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -537,7 +537,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("max_allowed_packet").AtMapKey("description"),
-						knownvalue.StringExact("Size of the largest message in bytes that can be received by the server. Default is 67108864 (64M)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -567,7 +567,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("max_heap_table_size").AtMapKey("description"),
-						knownvalue.StringExact("Limits the size of internal in-memory tables. Also set tmp_table_size. Default is 16777216 (16M)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -597,7 +597,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("net_buffer_length").AtMapKey("description"),
-						knownvalue.StringExact("Start sizes of connection buffer and result buffer. Default is 16384 (16K). Changing this parameter will lead to a restart of the MySQL service."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -627,7 +627,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("net_read_timeout").AtMapKey("description"),
-						knownvalue.StringExact("The number of seconds to wait for more data from a connection before aborting the read."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -657,7 +657,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("net_write_timeout").AtMapKey("description"),
-						knownvalue.StringExact("The number of seconds to wait for a block to be written to a connection before aborting the write."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -687,7 +687,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("sort_buffer_size").AtMapKey("description"),
-						knownvalue.StringExact("Sort buffer size in bytes for ORDER BY optimization. Default is 262144 (256K)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -717,7 +717,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("sql_mode").AtMapKey("description"),
-						knownvalue.StringExact("Global SQL mode. Set to empty to use MySQL server defaults. When creating a new service and not setting this field Akamai default SQL mode (strict, SQL standard compliant) will be assigned."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -747,7 +747,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("sql_require_primary_key").AtMapKey("description"),
-						knownvalue.StringExact("Require primary key to be defined for new tables or old tables modified with ALTER TABLE and fail if missing. It is recommended to always have primary keys because various functionality may break if any large table is missing them."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -767,7 +767,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("tmp_table_size").AtMapKey("description"),
-						knownvalue.StringExact("Limits the size of internal in-memory tables. Also set max_heap_table_size. Default is 16777216 (16M)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -797,7 +797,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("mysql").AtSliceIndex(0).AtMapKey("wait_timeout").AtMapKey("description"),
-						knownvalue.StringExact("The number of seconds the server waits for activity on a noninteractive connection before closing it."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -827,7 +827,7 @@ func TestAccDataSourceDatabaseMySQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("binlog_retention_period").AtSliceIndex(0).AtMapKey("description"),
-						knownvalue.StringExact("The minimum amount of time in seconds to keep binlog entries before deletion. This may be extended for services that require binlog entries for longer than the default for example if using the MySQL Debezium Kafka connector."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,

--- a/linode/databasepostgresqlconfig/datasource_test.go
+++ b/linode/databasepostgresqlconfig/datasource_test.go
@@ -28,7 +28,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_analyze_scale_factor").AtMapKey("description"),
-						knownvalue.StringExact("Specifies a fraction of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE. The default is 0.2 (20% of table size)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -53,7 +53,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_analyze_threshold").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the minimum number of inserted, updated or deleted tuples needed to trigger an ANALYZE in any one table. The default is 50 tuples."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -78,7 +78,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_max_workers").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the maximum number of autovacuum processes (other than the autovacuum launcher) that may be running at any one time. The default is three. This parameter can only be set at server start."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -103,7 +103,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_naptime").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the minimum delay between autovacuum runs on any given database. The delay is measured in seconds, and the default is one minute"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -128,7 +128,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_vacuum_cost_delay").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the cost delay value that will be used in automatic VACUUM operations. If -1 is specified, the regular vacuum_cost_delay value will be used. The default value is 20 milliseconds"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -153,7 +153,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_vacuum_cost_limit").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the cost limit value that will be used in automatic VACUUM operations. If -1 is specified (which is the default), the regular vacuum_cost_limit value will be used."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -178,7 +178,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_vacuum_scale_factor").AtMapKey("description"),
-						knownvalue.StringExact("Specifies a fraction of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM. The default is 0.2 (20% of table size)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -203,7 +203,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("autovacuum_vacuum_threshold").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the minimum number of updated or deleted tuples needed to trigger a VACUUM in any one table. The default is 50 tuples"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -228,7 +228,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("bgwriter_delay").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the delay between activity rounds for the background writer in milliseconds. Default is 200."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -253,7 +253,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("bgwriter_flush_after").AtMapKey("description"),
-						knownvalue.StringExact("Whenever more than bgwriter_flush_after bytes have been written by the background writer, attempt to force the OS to issue these writes to the underlying storage. Specified in kilobytes, default is 512. Setting of 0 disables forced writeback."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -278,7 +278,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("bgwriter_lru_maxpages").AtMapKey("description"),
-						knownvalue.StringExact("In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing. Default is 100."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -303,7 +303,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("bgwriter_lru_multiplier").AtMapKey("description"),
-						knownvalue.StringExact("The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to bgwriter_lru_maxpages). 1.0 represents a “just in time” policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes. The default is 2.0."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -328,7 +328,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("deadlock_timeout").AtMapKey("description"),
-						knownvalue.StringExact("This is the amount of time, in milliseconds, to wait on a lock before checking to see if there is a deadlock condition."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -353,7 +353,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("default_toast_compression").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the default TOAST compression method for values of compressible columns (the default is lz4)."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -381,7 +381,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("idle_in_transaction_session_timeout").AtMapKey("description"),
-						knownvalue.StringExact("Time out sessions with open transactions after this number of milliseconds"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -406,7 +406,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("jit").AtMapKey("description"),
-						knownvalue.StringExact("Controls system-wide use of Just-in-Time Compilation (JIT)."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -426,7 +426,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_files_per_process").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL maximum number of files that can be open per process"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -451,7 +451,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_locks_per_transaction").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL maximum locks per transaction"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -476,7 +476,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_logical_replication_workers").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL maximum logical replication workers (taken from the pool of max_parallel_workers)"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -501,7 +501,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_parallel_workers").AtMapKey("description"),
-						knownvalue.StringExact("Sets the maximum number of workers that the system can support for parallel queries"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -526,7 +526,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_parallel_workers_per_gather").AtMapKey("description"),
-						knownvalue.StringExact("Sets the maximum number of workers that can be started by a single Gather or Gather Merge node"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -551,7 +551,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_pred_locks_per_transaction").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL maximum predicate locks per transaction"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -576,7 +576,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_replication_slots").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL maximum replication slots"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -601,7 +601,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_slot_wal_keep_size").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL maximum WAL size (MB) reserved for replication slots. Default is -1 (unlimited). wal_keep_size minimum WAL size setting takes precedence over this."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -626,7 +626,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_stack_depth").AtMapKey("description"),
-						knownvalue.StringExact("Maximum depth of the stack in bytes"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -651,7 +651,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_standby_archive_delay").AtMapKey("description"),
-						knownvalue.StringExact("Max standby archive delay in milliseconds"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -676,7 +676,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_standby_streaming_delay").AtMapKey("description"),
-						knownvalue.StringExact("Max standby streaming delay in milliseconds"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -701,7 +701,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_wal_senders").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL maximum WAL senders"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -726,7 +726,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("max_worker_processes").AtMapKey("description"),
-						knownvalue.StringExact("Sets the maximum number of background processes that the system can support"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -751,7 +751,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("password_encryption").AtMapKey("description"),
-						knownvalue.StringExact("Chooses the algorithm for encrypting passwords."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -779,7 +779,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("pg_partman_bgw.interval").AtMapKey("description"),
-						knownvalue.StringExact("Sets the time interval to run pg_partman's scheduled tasks"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -804,7 +804,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("pg_partman_bgw.role").AtMapKey("description"),
-						knownvalue.StringExact("Controls which role to use for pg_partman's scheduled background tasks."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -834,7 +834,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("pg_stat_monitor.pgsm_enable_query_plan").AtMapKey("description"),
-						knownvalue.StringExact("Enables or disables query plan monitoring"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -854,7 +854,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("pg_stat_monitor.pgsm_max_buckets").AtMapKey("description"),
-						knownvalue.StringExact("Sets the maximum number of buckets "),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -884,7 +884,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("pg_stat_statements.track").AtMapKey("description"),
-						knownvalue.StringExact("Controls which statements are counted. Specify top to track top-level statements (those issued directly by clients), all to also track nested statements (such as statements invoked within functions), or none to disable statement statistics collection. The default value is top."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -908,7 +908,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("temp_file_limit").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL temporary file limit in KiB, -1 for unlimited"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -938,7 +938,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("timezone").AtMapKey("description"),
-						knownvalue.StringExact("PostgreSQL service timezone"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -968,7 +968,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("track_activity_query_size").AtMapKey("description"),
-						knownvalue.StringExact("Specifies the number of bytes reserved to track the currently executing command for each active session."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -998,7 +998,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("track_commit_timestamp").AtMapKey("description"),
-						knownvalue.StringExact("Record commit time of transactions."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1026,7 +1026,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("track_functions").AtMapKey("description"),
-						knownvalue.StringExact("Enables tracking of function call counts and time used."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1050,7 +1050,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("track_io_timing").AtMapKey("description"),
-						knownvalue.StringExact("Enables timing of database I/O calls. This parameter is off by default, because it will repeatedly query the operating system for the current time, which may cause significant overhead on some platforms."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1078,7 +1078,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("wal_sender_timeout").AtMapKey("description"),
-						knownvalue.StringExact("Terminate replication connections that are inactive for longer than this amount of time, in milliseconds. Setting this value to zero disables the timeout."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1098,7 +1098,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg").AtSliceIndex(0).AtMapKey("wal_writer_delay").AtMapKey("description"),
-						knownvalue.StringExact("WAL flush interval in milliseconds. Note that setting this value to lower than the default 200ms may negatively impact performance"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1128,7 +1128,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pg_stat_monitor_enable").AtSliceIndex(0).AtMapKey("description"),
-						knownvalue.StringExact("Enable the pg_stat_monitor extension. Enabling this extension will cause the cluster to be restarted.When this extension is enabled, pg_stat_statements results for utility commands are unreliable"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1143,7 +1143,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("pglookout").AtSliceIndex(0).AtMapKey("max_failover_replication_time_lag").AtMapKey("description"),
-						knownvalue.StringExact("Number of seconds of master unavailability before triggering database failover to standby"),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1168,7 +1168,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("shared_buffers_percentage").AtSliceIndex(0).AtMapKey("description"),
-						knownvalue.StringExact("Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the shared_buffers configuration value."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,
@@ -1193,7 +1193,7 @@ func TestAccDataSourceDatabasePostgreSQLConfig_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("work_mem").AtSliceIndex(0).AtMapKey("description"),
-						knownvalue.StringExact("Sets the maximum amount of memory to be used by a query operation (such as a sort or hash table) before writing to temporary disk files, in MB. Default is 1MB + 0.075% of total RAM (up to 32MB)."),
+						knownvalue.NotNull(),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,


### PR DESCRIPTION
## 📝 Description

Updated the `description` test checks to check that the value is non-null rather than comparing it to an exact string value. These descriptions can change, so this will require less maintenance and fixes.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Tests
`make test-int PKG_NAME="databasepostgresqlconfig" TEST_CASE="TestAccDataSourceDatabasePostgreSQLConfig_basic"`
`make test-int PKG_NAME="databasemysqlconfig" TEST_CASE="TestAccDataSourceDatabaseMySQLConfig_basic"`