### PR TITLE
Add RFC3339 custom type for `created` attribute of OBJ bucket data source

### DIFF
--- a/linode/objbucket/framework_datasource.go
+++ b/linode/objbucket/framework_datasource.go
@@ -2,13 +2,9 @@ package objbucket
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/linode/linodego"
 	"github.com/linode/terraform-provider-linode/v3/linode/helper"
 )
 
@@ -25,32 +21,6 @@ func NewDataSource() datasource.DataSource {
 
 type DataSource struct {
 	helper.BaseDataSource
-}
-
-func (data *DataSourceModel) parseObjectStorageBucket(bucket *linodego.ObjectStorageBucket) {
-	data.Cluster = types.StringValue(bucket.Cluster)
-	data.Region = types.StringValue(bucket.Region)
-	data.Created = types.StringValue(bucket.Created.Format(time.RFC3339))
-	data.Hostname = types.StringValue(bucket.Hostname)
-	data.ID = types.StringValue(fmt.Sprintf("%s:%s", bucket.Cluster, bucket.Label))
-	data.Label = types.StringValue(bucket.Label)
-	data.Objects = types.Int64Value(int64(bucket.Objects))
-	data.Size = types.Int64Value(int64(bucket.Size))
-	data.EndpointType = types.StringValue(string(bucket.EndpointType))
-	data.S3Endpoint = types.StringValue(bucket.S3Endpoint)
-}
-
-type DataSourceModel struct {
-	Cluster      types.String `tfsdk:"cluster"`
-	Region       types.String `tfsdk:"region"`
-	Created      types.String `tfsdk:"created"`
-	Hostname     types.String `tfsdk:"hostname"`
-	ID           types.String `tfsdk:"id"`
-	Label        types.String `tfsdk:"label"`
-	Objects      types.Int64  `tfsdk:"objects"`
-	Size         types.Int64  `tfsdk:"size"`
-	EndpointType types.String `tfsdk:"endpoint_type"`
-	S3Endpoint   types.String `tfsdk:"s3_endpoint"`
 }
 
 func (d *DataSource) Read(

--- a/linode/objbucket/framework_datasource_schema.go
+++ b/linode/objbucket/framework_datasource_schema.go
@@ -1,6 +1,7 @@
 package objbucket
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -42,6 +43,7 @@ var frameworkDatasourceSchema = schema.Schema{
 		},
 		"created": schema.StringAttribute{
 			Description: "When this bucket was created.",
+			CustomType:  timetypes.RFC3339Type{},
 			Computed:    true,
 		},
 		"hostname": schema.StringAttribute{

--- a/linode/objbucket/framework_models.go
+++ b/linode/objbucket/framework_models.go
@@ -1,0 +1,39 @@
+package objbucket
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego"
+)
+
+type BaseModel struct {
+	ID           types.String      `tfsdk:"id"`
+	Label        types.String      `tfsdk:"label"`
+	Cluster      types.String      `tfsdk:"cluster"`
+	Region       types.String      `tfsdk:"region"`
+	EndpointType types.String      `tfsdk:"endpoint_type"`
+	S3Endpoint   types.String      `tfsdk:"s3_endpoint"`
+	Hostname     types.String      `tfsdk:"hostname"`
+	Objects      types.Int64       `tfsdk:"objects"`
+	Size         types.Int64       `tfsdk:"size"`
+	Created      timetypes.RFC3339 `tfsdk:"created"`
+}
+
+type DataSourceModel struct {
+	BaseModel
+}
+
+func (data *DataSourceModel) parseObjectStorageBucket(bucket *linodego.ObjectStorageBucket) {
+	data.Cluster = types.StringValue(bucket.Cluster)
+	data.Region = types.StringValue(bucket.Region)
+	data.Created = timetypes.NewRFC3339TimePointerValue(bucket.Created)
+	data.Hostname = types.StringValue(bucket.Hostname)
+	data.ID = types.StringValue(fmt.Sprintf("%s:%s", bucket.Cluster, bucket.Label))
+	data.Label = types.StringValue(bucket.Label)
+	data.Objects = types.Int64Value(int64(bucket.Objects))
+	data.Size = types.Int64Value(int64(bucket.Size))
+	data.EndpointType = types.StringValue(string(bucket.EndpointType))
+	data.S3Endpoint = types.StringValue(bucket.S3Endpoint)
+}


### PR DESCRIPTION
## 📝 Description

1. Add the RFC3339 custom type to `created` attribute of OBJ bucket data source.
2. Create `framework_models.go` file and move model related stuff to there.

This is a preparation of OBJ bucket resource framework migration.

## ✔️ How to Test
```bash
make PKG_NAME="objbucket" test-int
```