### PR TITLE
Stabilize image uploading integrate test by restricting the regions

### DIFF
--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -47,6 +47,7 @@ var (
 		"au-mel":   true,
 		"sg-sin-2": true,
 		"jp-tyo-3": true,
+		"no-osl-1": true,
 	}
 
 	testRegion  string
@@ -59,7 +60,7 @@ func init() {
 		F:    sweep,
 	})
 
-	regions, err := acceptance.GetRegionsWithCaps([]string{"Object Storage"}, "core")
+	regions, err := acceptance.GetRegionsWithCaps([]string{"Object Storage", "Linodes"}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## 📝 Description

Add more restriction to the image regions selection for more stable test in image uploading.

## ✔️ How to Test

```
make test-int PKG_NAME="image" TEST_CASE="TestAccImage_uploadFile"
```

