### PR TITLE
Only use regions compatible with custom images for image tests

### DIFF
--- a/linode/helper/iterator.go
+++ b/linode/helper/iterator.go
@@ -62,5 +62,5 @@ func Filter[T any](seq iter.Seq[T], isValid func(T) bool) iter.Seq[T] {
 
 // FilterSlice returns a new slice yielding only values that meet the condition defined by isValid.
 func FilterSlice[T any](value []T, isValid func(T) bool) []T {
-	return slices.Collect(slices.Values(value))
+	return slices.Collect(Filter(slices.Values(value), isValid))
 }

--- a/linode/helper/iterator.go
+++ b/linode/helper/iterator.go
@@ -44,3 +44,23 @@ func MapMap[IK, OK comparable, IV, OV any](values map[IK]IV, transform func(IK, 
 		),
 	)
 }
+
+// Filter returns a new iterator yielding only values that meet the condition defined by isValid.
+func Filter[T any](seq iter.Seq[T], isValid func(T) bool) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for value := range seq {
+			if !isValid(value) {
+				continue
+			}
+
+			if !yield(value) {
+				return
+			}
+		}
+	}
+}
+
+// FilterSlice returns a new slice yielding only values that meet the condition defined by isValid.
+func FilterSlice[T any](value []T, isValid func(T) bool) []T {
+	return slices.Collect(slices.Values(value))
+}

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -69,8 +69,6 @@ func init() {
 		return !ok || !isDisallowed
 	})
 
-	fmt.Println(testRegions)
-
 	testRegion = testRegions[1]
 }
 

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -66,8 +66,11 @@ func init() {
 
 	testRegions = helper.FilterSlice(regions, func(region string) bool {
 		isDisallowed, ok := disallowedImageRegions[region]
+		fmt.Println(region, isDisallowed, ok)
 		return !ok || !isDisallowed
 	})
+
+	fmt.Println(testRegions)
 
 	testRegion = testRegions[1]
 }

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -66,7 +66,6 @@ func init() {
 
 	testRegions = helper.FilterSlice(regions, func(region string) bool {
 		isDisallowed, ok := disallowedImageRegions[region]
-		fmt.Println(region, isDisallowed, ok)
 		return !ok || !isDisallowed
 	})
 

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -37,6 +37,18 @@ var testImageBytesNew = []byte{
 }
 
 var (
+	// This is necessary because the API does not currently expose
+	// a capability for regions that allow custom image uploads.
+	//
+	// In the future, we should remove this if the API exposes a custom images capability or
+	//	if all Object Storage regions support custom images.
+	disallowedImageRegions = map[string]bool{
+		"gb-lon":   true,
+		"au-mel":   true,
+		"sg-sin-2": true,
+		"jp-tyo-3": true,
+	}
+
 	testRegion  string
 	testRegions []string
 )
@@ -52,8 +64,12 @@ func init() {
 		log.Fatal(err)
 	}
 
-	testRegion = regions[1]
-	testRegions = regions
+	testRegions = helper.FilterSlice(regions, func(region string) bool {
+		isDisallowed, ok := disallowedImageRegions[region]
+		return !ok || !isDisallowed
+	})
+
+	testRegion = testRegions[1]
 }
 
 func sweep(prefix string) error {


### PR DESCRIPTION
## 📝 Description

This pull request adds logic to only resolve regions that support custom images in the image integration test suite.

This is also done in the Cloud Manager repo: https://github.com/linode/manager/blob/a67c9acec537d453e9393c37ae69d48ab3a0a11d/packages/manager/src/constants.ts#L283-L288

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make test-int PKG_NAME=image
make test-int PKG_NAME=images
```