### PR TITLE
Add waiting period for temporary key to become effective for E2/3 endpoints as a workaround

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ This section outlines commonly used provider configuration options.
 
   The Object Secret Key can also be specified using the `LINODE_OBJ_SECRET_KEY` shell environment variable.
 
-* `obj_use_temp_keys` - (Optional) If true, temporary object keys will be created implicitly at apply-time for the [linode_object_storage_bucket](resources/object_storage_bucket.md) and [linode_object_storage_object](resources/object_storage_object.md) resource to use.
+* `obj_use_temp_keys` - (Optional) If true, a temporary object storage keys pair will be created implicitly at apply-time for each of the [linode_object_storage_bucket](resources/object_storage_bucket.md) and [linode_object_storage_object](resources/object_storage_object.md) resources to use. Due to current technical limitations, a temporary keys pair for E2/E3 endpoints takes 30 seconds to become effective, so enabling temporary keys for E2/E3 endpoints is not recommended.
 
 * `obj_bucket_force_delete` - (Optional) If true, all objects and versions will purged from a [linode_object_storage_bucket](resources/object_storage_bucket.md) before it is destroyed.
 

--- a/docs/resources/object_storage_bucket.md
+++ b/docs/resources/object_storage_bucket.md
@@ -109,7 +109,7 @@ For example, `us-mia-1` cluster can be translated into `us-mia` region. Exactly 
 
 * `s3_endpoint` - (Optional) The user's s3 endpoint URL, based on the `endpoint_type` and `region`.
 
-* `cors_enabled` - (Optional) If true, the bucket will have CORS enabled for all origins.
+* `cors_enabled` - (Optional) If true, the bucket will have CORS enabled for all origins. Not supported by E2/E3 endpoints.
 
 * `versioning` - (Optional) Whether to enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket. (Requires `access_key` and `secret_key`)
 

--- a/linode/obj/framework_models.go
+++ b/linode/obj/framework_models.go
@@ -80,6 +80,7 @@ func (data ResourceModel) GetObjectStorageKeys(
 	client *linodego.Client,
 	config *helper.FrameworkProviderModel,
 	permissions string,
+	endpointType *linodego.ObjectStorageEndpointType,
 	diags *diag.Diagnostics,
 ) (*ObjectKeys, func()) {
 	result := &ObjectKeys{}
@@ -99,7 +100,7 @@ func (data ResourceModel) GetObjectStorageKeys(
 	}
 
 	if config.ObjUseTempKeys.ValueBool() {
-		objKey := fwCreateTempKeys(ctx, client, data.Bucket.ValueString(), data.GetRegionOrCluster(ctx), permissions, diags)
+		objKey := fwCreateTempKeys(ctx, client, data.Bucket.ValueString(), data.GetRegionOrCluster(ctx), permissions, nil, diags)
 		if diags.HasError() {
 			return nil, nil
 		}
@@ -107,7 +108,9 @@ func (data ResourceModel) GetObjectStorageKeys(
 		result.AccessKey = objKey.AccessKey
 		result.SecretKey = objKey.SecretKey
 
-		teardownTempKeysCleanUp := func() { cleanUpTempKeys(ctx, client, objKey.ID) }
+		teardownTempKeysCleanUp := func() {
+			cleanUpTempKeys(ctx, client, objKey.ID)
+		}
 
 		return result, teardownTempKeysCleanUp
 	}

--- a/linode/obj/framework_resource.go
+++ b/linode/obj/framework_resource.go
@@ -55,7 +55,7 @@ func (r *Resource) Create(
 	plan.ComputeEndpointIfUnknown(ctx, client, &resp.Diagnostics)
 
 	s3client, teardownKeys := getS3ClientFromModel(
-		ctx, client, config, plan, READ_WRITE_PERMISSION, &resp.Diagnostics,
+		ctx, client, config, plan, READ_WRITE_PERMISSION, nil, &resp.Diagnostics,
 	)
 
 	if teardownKeys != nil {
@@ -145,7 +145,7 @@ func (r *Resource) Read(
 	}
 
 	s3client, teardownKeys := getS3ClientFromModel(
-		ctx, client, config, state, READ_PERMISSION, &resp.Diagnostics,
+		ctx, client, config, state, READ_PERMISSION, nil, &resp.Diagnostics,
 	)
 
 	if teardownKeys != nil {
@@ -196,7 +196,7 @@ func (r *Resource) Update(
 	plan.ComputeEndpointIfUnknown(ctx, client, &resp.Diagnostics)
 
 	s3client, teardownKeys := getS3ClientFromModel(
-		ctx, client, config, plan, READ_WRITE_PERMISSION, &resp.Diagnostics,
+		ctx, client, config, plan, READ_WRITE_PERMISSION, nil, &resp.Diagnostics,
 	)
 
 	if teardownKeys != nil {
@@ -256,7 +256,7 @@ func (r *Resource) Delete(
 	config := r.Meta.Config
 
 	s3client, teardownKeys := getS3ClientFromModel(
-		ctx, client, config, state, READ_WRITE_PERMISSION, &resp.Diagnostics,
+		ctx, client, config, state, READ_WRITE_PERMISSION, nil, &resp.Diagnostics,
 	)
 
 	if teardownKeys != nil {

--- a/linode/objbucket/resource.go
+++ b/linode/objbucket/resource.go
@@ -93,7 +93,7 @@ func readResource(
 			"lifecyclePresent":  lifecyclePresent,
 		})
 
-		objKeys, diags, teardownKeysCleanUp := obj.GetObjKeys(ctx, d, config, client, bucket.Label, regionOrCluster, "read_only")
+		objKeys, diags, teardownKeysCleanUp := obj.GetObjKeys(ctx, d, config, client, bucket.Label, regionOrCluster, "read_only", &bucket.EndpointType)
 		if diags != nil {
 			return diags
 		}
@@ -228,9 +228,15 @@ func updateResource(
 		config := meta.(*helper.ProviderMeta).Config
 		regionOrCluster := helper.GetRegionOrCluster(d)
 
-		bucket := d.Get("label").(string)
+		bucketLabel := d.Get("label").(string)
 
-		objKeys, diags, teardownKeysCleanUp := obj.GetObjKeys(ctx, d, config, client, bucket, regionOrCluster, "read_write")
+		et, etOK := d.GetOk("endpoint_type")
+		var endpointType *linodego.ObjectStorageEndpointType
+		if etOK {
+			endpointType = linodego.Pointer(linodego.ObjectStorageEndpointType(et.(string)))
+		}
+
+		objKeys, diags, teardownKeysCleanUp := obj.GetObjKeys(ctx, d, config, client, bucketLabel, regionOrCluster, "read_write", endpointType)
 		if diags != nil {
 			return diags
 		}
@@ -277,7 +283,13 @@ func deleteResource(
 	}
 
 	if config.ObjBucketForceDelete {
-		objKeys, diags, teardownKeysCleanUp := obj.GetObjKeys(ctx, d, config, client, label, regionOrCluster, "read_write")
+		et, etOK := d.GetOk("endpoint_type")
+		var endpointType *linodego.ObjectStorageEndpointType
+		if etOK {
+			endpointType = linodego.Pointer(linodego.ObjectStorageEndpointType(et.(string)))
+		}
+
+		objKeys, diags, teardownKeysCleanUp := obj.GetObjKeys(ctx, d, config, client, label, regionOrCluster, "read_write", endpointType)
 		if diags != nil {
 			return diags
 		}


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Adding a waiting period for limited temporary key to become effective.

## ✔️ How to Test

```hcl
resource "linode_object_storage_bucket" "test" {
  label         = "tf-test-bucket-123"
  region        = "sg-sin-2"
  endpoint_type = "E3"

  lifecycle_rule {
    prefix  = "tf"
    enabled = true

    abort_incomplete_multipart_upload_days = 5

    expiration {
      date = "2028-06-21"
    }
  }
}

resource "linode_object_storage_object" "object" {
  bucket = linode_object_storage_bucket.test.label
  region = linode_object_storage_bucket.test.region
  key    = "my-object"

  content = "This is the content of the Object..."
}
```