### PR TITLE
NodeBalancer VPC: Temporary workaround for ipv4_range bug

### DIFF
--- a/linode/nb/framework_models.go
+++ b/linode/nb/framework_models.go
@@ -116,12 +116,14 @@ func (data *NodeBalancerModel) Flatten(
 		},
 	)
 
-	vpcs, diags := types.ListValueFrom(ctx, resourceVPCObjType, vpcConfigsModels)
+	vpcs, diags := types.ListValueFrom(ctx, frameworkResourceSchemaVPCs.Type(), vpcConfigsModels)
 	if diags.HasError() {
 		return diags
 	}
 
-	data.VPCs = helper.KeepOrUpdateValue(data.VPCs, vpcs, preserveKnown)
+	// TODO: Make use of new KeepOrUpdate helpers once Linode Interfaces has been merged.
+	//		 In the meantime, enabling preserveKnown will break the diff logic for computed fields.
+	data.VPCs = helper.KeepOrUpdateValue(data.VPCs, vpcs, false)
 
 	return nil
 }

--- a/linode/nb/framework_resource_schema.go
+++ b/linode/nb/framework_resource_schema.go
@@ -40,11 +40,38 @@ var firewallObjType = types.ObjectType{
 	},
 }
 
-var resourceVPCObjType = types.ObjectType{
-	AttrTypes: map[string]attr.Type{
-		"subnet_id":              types.Int64Type,
-		"ipv4_range":             types.StringType,
-		"ipv4_range_auto_assign": types.BoolType,
+var frameworkResourceSchemaVPCs = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"subnet_id": schema.Int64Attribute{
+			Description: "The ID of a subnet to assign to this NodeBalancer.",
+			Required:    true,
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.RequiresReplace(),
+				int64planmodifier.UseStateForUnknown(),
+			},
+		},
+		"ipv4_range": schema.StringAttribute{
+			Description: "A CIDR range for the VPC's IPv4 addresses. " +
+				"The NodeBalancer sources IP addresses from this range " +
+				"when routing traffic to the backend VPC nodes.",
+			Optional: true,
+			Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"ipv4_range_auto_assign": schema.BoolAttribute{
+			Description: "Enables the use of a larger ipv4_range subnet for multiple NodeBalancers " +
+				"within the same VPC by allocating smaller /30 subnets for " +
+				"each NodeBalancer's backends.",
+			Optional:  true,
+			WriteOnly: true,
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.RequiresReplace(),
+				boolplanmodifier.UseStateForUnknown(),
+			},
+		},
 	},
 }
 
@@ -158,40 +185,7 @@ var frameworkResourceSchema = schema.Schema{
 				listplanmodifier.RequiresReplace(),
 				listplanmodifier.UseStateForUnknown(),
 			},
-			NestedObject: schema.NestedAttributeObject{
-				Attributes: map[string]schema.Attribute{
-					"subnet_id": schema.Int64Attribute{
-						Description: "The ID of a subnet to assign to this NodeBalancer.",
-						Required:    true,
-						PlanModifiers: []planmodifier.Int64{
-							int64planmodifier.RequiresReplace(),
-							int64planmodifier.UseStateForUnknown(),
-						},
-					},
-					"ipv4_range": schema.StringAttribute{
-						Description: "A CIDR range for the VPC's IPv4 addresses. " +
-							"The NodeBalancer sources IP addresses from this range " +
-							"when routing traffic to the backend VPC nodes.",
-						Optional: true,
-						Computed: true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-							stringplanmodifier.UseStateForUnknown(),
-						},
-					},
-					"ipv4_range_auto_assign": schema.BoolAttribute{
-						Description: "Enables the use of a larger ipv4_range subnet for multiple NodeBalancers " +
-							"within the same VPC by allocating smaller /30 subnets for " +
-							"each NodeBalancer's backends.",
-						Optional:  true,
-						WriteOnly: true,
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplace(),
-							boolplanmodifier.UseStateForUnknown(),
-						},
-					},
-				},
-			},
+			NestedObject: frameworkResourceSchemaVPCs,
 		},
 	},
 }


### PR DESCRIPTION
## 📝 Description

This pull request implements a temporary workaround to resolve an error that occurs on apply when `vpcs.*.ipv4_range` isn't specified. 

The Linode Interfaces branch introduces some helpers that will be a better solution in the long term. In the interest of squeezing this change into Wednesday's release, we can address this in the future.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and are using a Linode account with access to NodeBalancer VPCs.

### Integration Testing

```
make test-int
```

### Manual Testing

1. In a terraform-provider-linode sandbox environment (e.g. dx-devenv), apply the following configuration:

```
resource "linode_nodebalancer" "test" {
  label = "tf-test"
  region = "no-osl-1"
  vpcs = [
    {
      subnet_id = linode_vpc_subnet.test.id
    }
  ]
}

resource "linode_vpc" "test" {
  label = "tf-test"
  region = "no-osl-1"
}

resource "linode_vpc_subnet" "test" {
  vpc_id = linode_vpc.test.id
  label = "tf-test"
  ipv4 = "10.0.0.0/24"
}
```

2. Ensure the apply is successful and the newly created NodeBalancer matches the configuration.