### PR TITLE
Poll for database active after applying `updates` during creation; ignore members on database import test step; fix Instance Config assertions

### DIFF
--- a/linode/databasemysqlv2/framework_resource.go
+++ b/linode/databasemysqlv2/framework_resource.go
@@ -167,6 +167,19 @@ func (r *Resource) Create(
 			)
 			return
 		}
+
+		tflog.Debug(ctx, "Waiting for database to finish updating")
+
+		if err := client.WaitForDatabaseStatus(
+			ctx,
+			db.ID,
+			linodego.DatabaseEngineTypePostgres,
+			linodego.DatabaseStatusActive,
+			int(createTimeout.Seconds()),
+		); err != nil {
+			resp.Diagnostics.AddError("Failed to wait for PostgreSQL database active", err.Error())
+			return
+		}
 	}
 
 	if err := helper.ReconcileDatabaseSuspensionSync(

--- a/linode/databasemysqlv2/resource_test.go
+++ b/linode/databasemysqlv2/resource_test.go
@@ -135,7 +135,7 @@ func TestAccResource_basic(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -268,7 +268,7 @@ func TestAccResource_resize(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -401,7 +401,7 @@ func TestAccResource_complex(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -465,7 +465,7 @@ func TestAccResource_fork(t *testing.T) {
 				ResourceName:            resNameSource,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 			{
 				PreConfig: func() {
@@ -542,7 +542,7 @@ func TestAccResource_fork(t *testing.T) {
 				ResourceName:            resNameFork,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -635,6 +635,7 @@ func TestAccResource_suspension(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"updated",
 					"oldest_restore_time",
+					"members",
 
 					// These fields will be populated with null when importing a suspended database
 					"ca_cert", "root_password", "root_username",

--- a/linode/databasepostgresqlv2/framework_resource.go
+++ b/linode/databasepostgresqlv2/framework_resource.go
@@ -166,6 +166,19 @@ func (r *Resource) Create(
 			)
 			return
 		}
+
+		tflog.Debug(ctx, "Waiting for database to finish updating")
+
+		if err := client.WaitForDatabaseStatus(
+			ctx,
+			db.ID,
+			linodego.DatabaseEngineTypePostgres,
+			linodego.DatabaseStatusActive,
+			int(createTimeout.Seconds()),
+		); err != nil {
+			resp.Diagnostics.AddError("Failed to wait for PostgreSQL database active", err.Error())
+			return
+		}
 	}
 
 	if err := helper.ReconcileDatabaseSuspensionSync(

--- a/linode/databasepostgresqlv2/resource_test.go
+++ b/linode/databasepostgresqlv2/resource_test.go
@@ -132,7 +132,7 @@ func TestAccResource_basic(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -265,7 +265,7 @@ func TestAccResource_resize(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -398,7 +398,7 @@ func TestAccResource_complex(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -462,7 +462,7 @@ func TestAccResource_fork(t *testing.T) {
 				ResourceName:            resNameSource,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 			{
 				PreConfig: func() {
@@ -539,7 +539,7 @@ func TestAccResource_fork(t *testing.T) {
 				ResourceName:            resNameFork,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
 			},
 		},
 	})
@@ -632,6 +632,7 @@ func TestAccResource_suspension(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"updated",
 					"oldest_restore_time",
+					"members",
 
 					// These fields will be populated with null when importing a suspended database
 					"ca_cert", "root_password", "root_username",

--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -625,7 +625,6 @@ func TestAccResourceInstanceConfig_vpcInterfaceIPv6(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resName,
 						ipv6Path.
-							AtSliceIndex(0).
 							AtMapKey("range").
 							AtSliceIndex(0).
 							AtMapKey("assigned_range"),
@@ -669,6 +668,8 @@ func TestAccResourceInstanceConfig_vpcInterfaceIPv6(t *testing.T) {
 						knownvalue.NotNull(),
 					),
 
+					// The full path is required due to a bug that causes reusing a path
+					// to break bool checks under certain conditions.
 					statecheck.ExpectKnownValue(
 						resName,
 						ipv6Path.AtMapKey("is_public"),
@@ -765,6 +766,8 @@ func TestAccResourceInstanceConfig_vpcInterfaceIPv6(t *testing.T) {
 						knownvalue.NotNull(),
 					),
 
+					// The full path is required due to a bug that causes reusing a path
+					// to break bool checks under certain conditions.
 					statecheck.ExpectKnownValue(
 						resName,
 						ipv6Path.AtMapKey("is_public"),
@@ -786,10 +789,7 @@ func TestAccResourceInstanceConfig_vpcInterfaceIPv6(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						resName,
-						tfjsonpath.New("interface").
-							AtSliceIndex(0).
-							AtMapKey("ipv6").
-							AtSliceIndex(0).
+						ipv6Path.
 							AtMapKey("slaac").
 							AtSliceIndex(0).
 							AtMapKey("assigned_range"),
@@ -811,10 +811,7 @@ func TestAccResourceInstanceConfig_vpcInterfaceIPv6(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						resName,
-						tfjsonpath.New("interface").
-							AtSliceIndex(0).
-							AtMapKey("ipv6").
-							AtSliceIndex(0).
+						ipv6Path.
 							AtMapKey("range").
 							AtSliceIndex(0).
 							AtMapKey("assigned_range"),
@@ -831,7 +828,6 @@ func TestAccResourceInstanceConfig_vpcInterfaceIPv6(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						resName,
 						ipv6Path.
-							AtSliceIndex(0).
 							AtMapKey("range").
 							AtSliceIndex(1).
 							AtMapKey("assigned_range"),


### PR DESCRIPTION
## 📝 Description

This pull request fixes various issues blocking the upcoming release for this project.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and are using a Linode account with access to VPC Dual Stack.

### Integration Testing

```
make test-int PKG_NAME=databasepostgresqlv2
make test-int PKG_NAME=databasemysqlv2
make test-int PKG_NAME=instanceconfig
```