### PR TITLE
VPC Dual Stack: Add support in Legacy (Config) Interfaces

### DIFF
--- a/docs/data-sources/instances.md
+++ b/docs/data-sources/instances.md
@@ -207,6 +207,8 @@ Each interface exports the following attributes:
 
 * [`ipv4`](#ipv4) -The IPv4 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose.
 
+* [`ipv6`](#ipv6) - (Optional) The IPv6 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose.  NOTE: IPv6 VPCs may not yet be available to all users.
+
 * `vpc_id` - The ID of VPC which this interface is attached to.
 
 * `ip_ranges` - IPv4 CIDR VPC Subnet ranges that are routed to this Interface. IPv6 ranges are also available to select participants in the Beta program.
@@ -218,6 +220,32 @@ The following arguments are available in an `ipv4` configuration block of an `in
 * `vpc` - The IP from the VPC subnet to use for this interface. A random address will be assigned if this is not specified in a VPC interface.
 
 * `nat_1_1` - The public IP that will be used for the one-to-one NAT purpose. If this is `any`, the public IPv4 address assigned to this Linode is used on this interface and will be 1:1 NATted with the VPC IPv4 address.
+
+#### ipv6
+
+**NOTICE:** NOTE: IPv6 VPCs may not yet be available to all users.
+
+The following arguments are available in an `ipv6` configuration block of an `interface` block:
+
+* `is_public` - (Optional) If true, connections from the interface to IPv6 addresses outside the VPC, and connections from IPv6 addresses outside the VPC to the interface will be permitted. (Default: `false`)
+
+* [`slaac`](#ipv6slaac) - (Optional) An array of SLAAC prefixes to use for this interface.
+
+* [`range`](#ipv6range) - (Optional) An array of IPv6 ranges to use for this interface.
+
+#### ipv6.slaac
+
+The following arguments are available in a `slaac` configuration block of an [`ipv6`](#ipv6) block:
+
+* `range` - A prefix to add to this interface, or `auto` for a new IPv6 prefix to be automatically allocated.
+
+* `address` - The SLAAC address chosen for this interface.
+
+#### ipv6.range
+
+The following arguments are available in a `range` configuration block of an [`ipv6`](#ipv6) block:
+
+* `range` - A prefix to add to this interface, or `auto` for a new IPv6 prefix to be automatically allocated.
 
 ### Backups
 

--- a/docs/data-sources/instances.md
+++ b/docs/data-sources/instances.md
@@ -187,7 +187,7 @@ Configuration profiles define the VM settings and boot behavior of the Linode In
 
     * `disk_id` - The Disk ID of the associated `disk_label`, if used
 
-  * [`interface`](#interface) - (Optional) A list of network interfaces to be assigned to the Linode.
+  * [`interface`](#interface) - A list of network interfaces to be assigned to the Linode.
 
 ### Interface
 
@@ -207,7 +207,7 @@ Each interface exports the following attributes:
 
 * [`ipv4`](#ipv4) -The IPv4 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose.
 
-* [`ipv6`](#ipv6) - (Optional) The IPv6 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose.  NOTE: IPv6 VPCs may not yet be available to all users.
+* [`ipv6`](#ipv6) - The IPv6 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose.  NOTE: IPv6 VPCs may not yet be available to all users.
 
 * `vpc_id` - The ID of VPC which this interface is attached to.
 
@@ -227,11 +227,11 @@ The following arguments are available in an `ipv4` configuration block of an `in
 
 The following arguments are available in an `ipv6` configuration block of an `interface` block:
 
-* `is_public` - (Optional) If true, connections from the interface to IPv6 addresses outside the VPC, and connections from IPv6 addresses outside the VPC to the interface will be permitted. (Default: `false`)
+* `is_public` - If true, connections from the interface to IPv6 addresses outside the VPC, and connections from IPv6 addresses outside the VPC to the interface will be permitted. (Default: `false`)
 
-* [`slaac`](#ipv6slaac) - (Optional) An array of SLAAC prefixes to use for this interface.
+* [`slaac`](#ipv6slaac) - An array of SLAAC prefixes to use for this interface.
 
-* [`range`](#ipv6range) - (Optional) An array of IPv6 ranges to use for this interface.
+* [`range`](#ipv6range) - An array of IPv6 ranges to use for this interface.
 
 #### ipv6.slaac
 

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -329,6 +329,8 @@ Each interface exports the following attributes:
 
 * [`ipv4`](#ipv4) - (Optional) The IPv4 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose.
 
+* [`ipv6`](#ipv6) - (Optional) The IPv6 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose. NOTE: IPv6 VPCs may not yet be available to all users.
+
 The following computed attribute is available in a VPC interface:
 
 * `vpc_id` - The ID of VPC which this interface is attached to.
@@ -342,6 +344,36 @@ The following arguments are available in an `ipv4` configuration block of an `in
 * `vpc` - (Optional) The IP from the VPC subnet to use for this interface. A random address will be assigned if this is not specified in a VPC interface.
 
 * `nat_1_1` - (Optional) The public IP that will be used for the one-to-one NAT purpose. If this is `any`, the public IPv4 address assigned to this Linode is used on this interface and will be 1:1 NATted with the VPC IPv4 address.
+
+#### ipv6
+
+**NOTICE:** NOTE: IPv6 VPCs may not yet be available to all users.
+
+The following arguments are available in an `ipv6` configuration block of an `interface` block:
+
+* `is_public` - (Optional) If true, connections from the interface to IPv6 addresses outside the VPC, and connections from IPv6 addresses outside the VPC to the interface will be permitted. (Default: `false`)
+
+* [`slaac`](#ipv6slaac) - (Optional) An array of SLAAC prefixes to use for this interface.
+
+* [`range`](#ipv6range) - (Optional) An array of IPv6 ranges to use for this interface.
+
+#### ipv6.slaac
+
+The following arguments are available in a `slaac` configuration block of an [`ipv6`](#ipv6) block:
+
+* `range` - (Optional) A prefix to add to this interface, or `auto` for a new IPv6 prefix to be automatically allocated.
+
+* `allocated_range` - (Read-Only) The value of range computed by the API. This is necessary when needing to access the range implicitly allocated using `auto`.
+
+* `address` - (Read-Only) The SLAAC address chosen for this interface.
+
+#### ipv6.range
+
+The following arguments are available in a `range` configuration block of an [`ipv6`](#ipv6) block:
+
+* `range` - (Optional) A prefix to add to this interface, or `auto` for a new IPv6 prefix to be automatically allocated.
+
+* `allocated_range` - (Read-Only) The value of range computed by the API. This is necessary when needing to access the range implicitly allocated using `auto`.
 
 ### Timeouts
 

--- a/docs/resources/instance_config.md
+++ b/docs/resources/instance_config.md
@@ -244,6 +244,8 @@ The following arguments are available in an interface:
 
 * [`ipv4`](#ipv4) - (Optional) The IPv4 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose.
 
+* [`ipv6`](#ipv6) - (Optional) The IPv6 configuration of the VPC interface. This field is currently only allowed for interfaces with the `vpc` purpose. NOTE: IPv6 VPCs may not yet be available to all users.
+
 The following computed attribute is available in a VPC interface:
 
 * `vpc_id` - The ID of VPC which this interface is attached to.
@@ -257,6 +259,36 @@ The following arguments are available in an `ipv4` configuration block of an `in
 * `vpc` - (Optional) The IP from the VPC subnet to use for this interface. A random address will be assigned if this is not specified in a VPC interface.
 
 * `nat_1_1` - (Optional) The public IP that will be used for the one-to-one NAT purpose. If this is `any`, the public IPv4 address assigned to this Linode is used on this interface and will be 1:1 NATted with the VPC IPv4 address.
+
+#### ipv6
+
+**NOTICE:** NOTE: IPv6 VPCs may not yet be available to all users.
+
+The following arguments are available in an `ipv6` configuration block of an `interface` block:
+
+* `is_public` - (Optional) If true, connections from the interface to IPv6 addresses outside the VPC, and connections from IPv6 addresses outside the VPC to the interface will be permitted. (Default: `false`)
+
+* [`slaac`](#ipv6slaac) - (Optional) An array of SLAAC prefixes to use for this interface.
+
+* [`range`](#ipv6range) - (Optional) An array of IPv6 ranges to use for this interface.
+
+#### ipv6.slaac
+
+The following arguments are available in a `slaac` configuration block of an [`ipv6`](#ipv6) block:
+
+* `range` - (Optional) A prefix to add to this interface, or `auto` for a new IPv6 prefix to be automatically allocated.
+
+* `allocated_range` - (Read-Only) The value of range computed by the API. This is necessary when needing to access the range implicitly allocated using `auto`.
+
+* `address` - (Read-Only) The SLAAC address chosen for this interface.
+
+#### ipv6.range
+
+The following arguments are available in a `range` configuration block of an [`ipv6`](#ipv6) block:
+
+* `range` - (Optional) A prefix to add to this interface, or `auto` for a new IPv6 prefix to be automatically allocated.
+
+* `allocated_range` - (Read-Only) The value of range computed by the API. This is necessary when needing to access the range implicitly allocated using `auto`.
 
 ## Import
 

--- a/linode/helper/diffsuppressfuncs/autoallocrange.go
+++ b/linode/helper/diffsuppressfuncs/autoallocrange.go
@@ -1,0 +1,38 @@
+package diffsuppressfuncs
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/linode/terraform-provider-linode/v3/linode/helper"
+)
+
+// AutoAllocRange is a DiffSuppressFunc for fields that either accept a CIDR, "auto",
+// or a / followed by a prefix length.
+//
+// This prevents values of "auto" from causing repeating diffs on subsequent applies.
+func AutoAllocRange(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	if oldValue != "" && newValue == "auto" {
+		return true
+	}
+
+	addr, prefix, err := helper.ParseRangeOptionalAddress(oldValue)
+	if err != nil {
+		log.Printf("Failed to parse old range: %s", err)
+		return false
+	}
+
+	newAddr, newPrefix, err := helper.ParseRangeOptionalAddress(newValue)
+	if err != nil {
+		log.Printf("Failed to parse new range: %s", err)
+		return false
+	}
+
+	// One of the addresses only has a prefix specified,
+	// so we should only diff on the prefix.
+	if (addr == nil) || (newAddr == nil) {
+		return prefix == newPrefix
+	}
+
+	return prefix == newPrefix && addr.Compare(*newAddr) == 0
+}

--- a/linode/helper/networking.go
+++ b/linode/helper/networking.go
@@ -1,0 +1,38 @@
+package helper
+
+import (
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+func ParseRangeOptionalAddress(cidr string) (*netip.Addr, int, error) {
+	cidrSplit := strings.Split(cidr, "/")
+	if len(cidrSplit) != 2 {
+		return nil, 0, fmt.Errorf("malformed CIDR: %s", cidr)
+	}
+
+	ipStr, prefixStr := cidrSplit[0], cidrSplit[1]
+
+	if prefixStr == "" {
+		return nil, 0, fmt.Errorf("expected non-empty prefix: %s", cidr)
+	}
+
+	prefix, err := strconv.Atoi(prefixStr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("malformed prefix: %w", err)
+	}
+
+	// No address is specified
+	if ipStr == "" {
+		return nil, prefix, nil
+	}
+
+	ip, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to parse CIDR: %w", err)
+	}
+
+	return &ip, prefix, nil
+}

--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -177,3 +177,40 @@ func TestAccDataSourceInstances_multipleInstances(t *testing.T) {
 		},
 	})
 }
+
+func TestAccDataSourceInstance_interfaceVPCIPv6(t *testing.T) {
+	t.Parallel()
+
+	dataSourceName := "data.linode_instances.foobar"
+	instanceName := acctest.RandomWithPrefix("tf-test")
+	rootPass := acctest.RandString(64)
+
+	// TODO (VPC Dual Stack): Remove region hardcoding
+	targetRegion := "no-osl-1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		CheckDestroy:             acceptance.CheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataInterfacesVPCIPv6(
+					t,
+					instanceName,
+					targetRegion,
+					rootPass,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "instances.0.config.0.interface.0.ipv6.0.slaac.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.config.0.interface.0.ipv6.0.slaac.0.range"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.config.0.interface.0.ipv6.0.slaac.0.assigned_range"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.config.0.interface.0.ipv6.0.slaac.0.address"),
+
+					resource.TestCheckResourceAttr(dataSourceName, "instances.0.config.0.interface.0.ipv6.0.range.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.config.0.interface.0.ipv6.0.range.0.assigned_range"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.config.0.interface.0.ipv6.0.range.0.range"),
+				),
+			},
+		},
+	})
+}

--- a/linode/instance/schema_resource.go
+++ b/linode/instance/schema_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/linode/terraform-provider-linode/v3/linode/helper"
+	"github.com/linode/terraform-provider-linode/v3/linode/helper/diffsuppressfuncs"
 )
 
 const deviceDescription = "Device can be either a Disk or Volume identified by disk_id or " +
@@ -196,6 +197,79 @@ var InterfaceSchema = &schema.Resource{
 							}
 							return old == new
 						},
+					},
+				},
+			},
+		},
+		"ipv6": {
+			Type: schema.TypeList,
+			Description: "The IPv6 configuration of the VPC interface. " +
+				onlyAllowedForVPCMsg,
+			Computed: true,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"slaac": {
+						Type:        schema.TypeList,
+						Description: "An array of SLAAC prefixes to use for this interface.",
+						Computed:    true,
+						Optional:    true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"range": {
+									Type: schema.TypeString,
+									Description: "A SLAAC prefix to add to this interface, " +
+										"or `auto` for a new IPv6 prefix to be automatically allocated.",
+									Optional:         true,
+									DiffSuppressFunc: diffsuppressfuncs.AutoAllocRange,
+								},
+								"assigned_range": {
+									Type: schema.TypeString,
+									Description: "The value of `range` computed by the API. " +
+										"This is necessary when needing to access the range " +
+										"implicitly allocated using `auto`.",
+									Computed: true,
+								},
+								"address": {
+									Type:        schema.TypeString,
+									Description: "The SLAAC address chosen for this interface.",
+									Computed:    true,
+								},
+							},
+						},
+					},
+					"range": {
+						Type:        schema.TypeList,
+						Description: "An array of SLAAC prefixes to use for this interface.",
+						Computed:    true,
+						Optional:    true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"range": {
+									Type: schema.TypeString,
+									Description: "A prefix to add to this interface, " +
+										"or `auto` for a new IPv6 prefix to be automatically allocated.",
+									Optional:         true,
+									DiffSuppressFunc: diffsuppressfuncs.AutoAllocRange,
+								},
+								"assigned_range": {
+									Type: schema.TypeString,
+									Description: "The value of `range` computed by the API. " +
+										"This is necessary when needing to access the range " +
+										"implicitly allocated using `auto`.",
+									Computed: true,
+								},
+							},
+						},
+					},
+					"is_public": {
+						Type: schema.TypeBool,
+						Description: "If true, connections from the interface to IPv6 addresses outside the VPC, " +
+							"and connections from IPv6 addresses outside the VPC to the interface will be permitted.",
+						Optional: true,
+						Computed: true,
+						Default:  nil,
 					},
 				},
 			},
@@ -809,6 +883,7 @@ var resourceSchema = map[string]*schema.Schema{
 				"kernel": {
 					Type:     schema.TypeString,
 					Optional: true,
+					Computed: true,
 					Description: "A Kernel ID to boot a Linode with. Default is based on image choice. " +
 						"(examples: linode/latest-64bit, linode/grub2, linode/direct-disk)",
 				},

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -781,6 +781,58 @@ func WithReservedIP(t *testing.T, label, pubKey, region, rootPass string) string
 	return generatedConfig
 }
 
+func InterfacesVPCIPv60(t *testing.T, label, region, rootPass string) string {
+	generatedConfig := acceptance.ExecuteTemplate(t,
+		"instance_interfaces_vpc_ipv6_0", TemplateData{
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+
+	return generatedConfig
+}
+
+func InterfacesVPCIPv61(t *testing.T, label, region, rootPass string) string {
+	generatedConfig := acceptance.ExecuteTemplate(t,
+		"instance_interfaces_vpc_ipv6_1", TemplateData{
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+
+	return generatedConfig
+}
+
+func ConfigInterfacesVPCIPv6(t *testing.T, label, region, rootPass string) string {
+	generatedConfig := acceptance.ExecuteTemplate(t,
+		"instance_config_interfaces_vpc_ipv6", TemplateData{
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+
+	return generatedConfig
+}
+
+func DataInterfacesVPCIPv6(t *testing.T, label, region, rootPass string) string {
+	generatedConfig := acceptance.ExecuteTemplate(t,
+		"instance_data_interfaces_vpc_ipv6", TemplateData{
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+
+	return generatedConfig
+}
+
 func OnlyReservedIP(t *testing.T, region string) string {
 	return fmt.Sprintf(`
 resource "linode_networking_ip" "test" {

--- a/linode/instance/tmpl/templates/config_interfaces_vpc_ipv6.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces_vpc_ipv6.gotf
@@ -1,0 +1,73 @@
+{{ define "instance_config_interfaces_vpc_ipv6" }}
+
+{{ template "e2e_test_firewall" . }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+
+    boot_config_label = "primary"
+
+    config {
+        label = "primary"
+
+        devices {
+            sda {
+                disk_label = "primary"
+            }
+        }
+
+        interface {
+            purpose = "vpc"
+            subnet_id = linode_vpc_subnet.foobar.id
+
+            ipv6 {
+                is_public = true
+
+                slaac {
+                    range = "auto"
+                }
+
+                range {
+                    range = "auto"
+                }
+            }
+        }
+    }
+
+    disk {
+        label = "primary"
+        size = 8192
+        image = "linode/alpine3.21"
+    }
+
+
+    firewall_id = linode_firewall.e2e_test_firewall.id
+}
+
+resource "linode_vpc" "foobar" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+
+    ipv6 = [
+        {
+            range = "/52"
+        }
+    ]
+}
+
+resource "linode_vpc_subnet" "foobar" {
+    vpc_id = linode_vpc.foobar.id
+    label = "{{.Label}}"
+    ipv4 = "10.0.0.0/24"
+    ipv6 = [
+        {
+            range = "auto"
+        }
+    ]
+}
+
+
+{{ end }}

--- a/linode/instance/tmpl/templates/data_interfaces_vpc_ipv6.gotf
+++ b/linode/instance/tmpl/templates/data_interfaces_vpc_ipv6.gotf
@@ -1,0 +1,62 @@
+{{ define "instance_data_interfaces_vpc_ipv6" }}
+
+{{ template "e2e_test_firewall" . }}
+
+data "linode_instances" "foobar" {
+    depends_on = [linode_instance.foobar]
+
+    filter {
+        name = "label"
+        values = [linode_instance.foobar.label]
+    }
+}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+    image = "{{.Image}}"
+
+    interface {
+        purpose = "vpc"
+        subnet_id = linode_vpc_subnet.foobar.id
+
+        ipv6 {
+            is_public = true
+
+            slaac {
+                range = "auto"
+            }
+
+            range {
+                range = "auto"
+            }
+        }
+    }
+
+    firewall_id = linode_firewall.e2e_test_firewall.id
+}
+
+resource "linode_vpc" "foobar" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+
+    ipv6 = [
+        {
+            range = "/52"
+        }
+    ]
+}
+
+resource "linode_vpc_subnet" "foobar" {
+    vpc_id = linode_vpc.foobar.id
+    label = "{{.Label}}"
+    ipv4 = "10.0.0.0/24"
+    ipv6 = [
+        {
+            range = "auto"
+        }
+    ]
+}
+
+{{ end }}

--- a/linode/instance/tmpl/templates/interfaces_vpc_ipv6_0.gotf
+++ b/linode/instance/tmpl/templates/interfaces_vpc_ipv6_0.gotf
@@ -1,0 +1,53 @@
+{{ define "instance_interfaces_vpc_ipv6_0" }}
+
+{{ template "e2e_test_firewall" . }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+    image = "{{.Image}}"
+
+    interface {
+        purpose = "vpc"
+        subnet_id = linode_vpc_subnet.foobar.id
+
+        ipv6 {
+            slaac {
+                range = "auto"
+            }
+
+            range {
+                range = "auto"
+            }
+        }
+    }
+
+    firewall_id = linode_firewall.e2e_test_firewall.id
+}
+
+resource "linode_vpc" "foobar" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+
+    ipv6 = [
+        {
+            range = "/52"
+        }
+    ]
+}
+
+resource "linode_vpc_subnet" "foobar" {
+    vpc_id = linode_vpc.foobar.id
+    label = "{{.Label}}"
+    ipv4 = "10.0.0.0/24"
+    ipv6 = [
+        {
+            range = "auto"
+        }
+    ]
+}
+
+
+{{ end }}

--- a/linode/instance/tmpl/templates/interfaces_vpc_ipv6_1.gotf
+++ b/linode/instance/tmpl/templates/interfaces_vpc_ipv6_1.gotf
@@ -1,0 +1,59 @@
+{{ define "instance_interfaces_vpc_ipv6_1" }}
+
+{{ template "e2e_test_firewall" . }}
+
+resource "linode_instance" "foobar" {
+    label = "{{.Label}}"
+    group = "tf_test"
+    type = "g6-nanode-1"
+    region = "{{ .Region }}"
+    image = "{{.Image}}"
+
+    interface {
+        purpose = "vpc"
+        subnet_id = linode_vpc_subnet.foobar.id
+
+        ipv6 {
+            is_public = true
+
+            slaac {
+                range = "auto"
+            }
+
+            range {
+                range = "auto"
+            }
+
+            range {
+                range = "auto"
+            }
+        }
+    }
+
+    firewall_id = linode_firewall.e2e_test_firewall.id
+}
+
+resource "linode_vpc" "foobar" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+
+    ipv6 = [
+        {
+            range = "/52"
+        }
+    ]
+}
+
+resource "linode_vpc_subnet" "foobar" {
+    vpc_id = linode_vpc.foobar.id
+    label = "{{.Label}}"
+    ipv4 = "10.0.0.0/24"
+    ipv6 = [
+        {
+            range = "auto"
+        }
+    ]
+}
+
+
+{{ end }}

--- a/linode/instanceconfig/tmpl/template.go
+++ b/linode/instanceconfig/tmpl/template.go
@@ -152,3 +152,25 @@ func VPCInterfaceOnly(t testing.TB, label, region string, rootPass string) strin
 		},
 	)
 }
+
+func VPCInterfaceIPv60(t testing.TB, label, region string, rootPass string) string {
+	return acceptance.ExecuteTemplate(
+		t,
+		"instance_config_vpc_interface_ipv6_0", TemplateData{
+			Label:    label,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+}
+
+func VPCInterfaceIPv61(t testing.TB, label, region string, rootPass string) string {
+	return acceptance.ExecuteTemplate(
+		t,
+		"instance_config_vpc_interface_ipv6_1", TemplateData{
+			Label:    label,
+			Region:   region,
+			RootPass: rootPass,
+		},
+	)
+}

--- a/linode/instanceconfig/tmpl/vpc_interface_ipv6_0.gotf
+++ b/linode/instanceconfig/tmpl/vpc_interface_ipv6_0.gotf
@@ -1,0 +1,68 @@
+{{ define "instance_config_vpc_interface_ipv6_0" }}
+
+{{ template "instance_config_empty_instance" . }}
+
+{{ template "instance_config_disk" . }}
+
+resource "linode_instance_config" "foobar" {
+  linode_id = linode_instance.foobar.id
+  label = "my-config"
+
+  booted = true
+
+  device {
+    device_name = "sda"
+    disk_id = linode_instance_disk.foobar.id
+  }
+
+  interface {
+    purpose = "vpc"
+    subnet_id = linode_vpc_subnet.foobar.id
+
+    ipv4 {
+      vpc = "10.0.4.250"
+      nat_1_1 = "any"
+    }
+
+    ipv6 {
+      slaac {
+        range = "auto"
+      }
+
+      range {
+        range = "auto"
+      }
+    }
+
+    ip_ranges = ["10.0.4.101/32"]
+  }
+
+  kernel = "linode/grub2"
+  root_device = "/dev/sda"
+}
+
+resource "linode_vpc" "foobar" {
+  label = "{{.Label}}"
+  region = "{{.Region}}"
+  description = "test description"
+
+  ipv6 = [
+    {
+      range = "/52"
+    }
+  ]
+}
+
+resource "linode_vpc_subnet" "foobar" {
+  vpc_id = linode_vpc.foobar.id
+  label = "{{.Label}}"
+  ipv4 = "10.0.4.0/24"
+
+  ipv6 = [
+    {
+      range = "auto"
+    }
+  ]
+}
+
+{{ end }}

--- a/linode/instanceconfig/tmpl/vpc_interface_ipv6_1.gotf
+++ b/linode/instanceconfig/tmpl/vpc_interface_ipv6_1.gotf
@@ -1,0 +1,74 @@
+{{ define "instance_config_vpc_interface_ipv6_1" }}
+
+{{ template "instance_config_empty_instance" . }}
+
+{{ template "instance_config_disk" . }}
+
+resource "linode_instance_config" "foobar" {
+  linode_id = linode_instance.foobar.id
+  label = "my-config"
+
+  booted = true
+
+  device {
+    device_name = "sda"
+    disk_id = linode_instance_disk.foobar.id
+  }
+
+  interface {
+    purpose = "vpc"
+    subnet_id = linode_vpc_subnet.foobar.id
+
+    ipv4 {
+      vpc = "10.0.4.250"
+      nat_1_1 = "any"
+    }
+
+    ipv6 {
+      is_public = true
+
+      slaac {
+        range = "auto"
+      }
+
+      range {
+        range = "auto"
+      }
+
+      range {
+        range = "auto"
+      }
+    }
+
+    ip_ranges = ["10.0.4.101/32"]
+  }
+
+  kernel = "linode/grub2"
+  root_device = "/dev/sda"
+}
+
+resource "linode_vpc" "foobar" {
+  label = "{{.Label}}"
+  region = "{{.Region}}"
+  description = "test description"
+
+  ipv6 = [
+    {
+      range = "/52"
+    }
+  ]
+}
+
+resource "linode_vpc_subnet" "foobar" {
+  vpc_id = linode_vpc.foobar.id
+  label = "{{.Label}}"
+  ipv4 = "10.0.4.0/24"
+
+  ipv6 = [
+    {
+      range = "auto"
+    }
+  ]
+}
+
+{{ end }}


### PR DESCRIPTION
## 📝 Description

This pull request adds support for VPC Dual Stack in the following resources and data sources:

* `linode_instance`
* `linode_instance_config`
* `data.linode_instances`

Depends on #1901

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and your local environment is pointing at a Linode account with access to VPC Dual Stack. See TPT-3535 for more information.

### Integration Testing

```
make test-int PKG_NAME=instance
make test-int PKG_NAME=instanceconfig
```

### Manual Testing

1. In a terraform-provider-linode sandbox environment (e.g. dx-devenv), apply the following configuration:

```terraform

resource "linode_instance" "separate" {
  label  = "manual-test-separate"
  type   = "g6-nanode-1"
  region = "no-osl-1"
}

resource "linode_instance_disk" "separate-primary" {
  linode_id = linode_instance.separate.id
  label = "primary"
  size = 8192
  image = "linode/alpine3.21"
}

resource "linode_instance_config" "separate" {
  linode_id = linode_instance.separate.id
  label = "my-config"
  booted = true

  kernel = "linode/grub2"
  root_device = "/dev/sda"

  device {
    device_name = "sda"
    disk_id = linode_instance_disk.separate-primary.id
  }


  interface {
    purpose = "vpc"
    subnet_id = linode_vpc_subnet.test.id

    ipv6 {
      slaac {
        range = "auto"
      }

      range {
        range = "auto"
      }
    }
  }
}

resource "linode_instance" "explicit-configs" {
  label = "manual-test-explicit"
  type = "g6-nanode-1"
  region = "no-osl-1"
  boot_config_label = "primary"

  config {
    label = "primary"
    kernel = "linode/latest-64bit"

    devices {
      sda {
        disk_label = "primary"
      }
    }

    interface {
      purpose = "vpc"
      subnet_id = linode_vpc_subnet.test.id

      ipv6 {
        is_public = true

        slaac {
          range = "auto"
        }

        range {
          range = "auto"
        }
      }
    }
  }

  disk {
    label = "primary"
    size = 8192
    image = "linode/alpine3.21"
  }
}

resource "linode_instance" "implicit-configs" {
  label = "manual-test-implicit"
  type = "g6-nanode-1"
  region = "no-osl-1"
  image = "linode/alpine3.21"

  interface {
    purpose = "vpc"
    subnet_id = linode_vpc_subnet.test.id

    ipv6 {
      is_public = true

      slaac {
        range = "auto"
      }

      range {
        range = "auto"
      }
    }
  }
}

resource "linode_vpc" "test" {
  label = "manual-test"
  region = "no-osl-1"

  ipv6 = [
    {
      range = "/52"
    }
  ]
}

resource "linode_vpc_subnet" "test" {
  vpc_id = linode_vpc.test.id
  label = "manual-test"
  ipv4 = "10.0.0.0/24"
  ipv6 = [
    {
      range = "auto"
    }
  ]
}
```

2. Ensure the configuration applies successfully.
3. Make arbitrary updates to the interfaces in the resources defined in the configuration and re-apply.
4. Ensure the configuration applies successfully.
5. Plan the configuration and ensure no changes are proposed.