### PR TITLE
LKE: deprecate output variable dashboard_url

### DIFF
--- a/linode/lke/framework_datasource.go
+++ b/linode/lke/framework_datasource.go
@@ -69,20 +69,6 @@ func (r *DataSource) Read(
 		return
 	}
 
-	var dashboard *linodego.LKEClusterDashboard
-
-	// Only standard LKE has a dashboard URL
-	if cluster.Tier == TierStandard {
-		dashboard, err = client.GetLKEClusterDashboard(ctx, clusterId)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				fmt.Sprintf("Failed to get dashboard URL for LKE cluster %d", clusterId),
-				err.Error(),
-			)
-			return
-		}
-	}
-
 	kubeconfig, err := client.GetLKEClusterKubeconfig(ctx, clusterId)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -118,7 +104,7 @@ func (r *DataSource) Read(
 		}
 	}
 
-	resp.Diagnostics.Append(data.parseLKEAttributes(ctx, cluster, pools, kubeconfig, endpoints, dashboard, acl)...)
+	resp.Diagnostics.Append(data.parseLKEAttributes(ctx, cluster, pools, kubeconfig, endpoints, acl)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/linode/lke/framework_datasource_schema.go
+++ b/linode/lke/framework_datasource_schema.go
@@ -54,8 +54,9 @@ var frameworkDataSourceSchema = schema.Schema{
 			Description: "The Base64-encoded Kubeconfig for the cluster.",
 		},
 		"dashboard_url": schema.StringAttribute{
-			Computed:    true,
-			Description: "The dashboard URL of the cluster.",
+			Computed:           true,
+			Description:        "The dashboard URL of the cluster.",
+			DeprecationMessage: "LKE Dashboard has been deprecated. This value is empty and the attribute will be removed in future versions.",
 		},
 		"status": schema.StringAttribute{
 			Computed:    true,

--- a/linode/lke/framework_models.go
+++ b/linode/lke/framework_models.go
@@ -99,7 +99,6 @@ func (data *LKEDataModel) parseLKEAttributes(
 	pools []linodego.LKENodePool,
 	kubeconfig *linodego.LKEClusterKubeconfig,
 	endpoints []linodego.LKEClusterAPIEndpoint,
-	dashboard *linodego.LKEClusterDashboard,
 	acl *linodego.LKEClusterControlPlaneACLResponse,
 ) diag.Diagnostics {
 	data.Created = types.StringValue(cluster.Created.Format(helper.TIME_FORMAT))
@@ -225,11 +224,7 @@ func (data *LKEDataModel) parseLKEAttributes(
 	}
 	data.APIEndpoints = apiEndpoints
 
-	if dashboard != nil {
-		data.DashboardURL = types.StringValue(dashboard.URL)
-	} else {
-		data.DashboardURL = types.StringNull()
-	}
+	data.DashboardURL = types.StringNull() // deprecated & unused
 
 	return nil
 }

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -115,15 +115,9 @@ func readResource(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	}
 
 	flattenedControlPlane := flattenLKEClusterControlPlane(cluster.ControlPlane, acl)
-
-	// Only standard LKE has a dashboard URL
+	// Only standard LKE used to had a dashboard URL
 	if cluster.Tier == TierStandard {
-		dashboard, err := client.GetLKEClusterDashboard(ctx, id)
-		if err != nil {
-			return diag.Errorf("failed to get dashboard URL for LKE cluster %d: %s", id, err)
-		}
-
-		d.Set("dashboard_url", dashboard.URL)
+		d.Set("dashboard_url", "")
 	}
 
 	d.Set("label", cluster.Label)

--- a/linode/lke/schema_resource.go
+++ b/linode/lke/schema_resource.go
@@ -65,6 +65,7 @@ var resourceSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The dashboard URL of the cluster.",
+		Deprecated:  "LKE Dashboard has been deprecated. This value will be empty.",
 	},
 	"status": {
 		Type:        schema.TypeString,


### PR DESCRIPTION
LKE dashboard is being removed. This PR deprecates the dashboard_url output of linode_lke_cluster resource. Upgrades for existing users will look like the following:

      $ terraform apply
      Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

        # linode_lke_cluster.test has changed
        ~ resource "linode_lke_cluster" "test" {
            - dashboard_url = "https://f59fc4f4-f580-4ee4-b966-fa2a810937b7.redacted" -> null
              id            = "123456"
              tags          = [
                  "lke",
                  "tf",
              ]
              # (10 unchanged attributes hidden)
              # (2 unchanged blocks hidden)
          }

      Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes. ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

      Changes to Outputs: ~ dashboard_url  = "https://f59fc4f4-f580-4ee4-b966-fa2a810937b7.redacted" -> ""

LKE’s Kubernetes Dashboard will be decommissioned in May 2026

Following the upstream archival of the Kubernetes Dashboard project, Akamai Cloud will decommission the LKE-hosted Kubernetes Dashboard. This change will occur in May 2026. Once decommissioned, the Kubernetes Dashboard UI will no longer be available for new and existing LKE clusters.

https://techdocs.akamai.com/cloud-computing/docs/an-overview-of-the-kubernetes-dashboard-on-lke

## Context
The API endpoint is deprecated and it will start returning empty string instead of dashboard url in May 2026. Meaning, the older provider versions will continue to work fine for a forseeable future.