### PR TITLE
Update lock.md to clarify lock_type limitations

### DIFF
--- a/docs/resources/lock.md
+++ b/docs/resources/lock.md
@@ -60,6 +60,8 @@ The following arguments are supported:
   * `cannot_delete` - Prevents the resource from being deleted, rebuilt, or transferred to another account.
   * `cannot_delete_with_subresources` - Prevents the resource from being deleted, rebuilt, or transferred, and also prevents deletion of subresources (disks, configs, interfaces, and IP addresses).
 
+-> **Note** The cannot_delete_with_subresources form of lock_type that's available with other resources does not apply to an entity_type of lkecluster or lkenodepool
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION

## 📝 Description

**What does this PR do and why is this change necessary?**

Clarify that 'cannot_delete_with_subresources' lock does not apply to 'lkecluster' or 'lkenodepool' entity types. Akamai techdocs have this note, but linode terraform provider documentation does not. This is PR is adding it.

## ✔️ How to Test

Documentation update does not require testing. Just make sure that it will be visible as a blue banner note when pushed to the terraform registry.

**What are the steps to reproduce the issue or verify the changes?**
None.
**How do I run the relevant unit/integration tests?**
None.