### PR TITLE
Fix filtering on `tags` for nodebalancers

### DIFF
--- a/linode/nbs/datasource_test.go
+++ b/linode/nbs/datasource_test.go
@@ -63,6 +63,14 @@ func TestAccDataSourceNodeBalancers_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: tmpl.DataFilterTags(t, nbLabel, nbRegion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "nodebalancers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nodebalancers.0.region", nbRegion),
+					acceptance.CheckListContains(resourceName, "nodebalancers.0.tags", "tf_test_2"),
+				),
+			},
+			{
 				Config: tmpl.DataOrder(t, nbLabel, nbRegion),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "nodebalancers.0.label", nbLabel+"-0"),

--- a/linode/nbs/framework_schema_datasource.go
+++ b/linode/nbs/framework_schema_datasource.go
@@ -8,9 +8,11 @@ import (
 
 var filterConfig = frameworkfilter.Config{
 	"label":  {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
-	"tags":   {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
 	"ipv4":   {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
 	"region": {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+
+	// temporarily use client-side filter while API filter for tags is not working properly
+	"tags": {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
 
 	"hostname":             {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
 	"ipv6":                 {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},

--- a/linode/nbs/tmpl/data_filter_tags.gotf
+++ b/linode/nbs/tmpl/data_filter_tags.gotf
@@ -1,0 +1,16 @@
+{{ define "nbs_data_filter_tags" }}
+
+{{ template "nbs_data_base" . }}
+
+data "linode_nodebalancers" "nbs" {
+    filter {
+        name   = "tags"
+        values = ["tf_test_2"]
+    }
+    filter {
+        name = "region"
+        values = ["{{.Region}}"]
+    }
+}
+
+{{ end }}

--- a/linode/nbs/tmpl/template.go
+++ b/linode/nbs/tmpl/template.go
@@ -42,3 +42,11 @@ func DataOrder(t testing.TB, label, region string) string {
 			Region: region,
 		})
 }
+
+func DataFilterTags(t testing.TB, label, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"nbs_data_filter_tags", TemplateData{
+			Label:  label,
+			Region: region,
+		})
+}


### PR DESCRIPTION
## 📝 Description

The filter on `tags` did not work properly for linode_nodebalancers. The root cause is on the API side. To unblock customer quickly, we use client-side filter as a workaround. 

Addressed #1853 

## ✔️ How to Test

Integration test:
```
make test-int PKG_NAME=nbs
```

Manual test:

1. In a sandbox environment, firstly creating some basic nodebalancers for testing, i.e. 
```
resource "linode_nodebalancer" "foobar" {
    count = 2
    label = "test-my-nbs-${count.index}"
    region = "us-east"
    client_conn_throttle = 20
    client_udp_sess_throttle = 10
    tags = count.index == 0 ? ["tf_test_1"] : ["tf_test_1", "tf_test_2"]
}
```

2. Use the data source to list and filter on tags
```
data "linode_nodebalancers" "nbs" {
    filter {
        name   = "tags"
        values = ["tf_test_2"]
    }
}

output "result" {
  value = data.linode_nodebalancers.nbs.nodebalancers
}
```

3. Observe the result is correct in the output.
4. Change around the filters to make sure it works properly.
5. Destroy the resources.

