### PR TITLE
 Implement firewall settings resource

### DIFF
--- a/docs/resources/linode_firewall_settings.md
+++ b/docs/resources/linode_firewall_settings.md
@@ -1,0 +1,35 @@
+---
+title: "linode_firewall_settings"
+description: |-
+  Manages Linode account-level firewall settings.
+---
+
+# linode_firewall_settings
+
+Manages Linode account-level firewall settings. Resetting default firewall IDs
+to null is not available to all customers and unsupported in this resource.
+
+## Example Usage
+
+```hcl
+resource "linode_firewall_settings" "example" {
+  default_firewall_ids = {
+    linode           = 12345
+    nodebalancer     = 12345
+    public_interface = 12345
+    vpc_interface    = 12345
+  }
+}
+```
+
+## Argument Reference
+
+* `default_firewall_ids` - (Optional) A map of default firewall IDs for various interfaces.
+  * `linode` - (Optional) The Linode's default firewall.
+  * `nodebalancer` - (Optional) The NodeBalancer's default firewall.
+  * `public_interface` - (Optional) The public interface's default firewall.
+  * `vpc_interface` - (Optional) The VPC interface's default firewall.
+
+## API Reference
+
+See the [Linode API documentation](https://techdocs.akamai.com/linode-api/reference/put-firewall-settings) for more details.

--- a/linode/firewallsettings/framework_datasource.go
+++ b/linode/firewallsettings/framework_datasource.go
@@ -22,7 +22,11 @@ func NewDataSource() datasource.DataSource {
 	}
 }
 
-func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *DataSource) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
 	var state FirewallSettingsModel
 
 	client := d.Meta.Client
@@ -38,7 +42,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		return
 	}
 
-	state.ParseFirewallSettings(ctx, *firewallSettings, &resp.Diagnostics)
+	state.FlattenFirewallSettings(ctx, *firewallSettings, false, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/firewallsettings/framework_datasource_test.go
+++ b/linode/firewallsettings/framework_datasource_test.go
@@ -20,7 +20,7 @@ const (
 
 var testRegion string
 
-func TestAccDataSourceFirewalls_basic(t *testing.T) {
+func TestAccDataSourceFirewallSettings_basic(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -29,7 +29,11 @@ func TestAccDataSourceFirewalls_basic(t *testing.T) {
 			{
 				Config: tmpl.Data(t, dataName),
 				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(dataFullName, tfjsonpath.New("default_firewall_ids"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(
+						dataFullName,
+						tfjsonpath.New("default_firewall_ids"),
+						knownvalue.NotNull(),
+					),
 				},
 			},
 		},

--- a/linode/firewallsettings/framework_model_unit_test.go
+++ b/linode/firewallsettings/framework_model_unit_test.go
@@ -1,0 +1,139 @@
+//go:build unit
+
+package firewallsettings_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v3/linode/firewallsettings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenFirewallSettings(t *testing.T) {
+	ctx := context.Background()
+	defaultFirewallIDsObjectAttrType := firewallsettings.FrameworkResourceSchema.Attributes["default_firewall_ids"].(schema.SingleNestedAttribute).GetType().(types.ObjectType).AttrTypes
+	firewallSettings := linodego.FirewallSettings{
+		DefaultFirewallIDs: linodego.DefaultFirewallIDs{
+			Linode:          linodego.Pointer(123),
+			NodeBalancer:    nil,
+			PublicInterface: linodego.Pointer(789),
+			VPCInterface:    nil,
+		},
+	}
+
+	expectedModelWhenNotPreservingKnown := firewallsettings.FirewallSettingsModel{
+		DefaultFirewallIDs: types.ObjectValueMust(
+			defaultFirewallIDsObjectAttrType,
+			map[string]attr.Value{
+				"linode":           types.Int64Value(123),
+				"nodebalancer":     types.Int64Null(),
+				"public_interface": types.Int64Value(789),
+				"vpc_interface":    types.Int64Null(),
+			},
+		),
+	}
+
+	tests := map[string]struct {
+		model         firewallsettings.FirewallSettingsModel
+		settings      linodego.FirewallSettings
+		expected      firewallsettings.FirewallSettingsModel
+		preserveKnown bool
+	}{
+		"unknown default firewall IDs with preserving known": {
+			model: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectUnknown(defaultFirewallIDsObjectAttrType),
+			},
+			settings:      firewallSettings,
+			expected:      expectedModelWhenNotPreservingKnown,
+			preserveKnown: true,
+		},
+		"null default firewall IDs with preserving known": {
+			model: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectNull(defaultFirewallIDsObjectAttrType),
+			},
+			settings: firewallSettings,
+			expected: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectNull(defaultFirewallIDsObjectAttrType),
+			},
+			preserveKnown: true,
+		},
+		"known default firewall IDs with preserving known": {
+			model: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectValueMust(
+					defaultFirewallIDsObjectAttrType,
+					map[string]attr.Value{
+						"linode":           types.Int64Value(123),
+						"nodebalancer":     types.Int64Value(456),
+						"public_interface": types.Int64Unknown(),
+						"vpc_interface":    types.Int64Unknown(),
+					},
+				),
+			},
+			settings: firewallSettings,
+			expected: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectValueMust(
+					defaultFirewallIDsObjectAttrType,
+					map[string]attr.Value{
+						"linode":           types.Int64Value(123),
+						"nodebalancer":     types.Int64Value(456),
+						"public_interface": types.Int64Value(789),
+						"vpc_interface":    types.Int64Null(),
+					},
+				),
+			},
+			preserveKnown: true,
+		},
+		"unknown default firewall IDs without preserving known": {
+			model: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectUnknown(defaultFirewallIDsObjectAttrType),
+			},
+			settings:      firewallSettings,
+			expected:      expectedModelWhenNotPreservingKnown,
+			preserveKnown: false,
+		},
+		"null default firewall IDs without preserving known": {
+			model: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectNull(defaultFirewallIDsObjectAttrType),
+			},
+			settings:      firewallSettings,
+			expected:      expectedModelWhenNotPreservingKnown,
+			preserveKnown: false,
+		},
+		"known default firewall IDs without preserving known": {
+			model: firewallsettings.FirewallSettingsModel{
+				DefaultFirewallIDs: types.ObjectValueMust(
+					defaultFirewallIDsObjectAttrType,
+					map[string]attr.Value{
+						"linode":           types.Int64Value(123),
+						"nodebalancer":     types.Int64Value(456),
+						"public_interface": types.Int64Unknown(),
+						"vpc_interface":    types.Int64Unknown(),
+					},
+				),
+			},
+			settings:      firewallSettings,
+			expected:      expectedModelWhenNotPreservingKnown,
+			preserveKnown: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			diags := &diag.Diagnostics{}
+			tt.model.FlattenFirewallSettings(ctx, tt.settings, tt.preserveKnown, diags)
+
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags)
+			}
+
+			assert.Equal(t, tt.expected.DefaultFirewallIDs, tt.model.DefaultFirewallIDs,
+				"Flattened DefaultFirewallIDs should match expected value")
+		})
+	}
+}

--- a/linode/firewallsettings/framework_models.go
+++ b/linode/firewallsettings/framework_models.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v3/linode/helper"
 )
@@ -20,14 +21,94 @@ type FirewallSettingsModel struct {
 	DefaultFirewallIDs types.Object `tfsdk:"default_firewall_ids"`
 }
 
-func (fsds *FirewallSettingsModel) ParseFirewallSettings(ctx context.Context, settings linodego.FirewallSettings, diags *diag.Diagnostics) {
-	defaultIDs, newDiags := types.ObjectValueFrom(ctx, fsds.DefaultFirewallIDs.AttributeTypes(ctx), DefaultFirewallIDsAttributeModel{
-		Linode:          types.Int64PointerValue(helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.Linode)),
-		NodeBalancer:    types.Int64PointerValue(helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.NodeBalancer)),
-		PublicInterface: types.Int64PointerValue(helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.PublicInterface)),
-		VPCInterface:    types.Int64PointerValue(helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.VPCInterface)),
-	})
+func (fsds *FirewallSettingsModel) GetUpdateOptions(
+	ctx context.Context,
+	diags *diag.Diagnostics,
+) (opts linodego.FirewallSettingsUpdateOptions) {
+	var defaultFirewallIDs DefaultFirewallIDsAttributeModel
+	diags.Append(fsds.DefaultFirewallIDs.As(ctx, &defaultFirewallIDs, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    false,
+		UnhandledUnknownAsEmpty: false,
+	})...)
+
+	if diags.HasError() {
+		return
+	}
+
+	if !defaultFirewallIDs.Linode.IsUnknown() {
+		opts.DefaultFirewallIDs.Linode = linodego.Pointer(
+			helper.FrameworkSafeInt64PointerToIntPointer(defaultFirewallIDs.Linode.ValueInt64Pointer(), diags),
+		)
+	}
+
+	if !defaultFirewallIDs.NodeBalancer.IsUnknown() {
+		opts.DefaultFirewallIDs.NodeBalancer = linodego.Pointer(
+			helper.FrameworkSafeInt64PointerToIntPointer(defaultFirewallIDs.NodeBalancer.ValueInt64Pointer(), diags),
+		)
+	}
+
+	if !defaultFirewallIDs.PublicInterface.IsUnknown() {
+		opts.DefaultFirewallIDs.PublicInterface = linodego.Pointer(
+			helper.FrameworkSafeInt64PointerToIntPointer(defaultFirewallIDs.PublicInterface.ValueInt64Pointer(), diags),
+		)
+	}
+
+	if !defaultFirewallIDs.VPCInterface.IsUnknown() {
+		opts.DefaultFirewallIDs.VPCInterface = linodego.Pointer(
+			helper.FrameworkSafeInt64PointerToIntPointer(defaultFirewallIDs.VPCInterface.ValueInt64Pointer(), diags),
+		)
+	}
+
+	return
+}
+
+func (fsds *FirewallSettingsModel) FlattenFirewallSettings(
+	ctx context.Context,
+	settings linodego.FirewallSettings,
+	preserveKnown bool,
+	diags *diag.Diagnostics,
+) {
+	if preserveKnown && fsds.DefaultFirewallIDs.IsNull() {
+		return
+	}
+
+	var defaultFirewallIDs DefaultFirewallIDsAttributeModel
+
+	if !fsds.DefaultFirewallIDs.IsUnknown() && !fsds.DefaultFirewallIDs.IsNull() {
+		diags.Append(
+			fsds.DefaultFirewallIDs.As(ctx, &defaultFirewallIDs, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    false,
+				UnhandledUnknownAsEmpty: false,
+			})...,
+		)
+
+		if diags.HasError() {
+			return
+		}
+	}
+
+	// When the DefaultFirewallIDs wrapper object is unknown,
+	// we need to override all nested known values (not to preserve them).
+	preserveKnown = preserveKnown && !fsds.DefaultFirewallIDs.IsUnknown()
+
+	defaultFirewallIDs.FlattenFirewallSettings(settings, preserveKnown)
+
+	defaultIDs, newDiags := types.ObjectValueFrom(
+		ctx,
+		fsds.DefaultFirewallIDs.AttributeTypes(ctx),
+		defaultFirewallIDs,
+	)
 	diags.Append(newDiags...)
+	if diags.HasError() {
+		return
+	}
 
 	fsds.DefaultFirewallIDs = defaultIDs
+}
+
+func (dfiam *DefaultFirewallIDsAttributeModel) FlattenFirewallSettings(settings linodego.FirewallSettings, preserveKnown bool) {
+	dfiam.Linode = helper.KeepOrUpdateInt64Pointer(dfiam.Linode, helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.Linode), preserveKnown)
+	dfiam.NodeBalancer = helper.KeepOrUpdateInt64Pointer(dfiam.NodeBalancer, helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.NodeBalancer), preserveKnown)
+	dfiam.PublicInterface = helper.KeepOrUpdateInt64Pointer(dfiam.PublicInterface, helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.PublicInterface), preserveKnown)
+	dfiam.VPCInterface = helper.KeepOrUpdateInt64Pointer(dfiam.VPCInterface, helper.IntPtrToInt64Ptr(settings.DefaultFirewallIDs.VPCInterface), preserveKnown)
 }

--- a/linode/firewallsettings/framework_resource.go
+++ b/linode/firewallsettings/framework_resource.go
@@ -1,0 +1,150 @@
+package firewallsettings
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v3/linode/helper"
+)
+
+func NewResource() resource.Resource {
+	return &Resource{
+		BaseResource: helper.NewBaseResource(
+			helper.BaseResourceConfig{
+				Name:   "linode_firewall_settings",
+				IDType: types.StringType,
+				Schema: &FrameworkResourceSchema,
+			},
+		),
+	}
+}
+
+type Resource struct {
+	helper.BaseResource
+}
+
+func (r *Resource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
+	tflog.Debug(ctx, "Create "+r.Config.Name)
+	var plan FirewallSettingsModel
+	client := r.Meta.Client
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateFirewallSettings(ctx, client, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+
+	// IDs should always be overridden during creation (see #1085)
+	// TODO: Remove when Crossplane empty string ID issue is resolved
+	// plan.ID = types.StringValue(strconv.Itoa(firewall.ID))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
+	tflog.Debug(ctx, "Read "+r.Config.Name)
+
+	client := r.Meta.Client
+
+	var state FirewallSettingsModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	firewallSettings, err := client.GetFirewallSettings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get firewall settings",
+			fmt.Sprintf(
+				"An error occurred while retrieving the firewall settings: %s",
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	state.FlattenFirewallSettings(ctx, *firewallSettings, false, &resp.Diagnostics)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
+	tflog.Debug(ctx, "Update "+r.Config.Name)
+
+	client := r.Meta.Client
+	var plan FirewallSettingsModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateFirewallSettings(ctx, client, &plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func updateFirewallSettings(
+	ctx context.Context,
+	client *linodego.Client,
+	plan *FirewallSettingsModel,
+	diags *diag.Diagnostics,
+) {
+	tflog.Debug(ctx, "Updating firewall settings")
+
+	updateOptions := plan.GetUpdateOptions(ctx, diags)
+	if diags.HasError() {
+		return
+	}
+
+	firewallSettings, err := client.UpdateFirewallSettings(ctx, updateOptions)
+	if err != nil {
+		diags.AddError(
+			"Failed to update firewall settings",
+			fmt.Sprintf("An error occurred while updating the firewall settings: %s", err.Error()),
+		)
+		return
+	}
+
+	plan.FlattenFirewallSettings(ctx, *firewallSettings, true, diags)
+}
+
+func (r *Resource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
+	tflog.Debug(ctx, "Delete "+r.Config.Name)
+	tflog.Info(
+		ctx, "Firewall settings cannot be deleted. "+
+			"The TF state has been deleted, but the "+
+			"firewall settings will remain in Linode's system.",
+	)
+}

--- a/linode/firewallsettings/framework_resource.go
+++ b/linode/firewallsettings/framework_resource.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v3/linode/helper"
@@ -17,7 +16,6 @@ func NewResource() resource.Resource {
 		BaseResource: helper.NewBaseResource(
 			helper.BaseResourceConfig{
 				Name:   "linode_firewall_settings",
-				IDType: types.StringType,
 				Schema: &FrameworkResourceSchema,
 			},
 		),
@@ -146,5 +144,17 @@ func (r *Resource) Delete(
 		ctx, "Firewall settings cannot be deleted. "+
 			"The TF state has been deleted, but the "+
 			"firewall settings will remain in Linode's system.",
+	)
+}
+
+func (r *Resource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	resp.Diagnostics.AddError(
+		"Resource Import Not Supported",
+		"Importing state for this resource is not supported. "+
+			"Please use the resource to manage firewall settings directly for your account.",
 	)
 }

--- a/linode/firewallsettings/framework_resource_schema.go
+++ b/linode/firewallsettings/framework_resource_schema.go
@@ -13,6 +13,7 @@ var FrameworkResourceSchema = schema.Schema{
 			Description: "The default firewall ID for a linode, nodebalancer, public_interface, or vpc_interface.",
 			Attributes: map[string]schema.Attribute{
 				"linode": schema.Int64Attribute{
+					Description: "The Linode's default firewall.",
 					PlanModifiers: []planmodifier.Int64{
 						int64planmodifier.UseStateForUnknown(),
 					},
@@ -20,6 +21,7 @@ var FrameworkResourceSchema = schema.Schema{
 					Computed: true,
 				},
 				"nodebalancer": schema.Int64Attribute{
+					Description: "The NodeBalancer's default firewall.",
 					PlanModifiers: []planmodifier.Int64{
 						int64planmodifier.UseStateForUnknown(),
 					},
@@ -27,6 +29,7 @@ var FrameworkResourceSchema = schema.Schema{
 					Computed: true,
 				},
 				"public_interface": schema.Int64Attribute{
+					Description: "The public interface's default firewall.",
 					PlanModifiers: []planmodifier.Int64{
 						int64planmodifier.UseStateForUnknown(),
 					},
@@ -34,6 +37,7 @@ var FrameworkResourceSchema = schema.Schema{
 					Computed: true,
 				},
 				"vpc_interface": schema.Int64Attribute{
+					Description: "The VPC interface's default firewall.",
 					PlanModifiers: []planmodifier.Int64{
 						int64planmodifier.UseStateForUnknown(),
 					},

--- a/linode/firewallsettings/framework_resource_schema.go
+++ b/linode/firewallsettings/framework_resource_schema.go
@@ -1,0 +1,46 @@
+package firewallsettings
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+var FrameworkResourceSchema = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"default_firewall_ids": schema.SingleNestedAttribute{
+			Optional:    true,
+			Description: "The default firewall ID for a linode, nodebalancer, public_interface, or vpc_interface.",
+			Attributes: map[string]schema.Attribute{
+				"linode": schema.Int64Attribute{
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+					},
+					Optional: true,
+					Computed: true,
+				},
+				"nodebalancer": schema.Int64Attribute{
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+					},
+					Optional: true,
+					Computed: true,
+				},
+				"public_interface": schema.Int64Attribute{
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+					},
+					Optional: true,
+					Computed: true,
+				},
+				"vpc_interface": schema.Int64Attribute{
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+					},
+					Optional: true,
+					Computed: true,
+				},
+			},
+		},
+	},
+}

--- a/linode/firewallsettings/framework_resource_test.go
+++ b/linode/firewallsettings/framework_resource_test.go
@@ -1,0 +1,106 @@
+package firewallsettings_test
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/linode/linodego"
+	"github.com/linode/terraform-provider-linode/v3/linode/acceptance"
+	"github.com/linode/terraform-provider-linode/v3/linode/firewallsettings/tmpl"
+)
+
+var (
+	originalFirewallSettings *linodego.FirewallSettings
+	testFirewallID           int
+)
+
+const (
+	resourceName     = "test"
+	resourceFullName = "linode_firewall_settings." + resourceName
+)
+
+func init() {
+	client, err := acceptance.GetTestClient()
+	if err != nil {
+		log.Fatalf("failed to get client: %s", err)
+	}
+
+	originalFirewallSettings, err = client.GetFirewallSettings(context.Background())
+	if err != nil {
+		log.Fatalf("failed to get firewall settings: %s", err)
+	}
+
+	testFirewall, err := client.CreateFirewall(context.Background(), linodego.FirewallCreateOptions{
+		Label: acctest.RandomWithPrefix("tf_test"),
+		Rules: linodego.FirewallRuleSet{
+			InboundPolicy:  "DROP",
+			OutboundPolicy: "ACCEPT",
+		},
+	})
+	if err != nil {
+		log.Fatalf("failed to setup test firewall: %s", err)
+	}
+
+	testFirewallID = testFirewall.ID
+	time.Sleep(2 * time.Second) // Wait for the firewall to be fully created
+}
+
+func TestAccResourceFirewallSettings_basic(t *testing.T) {
+	t.Parallel()
+	t.Cleanup(func() {
+		client, err := acceptance.GetTestClient()
+		if err != nil {
+			log.Fatalf("failed to get client: %s", err)
+		}
+
+		if originalFirewallSettings != nil {
+			_, err = client.UpdateFirewallSettings(context.Background(), linodego.FirewallSettingsUpdateOptions{
+				DefaultFirewallIDs: linodego.DefaultFirewallIDsOptions{
+					Linode:          linodego.Pointer(originalFirewallSettings.DefaultFirewallIDs.Linode),
+					NodeBalancer:    linodego.Pointer(originalFirewallSettings.DefaultFirewallIDs.NodeBalancer),
+					PublicInterface: linodego.Pointer(originalFirewallSettings.DefaultFirewallIDs.PublicInterface),
+					VPCInterface:    linodego.Pointer(originalFirewallSettings.DefaultFirewallIDs.VPCInterface),
+				},
+			})
+			if err != nil {
+				log.Fatalf("failed to restore original firewall settings: %s", err)
+			}
+		}
+
+		err = client.DeleteFirewall(context.Background(), testFirewallID)
+		if err != nil {
+			log.Fatalf("failed to delete test firewall: %s", err)
+		}
+	})
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.Basic(t, resourceName, testFirewallID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceFullName, tfjsonpath.New("default_firewall_ids"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(
+						resourceFullName, tfjsonpath.New("default_firewall_ids").AtMapKey("linode"), knownvalue.Int64Exact(int64(testFirewallID)),
+					),
+					statecheck.ExpectKnownValue(
+						resourceFullName, tfjsonpath.New("default_firewall_ids").AtMapKey("nodebalancer"), knownvalue.Int64Exact(int64(testFirewallID)),
+					),
+					statecheck.ExpectKnownValue(
+						resourceFullName, tfjsonpath.New("default_firewall_ids").AtMapKey("public_interface"), knownvalue.Int64Exact(int64(testFirewallID)),
+					),
+					statecheck.ExpectKnownValue(
+						resourceFullName, tfjsonpath.New("default_firewall_ids").AtMapKey("vpc_interface"), knownvalue.Int64Exact(int64(testFirewallID)),
+					),
+				},
+			},
+		},
+	})
+}

--- a/linode/firewallsettings/tmpl/basic.gotf
+++ b/linode/firewallsettings/tmpl/basic.gotf
@@ -1,0 +1,12 @@
+{{ define "linode_firewall_settings_basic" }}
+
+resource "linode_firewall_settings" "{{ .ResourceName }}" {
+  default_firewall_ids = {
+    linode           = {{ .FirewallID }}
+    nodebalancer     = {{ .FirewallID }}
+    public_interface = {{ .FirewallID }}
+    vpc_interface    = {{ .FirewallID }}
+  }
+}
+
+{{ end }}

--- a/linode/firewallsettings/tmpl/template.go
+++ b/linode/firewallsettings/tmpl/template.go
@@ -8,6 +8,15 @@ import (
 
 type TemplateData struct {
 	DataSourceName string
+	ResourceName   string
+	FirewallID     int
+}
+
+func Basic(t testing.TB, resourceName string, testFirewallID int) string {
+	return acceptance.ExecuteTemplate(t, "linode_firewall_settings_basic", TemplateData{
+		ResourceName: resourceName,
+		FirewallID:   testFirewallID,
+	})
 }
 
 func Data(t testing.TB, datasourceName string) string {

--- a/linode/framework_provider.go
+++ b/linode/framework_provider.go
@@ -254,6 +254,7 @@ func (p *FrameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		networkingipassignment.NewResource,
 		obj.NewResource,
 		databasemysqlv2.NewResource,
+		firewallsettings.NewResource,
 	}
 }
 

--- a/linode/helper/framework_data.go
+++ b/linode/helper/framework_data.go
@@ -95,6 +95,7 @@ func KeepOrUpdateBoolPointer(original types.Bool, updated *bool, preserveKnown b
 	return KeepOrUpdateValue(original, types.BoolPointerValue(updated), preserveKnown)
 }
 
+// KeepOrUpdateValue is a generic function to keep the original value if it is known when preserveKnown is true, or
 func KeepOrUpdateValue[T attr.Value](original T, updated T, preserveKnown bool) T {
 	if preserveKnown && !original.IsUnknown() {
 		return original

--- a/linode/lke/schema_resource.go
+++ b/linode/lke/schema_resource.go
@@ -200,7 +200,8 @@ var resourceSchema = map[string]*schema.Schema{
 							},
 						},
 					},
-					Computed:    true,
+					Computed: true,
+
 					Description: "The nodes in the node pool.",
 				},
 				"autoscaler": {


### PR DESCRIPTION
## 📝 Description

Add `linode_firewall_settings` resource.

## ✔️ How to Test

You will need to enable Linode interface beta or corresponding tag for testing it.

```hcl
resource "linode_firewall_settings" "test" {
  default_firewall_ids = {
    linode           = 1629606
    nodebalancer     = 1629606
    public_interface = 1629606
    vpc_interface    = 1629606
  }
}
```

```bash
make test-int PKG_NAME="firewallsettings"
```