### PR TITLE
Apply `UseStateForUnknown` for hosts of database instances

### DIFF
--- a/linode/databasemysqlv2/framework_resource_schema.go
+++ b/linode/databasemysqlv2/framework_resource_schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -154,14 +155,20 @@ var frameworkResourceSchema = schema.Schema{
 			Description: "The primary host for the Managed Database.",
 			Computed:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
+				stringplanmodifiers.UseStateForUnknownUnlessTheseChanged(
+					path.MatchRoot("private_network"),
+					path.MatchRoot("type"),
+				),
 			},
 		},
 		"host_secondary": schema.StringAttribute{
 			Description: "The secondary/private host for the Managed Database.",
 			Computed:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
+				stringplanmodifiers.UseStateForUnknownUnlessTheseChanged(
+					path.MatchRoot("private_network"),
+					path.MatchRoot("type"),
+				),
 			},
 		},
 		"members": schema.MapAttribute{

--- a/linode/databasepostgresqlv2/framework_resource_schema.go
+++ b/linode/databasepostgresqlv2/framework_resource_schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -156,14 +157,20 @@ var frameworkResourceSchema = schema.Schema{
 			Description: "The primary host for the Managed Database.",
 			Computed:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
+				stringplanmodifiers.UseStateForUnknownUnlessTheseChanged(
+					path.MatchRoot("private_network"),
+					path.MatchRoot("type"),
+				),
 			},
 		},
 		"host_secondary": schema.StringAttribute{
 			Description: "The secondary/private host for the Managed Database.",
 			Computed:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
+				stringplanmodifiers.UseStateForUnknownUnlessTheseChanged(
+					path.MatchRoot("private_network"),
+					path.MatchRoot("type"),
+				),
 			},
 		},
 		"members": schema.MapAttribute{

--- a/linode/helper/stringplanmodifiers/usestateforunknownif.go
+++ b/linode/helper/stringplanmodifiers/usestateforunknownif.go
@@ -32,9 +32,7 @@ func UseStateForUnknownUnlessTheseChanged(expressions ...path.Expression) planmo
 				for _, mp := range matchedPaths {
 					var state, plan attr.Value
 
-					newDiags = request.Plan.GetAttribute(ctx, mp, &plan)
-
-					resp.Diagnostics.Append(newDiags...)
+					resp.Diagnostics.Append(request.Plan.GetAttribute(ctx, mp, &plan)...)
 					if resp.Diagnostics.HasError() {
 						return
 					}
@@ -43,9 +41,7 @@ func UseStateForUnknownUnlessTheseChanged(expressions ...path.Expression) planmo
 						continue
 					}
 
-					newDiags = request.State.GetAttribute(ctx, mp, &state)
-
-					resp.Diagnostics.Append(newDiags...)
+					resp.Diagnostics.Append(request.State.GetAttribute(ctx, mp, &state)...)
 					if resp.Diagnostics.HasError() {
 						return
 					}


### PR DESCRIPTION
## 📝 Description

Resolve #2085

## ✔️ How to Test

### First Step

Apply this TF config:
```hcl
provider "linode" {}

resource "linode_database_postgresql_v2" "this" {
  label = "mydatabase"
  engine_id = "postgresql/16"
  region = "us-mia"
  type = "g6-standard-1"
  allow_list = ["0.0.0.0/0"]
}
```

### Second Step

Change the `allow_list`, then apply again.

```hcl
provider "linode" {}

resource "linode_database_postgresql_v2" "this" {
  label = "mydatabase"
  engine_id = "postgresql/16"
  region = "us-mia"
  type = "g6-standard-1"
  allow_list = ["YOUR_IP_ADDRESS"] // change this to your IP
}

provider "postgresql" {
  host        = linode_database_postgresql_v2.this.host_primary
  port        = linode_database_postgresql_v2.this.port
  database    = "defaultdb"
  superuser   = false
  username    = linode_database_postgresql_v2.this.root_username
  password    = linode_database_postgresql_v2.this.root_password
  sslrootcert = linode_database_postgresql_v2.this.ca_cert
  sslmode     = "require"
}

resource "postgresql_role" "this" {
  name     = "test_role"
  password = "test_password"
}
```