### PR TITLE
Removed `v4beta` notices from Maintenance Policy

### DIFF
--- a/docs/data-sources/account_settings.md
+++ b/docs/data-sources/account_settings.md
@@ -31,4 +31,4 @@ data "linode_account_settings" "example" {}
 
 * `object_storage` - A string describing the status of this account’s Object Storage service enrollment.
 
-* `maintenance_policy` - The default maintenance policy for this account. (**Note: v4beta only.**)
+* `maintenance_policy` - The default maintenance policy for this account.

--- a/docs/data-sources/instances.md
+++ b/docs/data-sources/instances.md
@@ -75,7 +75,7 @@ Each Linode instance will be stored in the `instances` attribute and will export
 
 * `tags` - A list of tags applied to this object. Tags are case-insensitive and are for organizational purposes only.
 
-* `maintenance_policy` - The maintenance policy of this Linode instance. (**Note: v4beta only.**)
+* `maintenance_policy` - The maintenance policy of this Linode instance.
 
 * `capabilities` - A list of capabilities of this Linode instance.
 

--- a/docs/data-sources/maintenance_policies.md
+++ b/docs/data-sources/maintenance_policies.md
@@ -7,7 +7,7 @@ description: |-
 # linode\_maintenance\_policies
 
 Provides details about the Maintenance Policies available to apply to Accounts and Instances.
-For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-maintenance-policies). (**Note: v4beta only.**)
+For more information, see the [Linode APIv4 docs](https://techdocs.akamai.com/linode-api/reference/get-maintenance-policies).
 
 ## Example Usage
 

--- a/docs/resources/account_settings.md
+++ b/docs/resources/account_settings.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `interfaces_for_new_linodes` - (Optional) Type of interfaces for new Linode instances. Available values are `"legacy_config_only"`, `"legacy_config_default_but_linode_allowed"`, `"linode_default_but_legacy_config_allowed"`, and `"linode_only"`.
 
-* `maintenance_policy` - (Optional) The default maintenance policy for this account. Examples are `"linode/migrate"` and `"linode/power_off_on"`. Defaults to `"linode/migrate"`. (**Note: v4beta only.**)
+* `maintenance_policy` - (Optional) The default maintenance policy for this account. Examples are `"linode/migrate"` and `"linode/power_off_on"`. Defaults to `"linode/migrate"`.
 
 ## Additional Results
 

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -156,7 +156,7 @@ The following arguments are supported:
 
 * `locks` - (Read-Only) A list of locks applied to this Linode.
 
-* `maintenance_policy` - (Optional) The maintenance policy of this Linode instance. Examples are `"linode/migrate"` and `"linode/power_off_on"`. Defaults to the default maintenance policy of the account. (**Note: v4beta only.**)
+* `maintenance_policy` - (Optional) The maintenance policy of this Linode instance. Examples are `"linode/migrate"` and `"linode/power_off_on"`. Defaults to the default maintenance policy of the account.
 
 * `private_ip` - (Optional) If true, the created Linode will have private networking enabled, allowing use of the 192.168.128.0/17 network within the Linode's region. It can be enabled on an existing Linode but it can't be disabled.
 


### PR DESCRIPTION
## 📝 Description

Removed v4beta notices from Host Maintenance Policy documentation as the project is now in GA.