### PR TITLE
Add FirewallID to NodePool

### DIFF
--- a/docs/data-sources/lke_cluster.md
+++ b/docs/data-sources/lke_cluster.md
@@ -61,6 +61,8 @@ In addition to all arguments above, the following attributes are exported:
 
   * `label` - The label of the Node Pool.
 
+  * `firewall_id` - The ID of the firewall associated with the Node Pool.
+
   * `type` - The linode type for all of the nodes in the Node Pool. See all node types [here](https://api.linode.com/v4/linode/types).
 
   * `count` - The number of nodes in the Node Pool.

--- a/docs/resources/lke_cluster.md
+++ b/docs/resources/lke_cluster.md
@@ -118,6 +118,24 @@ resource "linode_lke_cluster" "my-cluster" {
 }
 ```
 
+Creating an LKE cluster with existing firewall on a node pool:
+
+```terraform
+resource "linode_lke_cluster" "my-cluster" {
+    label       = "my-cluster"
+    k8s_version = "1.32"
+    region      = "us-central"
+    tags        = ["prod"]
+
+    pool {
+        type  = "g6-standard-2"
+        count = 2
+        label = "db-pool"
+        firewall_id = 12345
+    }
+}
+```
+
 Creating an LKE cluster with node pool labels:
 
 ```terraform
@@ -186,6 +204,8 @@ The following arguments are supported in the `pool` specification block:
 * `count` - (Required; Optional with `autoscaler`) The number of nodes in the Node Pool. If undefined with an autoscaler the initial node count will equal the autoscaler minimum.
 
 * `label` - (Optional) A label for the Node Pool. If not provided, it defaults to empty string.
+
+* `firewall_id` - (Optional) The ID of the firewall to associate with this node pool. If not provided, default firewall will be associated.
 
 * `labels` - (Optional) A map of key/value pairs to apply to all nodes in the pool. Labels are used to identify and organize Kubernetes resources within your cluster.
 

--- a/docs/resources/lke_node_pool.md
+++ b/docs/resources/lke_node_pool.md
@@ -38,6 +38,17 @@ resource "linode_lke_node_pool" "my-pool" {
 }
 ```
 
+Creating a basic LKE Node with firewall:
+
+```terraform
+resource "linode_lke_node_pool" "my-pool" {
+    cluster_id  = 150003
+    type  = "g6-standard-2"
+    firewall_id =  12345
+    node_count = 3
+}
+```
+
 Creating an LKE Node Pool with autoscaler:
 
 ```terraform
@@ -103,6 +114,8 @@ The following arguments are supported:
 * `tags` - (Optional) An array of tags applied to the Node Pool. Tags can be used to flag node pools as externally managed, see [Externally Managed Node Pools](lke_cluster.md#externally-managed-node-pools) for more details.
 
 * `label` - (Optional) A label for the Node Pool. If not provided, it defaults to empty string.
+
+* `firewall_id` - (Optional) The ID of the firewall to associate with this node pool. If not provided, default firewall will be associated.
 
 * `labels` - (Optional) A map attribute containing key-value pairs to be added as labels to nodes in the node pool. Labels help classify your nodes and to easily select subsets of objects. To learn more, review [Add Labels and Taints to your LKE Node Pools](https://www.linode.com/docs/products/compute/kubernetes/guides/deploy-and-manage-cluster-with-the-linode-api/#add-labels-and-taints-to-your-lke-node-pools).
 

--- a/linode/lke/cluster.go
+++ b/linode/lke/cluster.go
@@ -28,6 +28,7 @@ type NodePoolSpec struct {
 	K8sVersion        *string
 	UpdateStrategy    *string
 	Label             *string
+	FirewallID        *int
 }
 
 type NodePoolUpdates struct {
@@ -63,6 +64,10 @@ func ReconcileLKENodePoolSpecs(
 
 		if spec.Label != nil && *spec.Label != "" {
 			createOpts.Label = spec.Label
+		}
+
+		if spec.FirewallID != nil && *spec.FirewallID != 0 {
+			createOpts.FirewallID = spec.FirewallID
 		}
 
 		if spec.Taints != nil {
@@ -145,6 +150,13 @@ func ReconcileLKENodePoolSpecs(
 		} else if newSpec.Label == nil && oldSpec.Label != nil {
 			empty := ""
 			updateOpts.Label = &empty
+		}
+
+		if (newSpec.FirewallID != nil && oldSpec.FirewallID != nil && *newSpec.FirewallID != *oldSpec.FirewallID) ||
+			(newSpec.FirewallID != nil && oldSpec.FirewallID == nil) {
+			updateOpts.FirewallID = newSpec.FirewallID
+		} else if newSpec.FirewallID == nil && oldSpec.FirewallID != nil {
+			updateOpts.FirewallID = nil
 		}
 
 		if enterprise {
@@ -432,6 +444,12 @@ func matchPoolsWithSchema(ctx context.Context, pools []linodego.LKENodePool, dec
 				}
 			}
 
+			if declaredFirewallID, ok := declaredPool["firewall_id"].(int); ok && declaredFirewallID != 0 {
+				if apiPool.FirewallID == nil || declaredFirewallID != *apiPool.FirewallID {
+					continue
+				}
+			}
+
 			// Pair the API pool with the declared pool
 			result[i] = apiPool
 			delete(apiPools, apiPool.ID)
@@ -496,9 +514,15 @@ func expandLinodeLKENodePoolSpecs(pool []interface{}, preserveNoTarget bool) (po
 			labelPtr = &v
 		}
 
+		var firewallIdPtr *int
+		if v, ok := specMap["firewall_id"].(int); ok && v != 0 {
+			firewallIdPtr = &v
+		}
+
 		poolSpecs = append(poolSpecs, NodePoolSpec{
 			ID:                specMap["id"].(int),
 			Label:             labelPtr,
+			FirewallID:        firewallIdPtr,
 			Type:              specMap["type"].(string),
 			Tags:              helper.ExpandStringSet(specMap["tags"].(*schema.Set)),
 			Taints:            helper.ExpandObjectSet(specMap["taint"].(*schema.Set)),
@@ -551,6 +575,7 @@ func flattenLKENodePools(pools []linodego.LKENodePool) []map[string]interface{} 
 			"autoscaler":      autoscaler,
 			"k8s_version":     pool.K8sVersion,
 			"update_strategy": pool.UpdateStrategy,
+			"firewall_id":     pool.FirewallID,
 		}
 	}
 	return flattened

--- a/linode/lke/framework_datasource_schema.go
+++ b/linode/lke/framework_datasource_schema.go
@@ -144,6 +144,10 @@ var frameworkDataSourceSchema = schema.Schema{
 						Description: "The label of the Node Pool.",
 						Optional:    true,
 					},
+					"firewall_id": schema.Int64Attribute{
+						Computed:    true,
+						Description: "The ID of the firewall associated with the Node Pool.",
+					},
 					"count": schema.Int64Attribute{
 						Computed:    true,
 						Description: "The number of nodes in the Node Pool.",

--- a/linode/lke/framework_models.go
+++ b/linode/lke/framework_models.go
@@ -73,6 +73,7 @@ type LKENodePool struct {
 	K8sVersion     types.String                     `tfsdk:"k8s_version"`
 	UpdateStrategy types.String                     `tfsdk:"update_strategy"`
 	Label          types.String                     `tfsdk:"label"`
+	FirewallId     types.Int64                      `tfsdk:"firewall_id"`
 }
 
 type LKENodePoolDisk struct {
@@ -142,6 +143,11 @@ func (data *LKEDataModel) parseLKEAttributes(
 				label = types.StringPointerValue(p.Label)
 			}
 			pool.Label = label
+
+			if p.FirewallID != nil {
+				firewallId := types.Int64Value(int64(*p.FirewallID))
+				pool.FirewallId = firewallId
+			}
 
 			if p.UpdateStrategy != nil {
 				pool.UpdateStrategy = types.StringValue(string(*p.UpdateStrategy))

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -219,8 +219,14 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta interface{
 			label = linodego.Pointer(poolSpec["label"].(string))
 		}
 
+		var firewallId *int
+		if poolSpec["firewall_id"] != 0 {
+			firewallId = linodego.Pointer(poolSpec["firewall_id"].(int))
+		}
+
 		createOpts.NodePools = append(createOpts.NodePools, linodego.LKENodePoolCreateOptions{
 			Label:      label,
+			FirewallID: firewallId,
 			Type:       poolSpec["type"].(string),
 			Tags:       helper.ExpandStringSet(poolSpec["tags"].(*schema.Set)),
 			Taints:     expandNodePoolTaints(helper.ExpandObjectSet(poolSpec["taint"].(*schema.Set))),

--- a/linode/lke/schema_resource.go
+++ b/linode/lke/schema_resource.go
@@ -129,6 +129,11 @@ var resourceSchema = map[string]*schema.Schema{
 					Description: "A Linode Type for all of the nodes in the Node Pool.",
 					Required:    true,
 				},
+				"firewall_id": {
+					Type:        schema.TypeInt,
+					Description: "The ID of the Firewall to attach to nodes in this node pool.",
+					Optional:    true,
+				},
 				"labels": {
 					Type: schema.TypeMap,
 					Elem: &schema.Schema{

--- a/linode/lke/tmpl/enterprise.gotf
+++ b/linode/lke/tmpl/enterprise.gotf
@@ -27,6 +27,7 @@ resource "linode_lke_cluster" "test" {
         count = 3
         tags  = ["test"]
         k8s_version = "{{.K8sVersion}}"
+        firewall_id = "{{.FirewallID}}"
         update_strategy = "{{.UpdateStrategy}}"
     }
 

--- a/linode/lke/tmpl/template.go
+++ b/linode/lke/tmpl/template.go
@@ -26,6 +26,7 @@ type TemplateData struct {
 	Labels           map[string]string
 	AuditLogsEnabled bool
 	Tier             string
+	FirewallID       int
 }
 
 func Basic(t testing.TB, name, version, region string) string {
@@ -108,14 +109,19 @@ func Enterprise(t testing.TB, name, version, region, updateStrategy string) stri
 		"lke_cluster_enterprise", TemplateData{Label: name, K8sVersion: version, Region: region, UpdateStrategy: updateStrategy})
 }
 
+func EnterpriseFirewall(t testing.TB, name, version, region string, firewall_id int) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_cluster_enterprise", TemplateData{Label: name, K8sVersion: version, Region: region, FirewallID: firewall_id})
+}
+
 func DataBasic(t testing.TB, name, version, region string) string {
 	return acceptance.ExecuteTemplate(t,
 		"lke_cluster_data_basic", TemplateData{Label: name, K8sVersion: version, Region: region})
 }
 
-func DataEnterprise(t testing.TB, name, version, region, updateStrategy string) string {
+func DataEnterprise(t testing.TB, name, version, region, updateStrategy string, firewall_id int) string {
 	return acceptance.ExecuteTemplate(t,
-		"lke_cluster_data_enterprise", TemplateData{Label: name, K8sVersion: version, Region: region, UpdateStrategy: updateStrategy})
+		"lke_cluster_data_enterprise", TemplateData{Label: name, K8sVersion: version, Region: region, UpdateStrategy: updateStrategy, FirewallID: firewall_id})
 }
 
 func DataAutoscaler(t testing.TB, name, version, region string) string {

--- a/linode/lkenodepool/framework_models.go
+++ b/linode/lkenodepool/framework_models.go
@@ -26,6 +26,7 @@ type NodePoolModel struct {
 	K8sVersion     types.String              `tfsdk:"k8s_version"`
 	UpdateStrategy types.String              `tfsdk:"update_strategy"`
 	Label          types.String              `tfsdk:"label"`
+	FirewallID     types.Int64               `tfsdk:"firewall_id"`
 }
 
 type NodePoolAutoscalerModel struct {
@@ -101,6 +102,7 @@ func (pool *NodePoolModel) FlattenLKENodePool(
 	pool.Type = helper.KeepOrUpdateString(pool.Type, p.Type, preserveKnown)
 	pool.DiskEncryption = helper.KeepOrUpdateString(pool.DiskEncryption, string(p.DiskEncryption), preserveKnown)
 	pool.Label = helper.KeepOrUpdateStringPointer(pool.Label, p.Label, preserveKnown)
+	pool.FirewallID = helper.KeepOrUpdateIntPointer(pool.FirewallID, p.FirewallID, preserveKnown)
 	pool.Tags = helper.KeepOrUpdateStringSet(pool.Tags, p.Tags, preserveKnown, diags)
 	if diags.HasError() {
 		return
@@ -147,6 +149,10 @@ func (pool *NodePoolModel) SetNodePoolCreateOptions(
 	)
 	p.Type = pool.Type.ValueString()
 	p.Label = pool.Label.ValueStringPointer()
+	if !pool.FirewallID.IsNull() && pool.FirewallID.ValueInt64() != 0 {
+		firewall_id := int(pool.FirewallID.ValueInt64())
+		p.FirewallID = &firewall_id
+	}
 
 	if !pool.Tags.IsNull() {
 		diags.Append(pool.Tags.ElementsAs(ctx, &p.Tags, false)...)
@@ -195,6 +201,12 @@ func (pool *NodePoolModel) SetNodePoolUpdateOptions(
 
 	if !state.Label.Equal(pool.Label) {
 		p.Label = pool.Label.ValueStringPointer()
+		shouldUpdate = true
+	}
+
+	if state.FirewallID != pool.FirewallID {
+		firewall_id := int(pool.FirewallID.ValueInt64())
+		p.FirewallID = &firewall_id
 		shouldUpdate = true
 	}
 
@@ -341,6 +353,7 @@ func (data *NodePoolModel) CopyFrom(other NodePoolModel, preserveKnown bool) {
 	data.K8sVersion = helper.KeepOrUpdateValue(data.K8sVersion, other.K8sVersion, preserveKnown)
 	data.UpdateStrategy = helper.KeepOrUpdateValue(data.UpdateStrategy, other.UpdateStrategy, preserveKnown)
 	data.Label = helper.KeepOrUpdateValue(data.Label, other.Label, preserveKnown)
+	data.FirewallID = helper.KeepOrUpdateValue(data.FirewallID, other.FirewallID, preserveKnown)
 
 	if !preserveKnown {
 		data.Autoscaler = other.Autoscaler

--- a/linode/lkenodepool/framework_models_unit_test.go
+++ b/linode/lkenodepool/framework_models_unit_test.go
@@ -15,11 +15,13 @@ import (
 
 func TestParseNodePool(t *testing.T) {
 	poolLabelName := "test-pool"
+	poolFirewallId := 12345
 	lkeNodePool := linodego.LKENodePool{
 		ID:             123,
 		Count:          3,
 		Label:          &poolLabelName,
 		Type:           "g6-standard-2",
+		FirewallID:     &poolFirewallId,
 		DiskEncryption: linodego.InstanceDiskEncryptionEnabled,
 		Disks: []linodego.LKENodePoolDisk{
 			{Size: 50, Type: "ssd"},
@@ -48,6 +50,7 @@ func TestParseNodePool(t *testing.T) {
 	assert.Equal(t, int64(3), nodePoolModel.Count.ValueInt64())
 	assert.Equal(t, "g6-standard-2", nodePoolModel.Type.ValueString())
 	assert.Equal(t, "enabled", nodePoolModel.DiskEncryption.ValueString())
+	assert.Equal(t, int64(12345), nodePoolModel.FirewallID.ValueInt64())
 	assert.Len(t, nodePoolModel.Nodes.Elements(), 3)
 
 	tags := make([]string, len(nodePoolModel.Tags.Elements()))
@@ -77,7 +80,7 @@ func TestSetNodePoolCreateOptions(t *testing.T) {
 	assert.Equal(t, "test-pool", *createOpts.Label)
 	assert.Contains(t, createOpts.Tags, "production")
 	assert.Contains(t, createOpts.Tags, "web-server")
-
+	assert.Equal(t, 12345, *createOpts.FirewallID)
 	assert.True(t, createOpts.Autoscaler.Enabled)
 	assert.Equal(t, 1, createOpts.Autoscaler.Min)
 	assert.Equal(t, 5, createOpts.Autoscaler.Max)
@@ -99,6 +102,7 @@ func TestSetNodePoolUpdateOptions(t *testing.T) {
 	assert.True(t, shouldUpdate)
 	assert.Equal(t, 3, updateOpts.Count)
 	assert.Equal(t, "test-pool", *updateOpts.Label)
+	assert.Equal(t, 12345, *updateOpts.FirewallID)
 	assert.Contains(t, *updateOpts.Tags, "production")
 	assert.Contains(t, *updateOpts.Tags, "web-server")
 
@@ -119,12 +123,13 @@ func createNodePoolModel() *NodePoolModel {
 	})
 
 	nodePoolModel := NodePoolModel{
-		ClusterID: types.Int64Value(1),
-		Count:     types.Int64Value(3),
-		Label:     types.StringValue("test-pool"),
-		Type:      types.StringValue("g6-standard-2"),
-		Nodes:     *nodes,
-		Tags:      tags,
+		ClusterID:  types.Int64Value(1),
+		Count:      types.Int64Value(3),
+		Label:      types.StringValue("test-pool"),
+		FirewallID: types.Int64Value(12345),
+		Type:       types.StringValue("g6-standard-2"),
+		Nodes:      *nodes,
+		Tags:       tags,
 		Autoscaler: []NodePoolAutoscalerModel{
 			{
 				Min: types.Int64Value(1),

--- a/linode/lkenodepool/framework_resource_schema.go
+++ b/linode/lkenodepool/framework_resource_schema.go
@@ -41,6 +41,11 @@ var resourceSchema = schema.Schema{
 			Default:     stringdefault.StaticString(""),
 			Computed:    true,
 		},
+		"firewall_id": schema.Int64Attribute{
+			Description: "The ID of the Firewall to attach to nodes in this node pool.",
+			Optional:    true,
+			Computed:    true,
+		},
 		"node_count": schema.Int64Attribute{
 			Validators: []validator.Int64{
 				int64validator.AtLeast(1),

--- a/linode/lkenodepool/framework_resource_test.go
+++ b/linode/lkenodepool/framework_resource_test.go
@@ -411,7 +411,6 @@ func TestAccResourceNodePool_taints_labels(t *testing.T) {
 
 func TestAccResourceNodePoolEnterprise_basic(t *testing.T) {
 	t.Parallel()
-
 	resName := "linode_lke_node_pool.foobar"
 	clusterLabel := acctest.RandomWithPrefix("tf_test_")
 	poolTag := acctest.RandomWithPrefix("tf_test_")
@@ -480,6 +479,77 @@ func TestAccResourceNodePoolEnterprise_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceNodePoolEnterprise_withFirewall(t *testing.T) {
+	t.Parallel()
+	resName := "linode_lke_node_pool.foobar"
+	clusterLabel := acctest.RandomWithPrefix("tf_test_")
+	poolTag := acctest.RandomWithPrefix("tf_test_")
+
+	client, err := acceptance.GetTestClient()
+	if err != nil {
+		log.Fatalf("failed to get client: %s", err)
+	}
+
+	versions, err := client.ListLKETierVersions(context.Background(), "enterprise", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(versions) < 1 {
+		t.Skip("No enterprise k8s versions found for test. Skipping now...")
+	}
+
+	enterpriseK8sVersion := versions[0].ID
+
+	region, err := acceptance.GetRandomRegionWithCaps([]string{"Kubernetes Enterprise"}, "core")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	firewall, err := client.CreateFirewall(context.Background(), linodego.FirewallCreateOptions{
+		Label: "tftest-enterprise-upgrade-" + acctest.RandString(5),
+		Rules: linodego.FirewallRuleSet{
+			InboundPolicy:  "ACCEPT",
+			OutboundPolicy: "ACCEPT",
+		},
+	})
+	if err != nil {
+		t.Errorf("failed creating firewall: %v", err)
+	}
+
+	templateData := createTemplateData()
+	templateData.ClusterLabel = clusterLabel
+	templateData.PoolTag = poolTag
+	templateData.K8sVersion = enterpriseK8sVersion
+	templateData.Region = region
+	templateData.FirewallID = firewall.ID
+	templateData.UpdateStrategy = "on_recycle"
+	createConfig := createEnterpriseResourceConfig(t, &templateData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		CheckDestroy:             checkNodePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					checkNodePoolExists,
+					resource.TestCheckResourceAttr(resName, "firewall_id", fmt.Sprintf("%d", firewall.ID)),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: resourceImportStateID,
+			},
+		},
+	})
+
+	client.DeleteFirewall(context.Background(), firewall.ID)
 }
 
 func TestAccResourceNodePool_disableAutoscalingExplicitNodeCount(t *testing.T) {

--- a/linode/lkenodepool/tmpl/lke_e_nodepool.gotf
+++ b/linode/lkenodepool/tmpl/lke_e_nodepool.gotf
@@ -24,6 +24,7 @@ resource "linode_lke_node_pool" "foobar" {
 {{ end }}
 
     label = "{{.Label}}"
+    firewall_id = "{{ .FirewallID }}"
     node_count = 2
     type  = "{{ .PoolNodeType }}"
     k8s_version = "{{.K8sVersion}}"

--- a/linode/lkenodepool/tmpl/template.go
+++ b/linode/lkenodepool/tmpl/template.go
@@ -26,6 +26,7 @@ type TemplateData struct {
 	Taints            []TaintData
 	Labels            map[string]string
 	Label             string
+	FirewallID        int
 	UpdateStrategy    string
 }
 


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**
- Add `firewall_id` to NodePool.

## ✔️ How to Test

- Run make build. It generates a terraform-provider-linode.
- Move the binary into ~/.terraform.d/plugins/local/lab/linode/99.0.0/darwin_arm64
- Set LINODE_API_VERSION to v4beta.
- Create 2 firewalls (firewall-1 and firewall-2)
- Create a LKE-E Cluster and use the below config to create a nodePool with a firewall-1 ID.
```
terraform {
  required_providers {
    linode = {
      source  = "local/lab/linode"
      version = "~> 99.0.0"
    }
  }
}

provider "linode" {
  token = "<token>"
}

# New node pool managed as a separate resource
resource "linode_lke_node_pool" "gpu_pool" {
  cluster_id = "<cluster-id>"
  type       = "g6-dedicated-2" # example; use any valid Linode type

  node_count  = 4
  label       = "tmp-c"
  firewall_id = 3476976
}
```
- After applying, ensure nodes are attached to firewall-1
- Change the firewall ID to firewall-2 and apply. Ensure that the change is reflected in cloud-manager UI 
- Use the below config to perform same set of operation but using the `linode_lke_cluster` resource
```
terraform {
  required_providers {
    linode = {
      source  = "local/lab/linode"
      version = "~> 99.0.0"
    }
  }
}

provider "linode" {
  token = "<token>"
}

resource "linode_lke_cluster" "my-cluster" {
  label       = "my-cluster"
  k8s_version = "v1.31.9+lke7"
  region      = "us-ord"
  tags        = ["prod"]
  tier        = "enterprise"
  # update_strategy = "on_recycle"

  pool {
    type        = "g6-dedicated-2"
    count       = 3
    label       = "test-pool"
    firewall_id = 3476976
    # tags        = ["hello", "world"]
  }

  pool {
    type        = "g6-dedicated-2"
    count       = 3
  }
}
```


**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**


**Note:** re-raised https://github.com/linode/terraform-provider-linode/pull/2169 with signed commits.