### PR TITLE
Update interval for AWS SDKs to be monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     ignore:
       - dependency-name: "github.com/linode/terraform-provider-linode/linode"
+      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -29,15 +34,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     ignore:
       - dependency-name: "github.com/linode/terraform-provider-linode/linode"
+      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
   - package-ecosystem: "gomod"
     target-branch: extended-support/v2
     directory: "/tools"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     target-branch: extended-support/v2
     directory: "/"


### PR DESCRIPTION
## 📝 Description

1. Update interval for AWS SDKs to be monthly
2. Remove unnecessary PRs limit.