### PR TITLE
TPT-4438: Added support for LDE in LKE Cluster Resource

### DIFF
--- a/docs/resources/lke_cluster.md
+++ b/docs/resources/lke_cluster.md
@@ -165,6 +165,29 @@ resource "linode_lke_cluster" "my-cluster" {
 }
 ```
 
+Creating an LKE cluster with disk encryption:
+
+```terraform
+resource "linode_lke_cluster" "my-cluster" {
+    label       = "my-cluster"
+    k8s_version = "1.32"
+    region      = "us-central"
+    tags        = ["prod"]
+
+    pool {
+        type            = "g6-standard-2"
+        count           = 2
+        disk_encryption = "enabled"
+    }
+
+    pool {
+        type            = "g6-standard-1"
+        count           = 1
+        disk_encryption = "disabled"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -220,6 +243,8 @@ The following arguments are supported in the `pool` specification block:
   * `value` - (Required) The Kubernetes taint value.
 
 * [`autoscaler`](#autoscaler) - (Optional) If defined, an autoscaler will be enabled with the given configuration.
+
+* `disk_encryption` - (Optional) The disk encryption policy for nodes in this pool. Must be `enabled` or `disabled`. If omitted, the account default encryption policy is applied. Changing this value will cause the pool to be replaced (deleted and recreated).
 
 * `k8s_version` - (Optional) The k8s version of the nodes in this Node Pool. For LKE enterprise only and may not currently available to all users even under v4beta.
 
@@ -278,8 +303,6 @@ In addition to all arguments above, the following attributes are exported:
 * `pool` - Additional nested attributes:
 
   * `id` - The ID of the Node Pool.
-
-  * `disk_encryption` - The disk encryption policy for nodes in this pool.
 
   * [`nodes`](#nodes) - The nodes in the Node Pool.
 

--- a/linode/lke/cluster.go
+++ b/linode/lke/cluster.go
@@ -467,6 +467,12 @@ func matchPoolsWithSchema(ctx context.Context, pools []linodego.LKENodePool, dec
 				}
 			}
 
+			if declaredDE, ok := declaredPool["disk_encryption"].(string); ok && declaredDE != "" {
+				if string(apiPool.DiskEncryption) != declaredDE {
+					continue
+				}
+			}
+
 			// Pair the API pool with the declared pool
 			result[i] = apiPool
 			delete(apiPools, apiPool.ID)

--- a/linode/lke/cluster.go
+++ b/linode/lke/cluster.go
@@ -29,6 +29,7 @@ type NodePoolSpec struct {
 	UpdateStrategy    *string
 	Label             *string
 	FirewallID        *int
+	DiskEncryption    *string
 }
 
 type NodePoolUpdates struct {
@@ -68,6 +69,11 @@ func ReconcileLKENodePoolSpecs(
 
 		if spec.FirewallID != nil && *spec.FirewallID != 0 {
 			createOpts.FirewallID = spec.FirewallID
+		}
+
+		if spec.DiskEncryption != nil {
+			de := linodego.InstanceDiskEncryption(*spec.DiskEncryption)
+			createOpts.DiskEncryption = &de
 		}
 
 		if spec.Taints != nil {
@@ -128,6 +134,20 @@ func ReconcileLKENodePoolSpecs(
 		// Types cannot be updated on node pools
 		// so we should delete the old one and create a new one
 		if newSpec.Type != oldSpec.Type {
+			if err := createPool(newSpec); err != nil {
+				return result, err
+			}
+
+			deletePool(oldSpec.ID)
+			continue
+		}
+
+		// Disk encryption cannot be updated on node pools
+		// so we should delete the old one and create a new one
+		diskEncryptionChanged := (newSpec.DiskEncryption != nil && oldSpec.DiskEncryption != nil && *newSpec.DiskEncryption != *oldSpec.DiskEncryption) ||
+			(newSpec.DiskEncryption != nil && oldSpec.DiskEncryption == nil) ||
+			(newSpec.DiskEncryption == nil && oldSpec.DiskEncryption != nil)
+		if diskEncryptionChanged {
 			if err := createPool(newSpec); err != nil {
 				return result, err
 			}
@@ -516,10 +536,16 @@ func expandLinodeLKENodePoolSpecs(pool []any, preserveNoTarget bool) (poolSpecs 
 			firewallIdPtr = &v
 		}
 
+		var diskEncryptionPtr *string
+		if v, ok := specMap["disk_encryption"].(string); ok && v != "" {
+			diskEncryptionPtr = &v
+		}
+
 		poolSpecs = append(poolSpecs, NodePoolSpec{
 			ID:                specMap["id"].(int),
 			Label:             labelPtr,
 			FirewallID:        firewallIdPtr,
+			DiskEncryption:    diskEncryptionPtr,
 			Type:              specMap["type"].(string),
 			Tags:              helper.ExpandStringSet(specMap["tags"].(*schema.Set)),
 			Taints:            helper.ExpandObjectSet(specMap["taint"].(*schema.Set)),

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -226,15 +226,22 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			firewallId = linodego.Pointer(poolSpec["firewall_id"].(int))
 		}
 
+		var diskEncryption *linodego.InstanceDiskEncryption
+		if v, ok := poolSpec["disk_encryption"].(string); ok && v != "" {
+			de := linodego.InstanceDiskEncryption(v)
+			diskEncryption = &de
+		}
+
 		createOpts.NodePools = append(createOpts.NodePools, linodego.LKENodePoolCreateOptions{
-			Label:      label,
-			FirewallID: firewallId,
-			Type:       poolSpec["type"].(string),
-			Tags:       helper.ExpandStringSet(poolSpec["tags"].(*schema.Set)),
-			Taints:     expandNodePoolTaints(helper.ExpandObjectSet(poolSpec["taint"].(*schema.Set))),
-			Labels:     helper.StringAnyMapToTyped[string](poolSpec["labels"].(map[string]any)),
-			Count:      count,
-			Autoscaler: autoscaler,
+			Label:          label,
+			FirewallID:     firewallId,
+			DiskEncryption: diskEncryption,
+			Type:           poolSpec["type"].(string),
+			Tags:           helper.ExpandStringSet(poolSpec["tags"].(*schema.Set)),
+			Taints:         expandNodePoolTaints(helper.ExpandObjectSet(poolSpec["taint"].(*schema.Set))),
+			Labels:         helper.StringAnyMapToTyped[string](poolSpec["labels"].(map[string]any)),
+			Count:          count,
+			Autoscaler:     autoscaler,
 		})
 	}
 

--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -1085,3 +1085,29 @@ func TestAccResourceLKECluster_tierNoAccess(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceLKECluster_poolDiskEncryption(t *testing.T) {
+	t.Parallel()
+
+	acceptance.RunTestWithRetries(t, 2, func(t *acceptance.WrappedT) {
+		clusterName := acctest.RandomWithPrefix("tf_test")
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { acceptance.PreCheck(t) },
+			ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: tmpl.DiskEncryptionPools(t, clusterName, k8sVersionLatest, testRegion),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "2"),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.0.disk_encryption", "enabled"),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.1.count", "1"),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.1.disk_encryption", "disabled"),
+						resource.TestCheckResourceAttr(resourceClusterName, "status", "ready"),
+					),
+				},
+			},
+		})
+	})
+}

--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -1089,6 +1089,16 @@ func TestAccResourceLKECluster_tierNoAccess(t *testing.T) {
 func TestAccResourceLKECluster_poolDiskEncryption(t *testing.T) {
 	t.Parallel()
 
+	diskEncryptionRegion, err := acceptance.GetRandomRegionWithCaps(
+		[]string{linodego.CapabilityLKE, linodego.CapabilityDiskEncryption}, "core",
+	)
+	if err != nil {
+		t.Skipf("Skipping test: no region with LKE and Disk Encryption capabilities: %s", err)
+	}
+
+	var cluster linodego.LKECluster
+	var initialPoolIDs []int
+
 	acceptance.RunTestWithRetries(t, 2, func(t *acceptance.WrappedT) {
 		clusterName := acctest.RandomWithPrefix("tf_test")
 		resource.Test(t, resource.TestCase{
@@ -1097,14 +1107,60 @@ func TestAccResourceLKECluster_poolDiskEncryption(t *testing.T) {
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: tmpl.DiskEncryptionPools(t, clusterName, k8sVersionLatest, testRegion),
+					Config: tmpl.DiskEncryptionPools(t, clusterName, k8sVersionLatest, diskEncryptionRegion),
 					Check: resource.ComposeTestCheckFunc(
+						checkLKEExists(&cluster),
 						resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
 						resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "2"),
 						resource.TestCheckResourceAttr(resourceClusterName, "pool.0.disk_encryption", "enabled"),
 						resource.TestCheckResourceAttr(resourceClusterName, "pool.1.count", "1"),
 						resource.TestCheckResourceAttr(resourceClusterName, "pool.1.disk_encryption", "disabled"),
 						resource.TestCheckResourceAttr(resourceClusterName, "status", "ready"),
+						// Capture initial pool IDs for comparison
+						func(s *terraform.State) error {
+							rs := s.RootModule().Resources[resourceClusterName]
+							pool0ID, _ := strconv.Atoi(rs.Primary.Attributes["pool.0.id"])
+							pool1ID, _ := strconv.Atoi(rs.Primary.Attributes["pool.1.id"])
+							initialPoolIDs = []int{pool0ID, pool1ID}
+							return nil
+						},
+					),
+				},
+				{
+					// Change disk_encryption values — pools should be replaced, cluster should not
+					Config: tmpl.DiskEncryptionPoolsUpdated(t, clusterName, k8sVersionLatest, diskEncryptionRegion),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.0.count", "2"),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.0.disk_encryption", "disabled"),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.1.count", "1"),
+						resource.TestCheckResourceAttr(resourceClusterName, "pool.1.disk_encryption", "enabled"),
+						resource.TestCheckResourceAttr(resourceClusterName, "status", "ready"),
+						// Verify cluster ID is unchanged (no cluster recreation)
+						func(s *terraform.State) error {
+							rs := s.RootModule().Resources[resourceClusterName]
+							clusterID, _ := strconv.Atoi(rs.Primary.ID)
+							if clusterID != cluster.ID {
+								return fmt.Errorf(
+									"expected cluster ID to remain %d, but got %d (cluster was recreated)",
+									cluster.ID, clusterID,
+								)
+							}
+							return nil
+						},
+						// Verify pool IDs have changed (pools were replaced)
+						func(s *terraform.State) error {
+							rs := s.RootModule().Resources[resourceClusterName]
+							pool0ID, _ := strconv.Atoi(rs.Primary.Attributes["pool.0.id"])
+							pool1ID, _ := strconv.Atoi(rs.Primary.Attributes["pool.1.id"])
+							if pool0ID == initialPoolIDs[0] {
+								return fmt.Errorf("expected pool.0.id to change after disk_encryption update, but it remained %d", pool0ID)
+							}
+							if pool1ID == initialPoolIDs[1] {
+								return fmt.Errorf("expected pool.1.id to change after disk_encryption update, but it remained %d", pool1ID)
+							}
+							return nil
+						},
 					),
 				},
 			},

--- a/linode/lke/schema_resource.go
+++ b/linode/lke/schema_resource.go
@@ -210,10 +210,11 @@ var resourceSchema = map[string]*schema.Schema{
 					},
 				},
 				"disk_encryption": {
-					Type:        schema.TypeString,
-					Description: "The disk encryption policy for the nodes in this pool.",
-					Optional:    true,
-					Computed:    true,
+					Type:         schema.TypeString,
+					Description:  "The disk encryption policy for the nodes in this pool.",
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringInSlice([]string{"enabled", "disabled"}, false),
 				},
 				"nodes": {
 					Type: schema.TypeList,

--- a/linode/lke/schema_resource.go
+++ b/linode/lke/schema_resource.go
@@ -212,6 +212,7 @@ var resourceSchema = map[string]*schema.Schema{
 				"disk_encryption": {
 					Type:        schema.TypeString,
 					Description: "The disk encryption policy for the nodes in this pool.",
+					Optional:    true,
 					Computed:    true,
 				},
 				"nodes": {

--- a/linode/lke/tmpl/lke_pools_disk_encryption.gotf
+++ b/linode/lke/tmpl/lke_pools_disk_encryption.gotf
@@ -1,0 +1,23 @@
+{{ define "lke_pools_disk_encryption" }}
+
+resource "linode_lke_cluster" "test" {
+    label       = "{{.Label}}"
+    region      = "{{ .Region }}"
+    k8s_version = "{{.K8sVersion}}"
+    tags        = ["test"]
+    tier = "standard"
+
+    pool {
+        type  = "g6-standard-2"
+        count = 2
+        disk_encryption = "enabled"
+    }
+
+    pool {
+        type = "g6-standard-1"
+        count = 1
+        disk_encryption = "disabled"
+    }
+}
+
+{{ end }}

--- a/linode/lke/tmpl/lke_pools_disk_encryption_updated.gotf
+++ b/linode/lke/tmpl/lke_pools_disk_encryption_updated.gotf
@@ -1,0 +1,24 @@
+{{ define "lke_pools_disk_encryption_updated" }}
+
+resource "linode_lke_cluster" "test" {
+    label       = "{{.Label}}"
+    region      = "{{ .Region }}"
+    k8s_version = "{{.K8sVersion}}"
+    tags        = ["test"]
+    tier = "standard"
+
+    pool {
+        type  = "g6-standard-2"
+        count = 2
+        disk_encryption = "disabled"
+    }
+
+    pool {
+        type = "g6-standard-1"
+        count = 1
+        disk_encryption = "enabled"
+    }
+}
+
+{{ end }}
+

--- a/linode/lke/tmpl/template.go
+++ b/linode/lke/tmpl/template.go
@@ -198,3 +198,8 @@ func DiskEncryptionPools(t testing.TB, name, version, region string) string {
 	return acceptance.ExecuteTemplate(t,
 		"lke_pools_disk_encryption", TemplateData{Label: name, K8sVersion: version, Region: region})
 }
+
+func DiskEncryptionPoolsUpdated(t testing.TB, name, version, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_pools_disk_encryption_updated", TemplateData{Label: name, K8sVersion: version, Region: region})
+}

--- a/linode/lke/tmpl/template.go
+++ b/linode/lke/tmpl/template.go
@@ -193,3 +193,8 @@ func TierConditionalWithUpdateStrategy(t testing.TB, name, version, region, tier
 		TemplateData{Label: name, K8sVersion: version, Region: region, Tier: tier, UpdateStrategy: updateStrategy},
 	)
 }
+
+func DiskEncryptionPools(t testing.TB, name, version, region string) string {
+	return acceptance.ExecuteTemplate(t,
+		"lke_pools_disk_encryption", TemplateData{Label: name, K8sVersion: version, Region: region})
+}


### PR DESCRIPTION
## 📝 Description

Updated `disk_encryption` field in LKE Cluster pool field to be optional + computed so that users can set it upon creation (not updates).

## ✔️ How to Test

### Unit Testing
`make test-unit`

### Integration Testing
`make test-int PKG_NAME="lke" TEST_CASE="TestAccResourceLKECluster_poolDiskEncryption"`


### Manual Testing
In a sandbox environment (i.e. DX Devenv), run the following config:

```
resource "linode_lke_cluster" "test" {
  label       = "disk-encryption-test"
  region      = "us-east"
  k8s_version = "1.35"

  pool {
    type  = "g6-standard-1"
    count = 1
    disk_encryption = "enabled"
  }
}
```

Confirm that the LKE Node Pool in the cluster has disk encryption enabled. Then, try to set `disk_encryption` to disabled and verify that the pool is recreated (without destroying the LKE Cluster), since `disk_encryption` cannot be updated on an LKE Node Pool.