### PR TITLE
Fix instance resource boot status waiting

### DIFF
--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -452,38 +452,31 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	targetStatus := linodego.InstanceRunning
 
-	if createOpts.Booted == nil || !*createOpts.Booted {
-		if disksOk && configsOk && (bootedNull || booted) {
-			p, err := client.NewEventPoller(ctx, instance.ID, linodego.EntityLinode, linodego.ActionLinodeBoot)
-			if err != nil {
-				return diag.Errorf("failed to initialize event poller: %s", err)
-			}
-
-			tflog.Debug(ctx, "client.BootInstance(...)", map[string]any{
-				"config_id": bootConfig,
-			})
-
-			if err = client.BootInstance(ctx, instance.ID, bootConfig); err != nil {
-				return diag.Errorf("Error booting Linode instance %d: %s", instance.ID, err)
-			}
-
-			event, err := p.WaitForFinished(
-				ctx, getDeadlineSeconds(ctx, d),
-			)
-			if err != nil {
-				return diag.Errorf("Error booting Linode instance %d: %s", instance.ID, err)
-			}
-
-			tflog.Debug(ctx, "Instance finished booting", map[string]any{
-				"event_id": event.ID,
-			})
-		} else {
-			targetStatus = linodego.InstanceOffline
+	if disksOk && configsOk && (bootedNull || booted) {
+		p, err := client.NewEventPoller(ctx, instance.ID, linodego.EntityLinode, linodego.ActionLinodeBoot)
+		if err != nil {
+			return diag.Errorf("failed to initialize event poller: %s", err)
 		}
-	}
 
-	// If the instance has implicit disks and config with no specified image it will not boot.
-	if (!disksOk || !configsOk) && len(createOpts.Image) < 1 {
+		tflog.Debug(ctx, "client.BootInstance(...)", map[string]any{
+			"config_id": bootConfig,
+		})
+
+		if err = client.BootInstance(ctx, instance.ID, bootConfig); err != nil {
+			return diag.Errorf("Error booting Linode instance %d: %s", instance.ID, err)
+		}
+
+		event, err := p.WaitForFinished(
+			ctx, getDeadlineSeconds(ctx, d),
+		)
+		if err != nil {
+			return diag.Errorf("Error booting Linode instance %d: %s", instance.ID, err)
+		}
+
+		tflog.Debug(ctx, "Instance finished booting", map[string]any{
+			"event_id": event.ID,
+		})
+	} else if createOpts.Image == "" || (!bootedNull && !booted) {
 		targetStatus = linodego.InstanceOffline
 	}
 


### PR DESCRIPTION
## 📝 Description

Correct the behavior of the waiting of desired status.

Easier diff view from VS Code:
<img width="1602" height="534" alt="image" src="https://github.com/user-attachments/assets/2e7237f7-4d14-4330-b5f9-5270e2a07f04" />


## ✔️ How to Test
```bash
make test-int PKG_NAME=instance PARALLEL=8
```

An error like `Error: timed-out waiting for Linode instance 1234567 to reach status running: Error waiting for Instance 85130399 status running: context deadline exceeded` is relevant to the change, and others might be intermittent or irrelevant issues.