### PR TITLE
Set APIFilterable to false for image type attribute to workaround API bug

### DIFF
--- a/linode/images/framework_schema_datasource.go
+++ b/linode/images/framework_schema_datasource.go
@@ -11,11 +11,12 @@ var filterConfig = frameworkfilter.Config{
 	"is_public":  {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeBool},
 	"label":      {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
 	"size":       {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeInt},
-	"type":       {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
 	"vendor":     {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
 
-	// TODO: check if tags become API filterable
-	"tags":        {TypeFunc: frameworkfilter.FilterTypeString},
+	// TODO: change to API filterable when API fixes it
+	"type": {TypeFunc: frameworkfilter.FilterTypeString},
+	"tags": {TypeFunc: frameworkfilter.FilterTypeString},
+
 	"created_by":  {TypeFunc: frameworkfilter.FilterTypeString},
 	"id":          {TypeFunc: frameworkfilter.FilterTypeString},
 	"status":      {TypeFunc: frameworkfilter.FilterTypeString},


### PR DESCRIPTION
## 📝 Description

Set APIFilterable to false for image type attribute to workaround API bug

## ✔️ How to Test

Verify this works:

```hcl
data "linode_images" "aggr_images" {
  filter {
    name   = "type"
    values = ["manual"] # We don't need image created automatically from a deleted compute instance
  }

}

output "images" {
  value = data.linode_images.aggr_images.images
}
```