### PR TITLE
Change all dependency update intervals to be monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,47 +9,33 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "github.com/linode/terraform-provider-linode/linode"
-      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   # extended-support/v2
   - package-ecosystem: "gomod"
     target-branch: extended-support/v2
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "github.com/linode/terraform-provider-linode/linode"
-      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
   - package-ecosystem: "gomod"
     target-branch: extended-support/v2
     directory: "/tools"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     target-branch: extended-support/v2
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
## 📝 Description

[The previous PR](https://github.com/linode/terraform-provider-linode/pull/2043) trying to change the update interval of AWS dependency update intervals [has failed](https://github.com/linode/terraform-provider-linode/runs/49020643306) because the dependabot doesn't support configuring the interval for a specific dependencies.

Considering change all intervals to be monthly for solving it. The security updates is still immediately applied and won't be affected by this config change, because it's operating separately.