### PR TITLE
Add DiffSuppressFunc to the linode_lke_cluster resource tier field 

### DIFF
--- a/linode/acceptance/tmpl/provider_v4.gotf
+++ b/linode/acceptance/tmpl/provider_v4.gotf
@@ -1,7 +1,0 @@
-{{ define "provider_v4" }}
-
-provider "linode" {
-    api_version = "v4"
-}
-
-{{ end }}

--- a/linode/lke/framework_resource_test.go
+++ b/linode/lke/framework_resource_test.go
@@ -820,3 +820,38 @@ func TestAccResourceLKECluster_acl_disabled_addresses(t *testing.T) {
 		},
 	})
 }
+
+// TestAccResourceLKECluster_tierNoAccess ensures that a tier value of
+// `standard` will not trigger diffs in a cluster that does not expose
+// the `tier` field due to various circumstances.
+func TestAccResourceLKECluster_tierNoAccess(t *testing.T) {
+	t.Parallel()
+
+	clusterName := acctest.RandomWithPrefix("tf_test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		CheckDestroy:             acceptance.CheckLKEClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.TierNoAccess(t, clusterName, k8sVersionLatest, testRegion, string(linodego.LKEVersionStandard)),
+			},
+			{
+				Config: tmpl.TierNoAccess(t, clusterName, k8sVersionLatest, testRegion, string(linodego.LKEVersionStandard)),
+			},
+			{
+				Config: tmpl.TierNoAccess(
+					t,
+					clusterName,
+					k8sVersionLatest,
+					testRegion,
+					string(linodego.LKEVersionEnterprise),
+				),
+				ExpectError: regexp.MustCompile(".*"),
+			},
+			{
+				Config: tmpl.TierNoAccess(t, clusterName, k8sVersionLatest, testRegion, string(linodego.LKEVersionStandard)),
+			},
+		},
+	})
+}

--- a/linode/lke/tmpl/template.go
+++ b/linode/lke/tmpl/template.go
@@ -25,6 +25,7 @@ type TemplateData struct {
 	Taints           []TaintData
 	Labels           map[string]string
 	AuditLogsEnabled bool
+	Tier             string
 }
 
 func Basic(t testing.TB, name, version, region string) string {
@@ -155,5 +156,12 @@ func ACLDisabledAddressesDisallowed(t testing.TB, name, version, region string) 
 	return acceptance.ExecuteTemplate(t,
 		"lke_cluster_acl_disabled_addresses_disallowed",
 		TemplateData{Label: name, K8sVersion: version, Region: region},
+	)
+}
+
+func TierNoAccess(t testing.TB, name, version, region, tier string) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_cluster_tier_no_access",
+		TemplateData{Label: name, K8sVersion: version, Region: region, Tier: tier},
 	)
 }

--- a/linode/lke/tmpl/tier_no_access.gotf
+++ b/linode/lke/tmpl/tier_no_access.gotf
@@ -1,0 +1,23 @@
+{{ define "lke_cluster_tier_no_access" }}
+
+provider "linode" {
+    alias  = "v4"
+    api_version = "v4"
+}
+
+resource "linode_lke_cluster" "test" {
+    provider = linode.v4
+
+    label       = "{{ .Label }}"
+    region      = "{{ .Region }}"
+    k8s_version = "{{ .K8sVersion }}"
+    tier        = "{{ .Tier }}"
+
+    pool {
+        type  = "g6-standard-1"
+        count = 1
+    }
+}
+
+{{ end }}
+


### PR DESCRIPTION
## 📝 Description

This pull request adds a DiffSuppressFunc to the `tier` field of the `linode_lke_cluster` resource.

This prevents the recreation of clusters when managing a cluster without access to LKE tiers (e.g. using v4, cluster created before LKE-E, etc.).

**NOTE: I'm not particularly happy with this solution so please let me know if you can think of any good alternative approaches.**

Resolves #1945 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make test-int PKG_NAME=lke TEST_ARGS="-run TestAccResourceLKECluster_tierNoAccess"
```

### Manual Testing

1. In a terraform-provider-linode sandbox environment (e.g. dx-devenv), apply the following:

```
resource "linode_lke_cluster" "test" {
  label       = "tf-test-manual"
  region      = "us-mia"
  k8s_version = "1.33"
  tier = "standard"

  pool {
    type  = "g6-standard-1"
    count = 1
  }
}
```

2. Ensure the apply completes successfully.
3. Plan the configuration and ensure no changes are proposed.