### PR TITLE
Remove RequiresReplace() for node pool k8s_version update

### DIFF
--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -5,6 +5,10 @@ package instanceconfig_test
 import (
 	"context"
 	"fmt"
+	"log"
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -12,9 +16,6 @@ import (
 	"github.com/linode/terraform-provider-linode/v3/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/v3/linode/helper"
 	"github.com/linode/terraform-provider-linode/v3/linode/instanceconfig/tmpl"
-	"log"
-	"strconv"
-	"testing"
 )
 
 var testRegion string

--- a/linode/lkenodepool/framework_resource_schema.go
+++ b/linode/lkenodepool/framework_resource_schema.go
@@ -1,8 +1,6 @@
 package lkenodepool
 
 import (
-	"context"
-
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -90,19 +88,6 @@ var resourceSchema = schema.Schema{
 			Computed: true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
-				stringplanmodifier.RequiresReplaceIf(
-					func(
-						ctx context.Context,
-						sr planmodifier.StringRequest,
-						rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse,
-					) {
-						var strategy string
-						sr.Plan.GetAttribute(ctx, path.Root("update_strategy"), &strategy)
-						rrifr.RequiresReplace = strategy == "rolling_update"
-					},
-					"Triggers replacement when `k8s_version` is changed and `update_strategy` is rolling_update",
-					"Changing `k8s_version` with a Rolling Update strategy forces a new resource.",
-				),
 			},
 		},
 		"update_strategy": schema.StringAttribute{


### PR DESCRIPTION
## 📝 Description

Remove forcing RequriesReplace() when the update strategy is rolling_udpate. Send the k8s version update to API for recycling the node pool safely. 

Resolved #1937 

## ✔️ How to Test

Integration test:
```
make test-int TEST_SUITE=lkenodepool 
```

Manual Test:
1. In a sandbox environment, put the following tf config to create a cluster and a externally managed node pool resource:
```
provider "linode" {
  api_version="v4beta"
}

resource "linode_lke_cluster" "nodepool_test_cluster" {
  label       = "lke-e-nodepool-test-cluster"
  region      = "us-lax"
  k8s_version = "v1.31.8+lke5"
  tags        = ["nodepool_test_cluster"]
  external_pool_tags  = ["external"]
  tier = "enterprise"

  pool {
      type  = "g6-standard-1"
      count = 1
  }
}

resource "linode_lke_node_pool" "foobar" {
    cluster_id = linode_lke_cluster.nodepool_test_cluster.id
    node_count = 2
    type  = "g6-standard-2"
    tags  = ["external", "my-pool"]
    labels = {"qq": "change"}

    update_strategy = "rolling_update"
    k8s_version = linode_lke_cluster.nodepool_test_cluster.k8s_version
}
```

2. After the node pool created, try to update the k8s_version and run `make plan`. Notice that the only valid k8s_version currently is "v1.31.8+lke5", so we can't actually apply the upgrade. Make sure the plan indicates a replace in-place.
