### PR TITLE
Remove sample using terraform < 0.13

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,20 +36,6 @@ resource "linode_instance" "foobar" {
 }
 ```
 
-Terraform 0.12 and earlier:
-
-```terraform
-# Configure the Linode Provider
-provider "linode" {
-  # token = "..."
-}
-
-# Create a Linode
-resource "linode_instance" "foobar" {
-  # ...
-}
-```
-
 ## Configuration Reference
 
 The following keys can be used to configure the provider.


### PR DESCRIPTION
## 📝 Description

This PR removes sample code snippet using terraform version lower than 0.13 which is no longer supported.

## ✔️ How to Test

After merge and release, https://registry.terraform.io/providers/linode/linode/latest/docs#example-usage should not contain the sample with terraform version lower than 0.13.