### PR TITLE
Use the correct DB type for MySQL database update polling during creation

### DIFF
--- a/linode/databasemysqlv2/framework_resource.go
+++ b/linode/databasemysqlv2/framework_resource.go
@@ -173,11 +173,11 @@ func (r *Resource) Create(
 		if err := client.WaitForDatabaseStatus(
 			ctx,
 			db.ID,
-			linodego.DatabaseEngineTypePostgres,
+			linodego.DatabaseEngineTypeMySQL,
 			linodego.DatabaseStatusActive,
 			int(createTimeout.Seconds()),
 		); err != nil {
-			resp.Diagnostics.AddError("Failed to wait for PostgreSQL database active", err.Error())
+			resp.Diagnostics.AddError("Failed to wait for MySQL database active", err.Error())
 			return
 		}
 	}


### PR DESCRIPTION
## 📝 Description

This pull request resolves an issue where the incorrect database type was given to `WaitForDatabaseStatus(...)` in part of the MySQL creation polling logic.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Tests

```
make test-int PKG_NAME=databasemysqlv2
```