### PR TITLE
Require `Maintenance Policy` capability in related tests

### DIFF
--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -14,6 +14,15 @@ import (
 func TestAccDataSourceInstances_basic(t *testing.T) {
 	t.Parallel()
 
+	// Resolve a region with support for Maintenance Policy
+	region, err := acceptance.GetRandomRegionWithCaps(
+		[]string{"Linodes", "Maintenance Policy"},
+		"core",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	resName := "data.linode_instances.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	rootPass := acctest.RandString(64)
@@ -26,7 +35,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataBasic(t, instanceName, testRegion, rootPass, maintenancePolicy),
+				Config: tmpl.DataBasic(t, instanceName, region, rootPass, maintenancePolicy),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "instances.#", "1"),
 					resource.TestCheckResourceAttrSet(resName, "instances.0.id"),

--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -42,7 +42,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "instances.0.type", "g6-nanode-1"),
 					resource.TestCheckResourceAttr(resName, "instances.0.tags.#", "2"),
 					resource.TestCheckResourceAttr(resName, "instances.0.image", acceptance.TestImageLatest),
-					resource.TestCheckResourceAttr(resName, "instances.0.region", testRegion),
+					resource.TestCheckResourceAttr(resName, "instances.0.region", region),
 					resource.TestCheckResourceAttr(resName, "instances.0.maintenance_policy", maintenancePolicy),
 					resource.TestCheckResourceAttr(resName, "instances.0.group", "tf_test"),
 					resource.TestCheckResourceAttr(resName, "instances.0.swap_size", "256"),

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"regexp"
 	"strconv"
@@ -897,6 +898,10 @@ func TestAccResourceInstance_updateSimple(t *testing.T) {
 func TestAccResourceInstance_updateMaintenancePolicy(t *testing.T) {
 	t.Parallel()
 	var instance linodego.Instance
+
+	region, err := acceptance.GetRandomRegionWithCaps([]string{"Maintenance Policy"}, "core")
+	require.NoError(t, err)
+
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_instance.foobar"
 	rootPass := acctest.RandString(64)
@@ -910,7 +915,7 @@ func TestAccResourceInstance_updateMaintenancePolicy(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.MaintenancePolicy(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass, maintenancePolicyMigrate),
+				Config: tmpl.MaintenancePolicy(t, instanceName, acceptance.PublicKeyMaterial, region, rootPass, maintenancePolicyMigrate),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -918,7 +923,7 @@ func TestAccResourceInstance_updateMaintenancePolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.MaintenancePolicy(t, instanceName, acceptance.PublicKeyMaterial, testRegion, rootPass, maintenancePolicyPowerOnOff),
+				Config: tmpl.MaintenancePolicy(t, instanceName, acceptance.PublicKeyMaterial, region, rootPass, maintenancePolicyPowerOnOff),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -6,13 +6,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"regexp"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -899,7 +899,7 @@ func TestAccResourceInstance_updateMaintenancePolicy(t *testing.T) {
 	t.Parallel()
 	var instance linodego.Instance
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{"Maintenance Policy"}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]string{"Linodes", "Maintenance Policy"}, "core")
 	require.NoError(t, err)
 
 	instanceName := acctest.RandomWithPrefix("tf_test")

--- a/linode/maintenancepolicies/framework_datasource_test.go
+++ b/linode/maintenancepolicies/framework_datasource_test.go
@@ -3,6 +3,7 @@
 package maintenancepolicies_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -48,7 +49,13 @@ func TestAccDataSourceMaintenancePolicies_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resourceName,
 						tfjsonpath.New("maintenance_policies").AtSliceIndex(0).AtMapKey("notification_period_sec"),
-						knownvalue.Int64Exact(300),
+						knownvalue.Int64Func(func(value int64) error {
+							if value <= 0 {
+								return fmt.Errorf("expected non-zero notification_period_sec")
+							}
+
+							return nil
+						}),
 					),
 					statecheck.ExpectKnownValue(
 						resourceName,


### PR DESCRIPTION
## 📝 Description

This pull request updates the `TestAccResourceInstance_updateMaintenancePolicy` and `TestAccDataSourceInstances_basic` integration tests to use a region with the `Maintenance Policy` capability, which should resolve the test failures caused by the limited rollout.

CI Integration Test Run (failures unrelated): https://github.com/linode/terraform-provider-linode/actions/runs/17135246549

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make test-int PKG_NAME=instance
```