### PR TITLE
Fixed integration tests broken by SLADE/CLEO changes

### DIFF
--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -220,6 +220,7 @@ func TestAccDataSourceInstances_explicitInterfaceGeneration(t *testing.T) {
 
 	resName := "data.linode_instances.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	firstInstancePath := tfjsonpath.New("instances").AtSliceIndex(0)
 
@@ -237,6 +238,7 @@ func TestAccDataSourceInstances_explicitInterfaceGeneration(t *testing.T) {
 					acceptance.TestImageLatest,
 					linodego.GenerationLinode,
 					false,
+					rootPass,
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -358,6 +358,7 @@ func TestAccResourceInstance_interfaces(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -366,7 +367,7 @@ func TestAccResourceInstance_interfaces(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Interfaces(t, instanceName, testRegion),
+				Config: tmpl.Interfaces(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -382,7 +383,7 @@ func TestAccResourceInstance_interfaces(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.InterfacesUpdate(t, instanceName, testRegion),
+				Config: tmpl.InterfacesUpdate(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "2"),
 
@@ -393,7 +394,7 @@ func TestAccResourceInstance_interfaces(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.InterfacesUpdateEmpty(t, instanceName, testRegion),
+				Config: tmpl.InterfacesUpdateEmpty(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "config.0.interface.#", "1"),
 				),
@@ -402,7 +403,7 @@ func TestAccResourceInstance_interfaces(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk", "migration_type", "firewall_id"},
+				ImportStateVerifyIgnore: []string{"root_pass", "image", "interface", "resize_disk", "migration_type", "firewall_id"},
 			},
 		},
 	})
@@ -944,6 +945,7 @@ func TestAccResourceInstance_privateImage(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -952,7 +954,7 @@ func TestAccResourceInstance_privateImage(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.PrivateImage(t, instanceName, testRegion),
+				Config: tmpl.PrivateImage(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -960,9 +962,9 @@ func TestAccResourceInstance_privateImage(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "region", testRegion),
 					resource.TestCheckResourceAttr(resName, "group", "tf_test"),
 					checkInstanceDisks(&instance,
-						testDisk("boot", testDiskSize(1000)),
-						testDisk("swap", testDiskSize(800)),
-						testDisk("logs", testDiskSize(600)),
+						testDisk("boot", testDiskSize(2200)),
+						testDisk("swap", testDiskSize(512)),
+						testDisk("logs", testDiskSize(512)),
 					),
 				),
 			},
@@ -1907,6 +1909,7 @@ func TestAccResourceInstance_stackScriptInstance(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1915,7 +1918,7 @@ func TestAccResourceInstance_stackScriptInstance(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.StackScript(t, instanceName, testRegion),
+				Config: tmpl.StackScript(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -1942,6 +1945,7 @@ func TestAccResourceInstance_diskImageUpdate(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -1950,13 +1954,13 @@ func TestAccResourceInstance_diskImageUpdate(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DiskBootImage(t, instanceName, acceptance.TestImagePrevious, testRegion),
+				Config: tmpl.DiskBootImage(t, instanceName, acceptance.TestImagePrevious, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName)),
 			},
 			{
-				Config: tmpl.DiskBootImage(t, instanceName, acceptance.TestImageLatest, testRegion),
+				Config: tmpl.DiskBootImage(t, instanceName, acceptance.TestImageLatest, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2010,6 +2014,7 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 	// oldDiskSize := 0
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2019,7 +2024,7 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create an initial instance
 			{
-				Config: tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", testRegion, true),
+				Config: tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", testRegion, true, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2028,7 +2033,7 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 			},
 			// Upsize the instance and disk
 			{
-				Config: tmpl.TypeChangeDisk(t, instanceName, "g6-standard-1", testRegion, true),
+				Config: tmpl.TypeChangeDisk(t, instanceName, "g6-standard-1", testRegion, true, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2037,7 +2042,7 @@ func TestAccResourceInstance_typeChangeDiskImplicit(t *testing.T) {
 			},
 			// Attempt a downsize
 			{
-				Config:      tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", testRegion, true),
+				Config:      tmpl.TypeChangeDisk(t, instanceName, "g6-nanode-1", testRegion, true, rootPass),
 				ExpectError: regexp.MustCompile("Did you try to resize a linode with implicit"),
 			},
 		},
@@ -2134,6 +2139,7 @@ func TestAccResourceInstance_powerStateUpdates(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2142,7 +2148,7 @@ func TestAccResourceInstance_powerStateUpdates(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.BootState(t, instanceName, testRegion, false),
+				Config: tmpl.BootState(t, instanceName, testRegion, false, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2150,7 +2156,7 @@ func TestAccResourceInstance_powerStateUpdates(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.BootState(t, instanceName, testRegion, true),
+				Config: tmpl.BootState(t, instanceName, testRegion, true, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2158,7 +2164,7 @@ func TestAccResourceInstance_powerStateUpdates(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.BootState(t, instanceName, testRegion, false),
+				Config: tmpl.BootState(t, instanceName, testRegion, false, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2167,7 +2173,7 @@ func TestAccResourceInstance_powerStateUpdates(t *testing.T) {
 			},
 			// Ensure an implicit reboot isn't triggered when booted == false
 			{
-				Config: tmpl.BootStateInterface(t, instanceName, testRegion, false),
+				Config: tmpl.BootStateInterface(t, instanceName, testRegion, false, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2196,7 +2202,7 @@ func TestAccResourceInstance_powerStateUpdates(t *testing.T) {
 						t.Fatal("found reboot event when no reboot was expected")
 					}
 				},
-				Config: tmpl.BootStateInterface(t, instanceName, testRegion, false),
+				Config: tmpl.BootStateInterface(t, instanceName, testRegion, false, rootPass),
 			},
 		},
 	})
@@ -2276,6 +2282,7 @@ func TestAccResourceInstance_powerStateBooted(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2284,7 +2291,7 @@ func TestAccResourceInstance_powerStateBooted(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.BootState(t, instanceName, testRegion, true),
+				Config: tmpl.BootState(t, instanceName, testRegion, true, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2517,6 +2524,7 @@ func TestAccResourceInstance_VPCInterface(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf-test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	acceptance.RunTestWithRetries(t, 3, func(t *acceptance.WrappedT) {
 		resource.Test(t, resource.TestCase{
@@ -2526,7 +2534,7 @@ func TestAccResourceInstance_VPCInterface(t *testing.T) {
 
 			Steps: []resource.TestStep{
 				{
-					Config: tmpl.VPCInterface(t, instanceName, testRegion),
+					Config: tmpl.VPCInterface(t, instanceName, testRegion, rootPass),
 					Check: resource.ComposeTestCheckFunc(
 						acceptance.CheckInstanceExists(resName, &instance),
 						resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2545,6 +2553,7 @@ func TestAccResourceInstance_VPCInterface(t *testing.T) {
 					ImportState:       true,
 					ImportStateVerify: true,
 					ImportStateVerifyIgnore: []string{
+						"root_pass",
 						"image",
 						"interface",
 						"resize_disk",
@@ -2566,6 +2575,7 @@ func TestAccResourceInstance_VPCPublicInterfacesAddRemoveSwap(t *testing.T) {
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf-test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2574,7 +2584,7 @@ func TestAccResourceInstance_VPCPublicInterfacesAddRemoveSwap(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.PublicInterface(t, instanceName, testRegion),
+				Config: tmpl.PublicInterface(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2585,7 +2595,7 @@ func TestAccResourceInstance_VPCPublicInterfacesAddRemoveSwap(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.PublicAndVPCInterfaces(t, instanceName, testRegion),
+				Config: tmpl.PublicAndVPCInterfaces(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2600,10 +2610,10 @@ func TestAccResourceInstance_VPCPublicInterfacesAddRemoveSwap(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk", "migration_type", "firewall_id"},
+				ImportStateVerifyIgnore: []string{"root_pass", "image", "interface", "resize_disk", "migration_type", "firewall_id"},
 			},
 			{
-				Config: tmpl.VPCAndPublicInterfaces(t, instanceName, testRegion),
+				Config: tmpl.VPCAndPublicInterfaces(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2615,7 +2625,7 @@ func TestAccResourceInstance_VPCPublicInterfacesAddRemoveSwap(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.PublicInterface(t, instanceName, testRegion),
+				Config: tmpl.PublicInterface(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
@@ -2629,7 +2639,7 @@ func TestAccResourceInstance_VPCPublicInterfacesAddRemoveSwap(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"image", "interface", "resize_disk", "migration_type", "firewall_id"},
+				ImportStateVerifyIgnore: []string{"root_pass", "image", "interface", "resize_disk", "migration_type", "firewall_id"},
 			},
 		},
 	})
@@ -2926,6 +2936,7 @@ func TestAccResourceInstance_interfaceGenerationLegacy(t *testing.T) {
 
 	resName := "linode_instance.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2940,6 +2951,7 @@ func TestAccResourceInstance_interfaceGenerationLegacy(t *testing.T) {
 					true,
 					linodego.GenerationLegacyConfig,
 					nil,
+					rootPass,
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -2985,6 +2997,7 @@ func TestAccResourceInstance_interfaceGenerationLinode(t *testing.T) {
 
 	resName := "linode_instance.foobar"
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -2999,6 +3012,7 @@ func TestAccResourceInstance_interfaceGenerationLinode(t *testing.T) {
 					true,
 					linodego.GenerationLinode,
 					linodego.Pointer(true),
+					rootPass,
 				),
 				ExpectError: regexp.MustCompile(
 					"The Linode must have at least 1 interface defined to boot",
@@ -3012,6 +3026,7 @@ func TestAccResourceInstance_interfaceGenerationLinode(t *testing.T) {
 					false,
 					linodego.GenerationLinode,
 					linodego.Pointer(true),
+					rootPass,
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(

--- a/linode/instance/tmpl/template.go
+++ b/linode/instance/tmpl/template.go
@@ -147,30 +147,33 @@ func MaintenancePolicy(t testing.TB, label, pubKey, region, rootPass, maintenanc
 		})
 }
 
-func Interfaces(t testing.TB, label, region string) string {
+func Interfaces(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_interfaces", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func InterfacesUpdate(t testing.TB, label, region string) string {
+func InterfacesUpdate(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_interfaces_update", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func InterfacesUpdateEmpty(t testing.TB, label, region string) string {
+func InterfacesUpdateEmpty(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_interfaces_update_empty", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -181,6 +184,7 @@ func ExplicitInterfaceGeneration(
 	booted bool,
 	generation linodego.InterfaceGeneration,
 	networkHelper *bool,
+	rootPass string,
 ) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_explicit_interface_generation", TemplateData{
@@ -190,6 +194,7 @@ func ExplicitInterfaceGeneration(
 			InterfaceGeneration: generation,
 			NetworkHelper:       networkHelper,
 			Booted:              booted,
+			RootPass:            rootPass,
 		})
 }
 
@@ -435,12 +440,13 @@ func DiskConfigDeviceBlockExt(t testing.TB, label, instanceType, region string, 
 		})
 }
 
-func DiskBootImage(t testing.TB, label, image, region string) string {
+func DiskBootImage(t testing.TB, label, image, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_disk_boot_image", TemplateData{
-			Label:  label,
-			Image:  image,
-			Region: region,
+			Label:    label,
+			Image:    image,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -455,12 +461,13 @@ func VolumeConfig(t testing.TB, label, pubKey, region string, rootPass string) s
 		})
 }
 
-func PrivateImage(t testing.TB, label, region string) string {
+func PrivateImage(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_private_image", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -514,12 +521,13 @@ func DiskAuthorizedKeysEmpty(t testing.TB, label, region string, rootPass string
 		})
 }
 
-func StackScript(t testing.TB, label, region string) string {
+func StackScript(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_stackscript", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -534,13 +542,14 @@ func DiskStackScript(t testing.TB, label, pubKey, region string, rootPass string
 		})
 }
 
-func BootState(t testing.TB, label, region string, booted bool) string {
+func BootState(t testing.TB, label, region string, booted bool, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_boot_state", TemplateData{
-			Label:  label,
-			Image:  acceptance.TestImageLatest,
-			Booted: booted,
-			Region: region,
+			Label:    label,
+			Image:    acceptance.TestImageLatest,
+			Booted:   booted,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -553,13 +562,14 @@ func BootStateNoImage(t testing.TB, label, region string, booted bool) string {
 		})
 }
 
-func BootStateInterface(t testing.TB, label, region string, booted bool) string {
+func BootStateInterface(t testing.TB, label, region string, booted bool, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_boot_state_interface", TemplateData{
-			Label:  label,
-			Booted: booted,
-			Image:  acceptance.TestImageLatest,
-			Region: region,
+			Label:    label,
+			Booted:   booted,
+			Image:    acceptance.TestImageLatest,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
@@ -574,7 +584,7 @@ func BootStateConfig(t testing.TB, label, region string, booted bool, rootPass s
 		})
 }
 
-func TypeChangeDisk(t testing.TB, label, instanceType, region string, resizeDisk bool) string {
+func TypeChangeDisk(t testing.TB, label, instanceType, region string, resizeDisk bool, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_type_change_disk", TemplateData{
 			Label:      label,
@@ -582,6 +592,7 @@ func TypeChangeDisk(t testing.TB, label, instanceType, region string, resizeDisk
 			Image:      acceptance.TestImageLatest,
 			ResizeDisk: resizeDisk,
 			Region:     region,
+			RootPass:   rootPass,
 		})
 }
 
@@ -778,6 +789,7 @@ func DataExplicitInterfaceGeneration(
 	image string,
 	generation linodego.InterfaceGeneration,
 	booted bool,
+	rootPass string,
 ) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_data_explicit_interface_generation", TemplateData{
@@ -786,6 +798,7 @@ func DataExplicitInterfaceGeneration(
 			Image:               image,
 			InterfaceGeneration: generation,
 			Booted:              booted,
+			RootPass:            rootPass,
 		})
 }
 
@@ -799,39 +812,43 @@ func FirewallOnCreation(t testing.TB, label, region string, rootPass string) str
 		})
 }
 
-func VPCInterface(t testing.TB, label, region string) string {
+func VPCInterface(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_vpc_interface", TemplateData{
-			Label:  label,
-			Region: region,
-			Image:  acceptance.TestImageLatest,
+			Label:    label,
+			Region:   region,
+			Image:    acceptance.TestImageLatest,
+			RootPass: rootPass,
 		})
 }
 
-func VPCAndPublicInterfaces(t testing.TB, label, region string) string {
+func VPCAndPublicInterfaces(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_vpc_public_interface", TemplateData{
-			Label:  label,
-			Region: region,
-			Image:  acceptance.TestImageLatest,
+			Label:    label,
+			Region:   region,
+			Image:    acceptance.TestImageLatest,
+			RootPass: rootPass,
 		})
 }
 
-func PublicAndVPCInterfaces(t testing.TB, label, region string) string {
+func PublicAndVPCInterfaces(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_public_vpc_interface", TemplateData{
-			Label:  label,
-			Region: region,
-			Image:  acceptance.TestImageLatest,
+			Label:    label,
+			Region:   region,
+			Image:    acceptance.TestImageLatest,
+			RootPass: rootPass,
 		})
 }
 
-func PublicInterface(t testing.TB, label, region string) string {
+func PublicInterface(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_public_interface", TemplateData{
-			Label:  label,
-			Region: region,
-			Image:  acceptance.TestImageLatest,
+			Label:    label,
+			Region:   region,
+			Image:    acceptance.TestImageLatest,
+			RootPass: rootPass,
 		})
 }
 

--- a/linode/instance/tmpl/templates/config_interfaces_vpc_ipv6.gotf
+++ b/linode/instance/tmpl/templates/config_interfaces_vpc_ipv6.gotf
@@ -41,6 +41,7 @@ resource "linode_instance" "foobar" {
         label = "primary"
         size = 8192
         image = "linode/arch"
+        root_pass = "{{ .RootPass }}"
     }
 
 

--- a/linode/instance/tmpl/templates/data_interfaces_vpc_ipv6.gotf
+++ b/linode/instance/tmpl/templates/data_interfaces_vpc_ipv6.gotf
@@ -16,6 +16,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "vpc"

--- a/linode/instance/tmpl/templates/disk_boot_image.gotf
+++ b/linode/instance/tmpl/templates/disk_boot_image.gotf
@@ -12,6 +12,7 @@ resource "linode_instance" "foobar" {
         size = 5000
         filesystem = "ext4"
         image = "{{.Image}}"
+        root_pass = "{{ .RootPass }}"
     }
     disk {
         label = "swap"

--- a/linode/instance/tmpl/templates/explicit_interface_generation.gotf
+++ b/linode/instance/tmpl/templates/explicit_interface_generation.gotf
@@ -7,6 +7,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     image = "{{.Image}}"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
     booted = {{ .Booted }}
 

--- a/linode/instance/tmpl/templates/interfaces.gotf
+++ b/linode/instance/tmpl/templates/interfaces.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "vlan"

--- a/linode/instance/tmpl/templates/interfaces_update.gotf
+++ b/linode/instance/tmpl/templates/interfaces_update.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "public"

--- a/linode/instance/tmpl/templates/interfaces_update_empty.gotf
+++ b/linode/instance/tmpl/templates/interfaces_update_empty.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "vlan"

--- a/linode/instance/tmpl/templates/interfaces_vpc_ipv6_0.gotf
+++ b/linode/instance/tmpl/templates/interfaces_vpc_ipv6_0.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "vpc"

--- a/linode/instance/tmpl/templates/interfaces_vpc_ipv6_1.gotf
+++ b/linode/instance/tmpl/templates/interfaces_vpc_ipv6_1.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "vpc"

--- a/linode/instance/tmpl/templates/power_state.gotf
+++ b/linode/instance/tmpl/templates/power_state.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     group = "tf_test"
     type = "g6-nanode-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     booted = {{.Booted}}
 
     interface {

--- a/linode/instance/tmpl/templates/power_state_interface.gotf
+++ b/linode/instance/tmpl/templates/power_state_interface.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     group = "tf_test"
     type = "g6-nanode-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     booted = {{.Booted}}
 
     interface {

--- a/linode/instance/tmpl/templates/private_image.gotf
+++ b/linode/instance/tmpl/templates/private_image.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar-orig" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "linode/arch"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 
@@ -25,18 +26,19 @@ resource "linode_instance" "foobar" {
     region = "{{ .Region }}"
     disk {
         label = "boot"
-        size = 1000
+        size = 2200
         filesystem = "ext4"
         image = "${linode_image.foobar.id}"
+        root_pass = "{{ .RootPass }}"
     }
     disk {
         label = "swap"
-        size = 800
+        size = 512
         filesystem = "ext4"
     }
     disk {
         label = "logs"
-        size = 600
+        size = 512
         filesystem = "ext4"
     }
     firewall_id = linode_firewall.e2e_test_firewall.id

--- a/linode/instance/tmpl/templates/public_interface.gotf
+++ b/linode/instance/tmpl/templates/public_interface.gotf
@@ -18,6 +18,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{ .Image }}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "public"

--- a/linode/instance/tmpl/templates/public_vpc_interface.gotf
+++ b/linode/instance/tmpl/templates/public_vpc_interface.gotf
@@ -18,6 +18,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{ .Image }}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "public"

--- a/linode/instance/tmpl/templates/stackscript.gotf
+++ b/linode/instance/tmpl/templates/stackscript.gotf
@@ -25,6 +25,7 @@ resource "linode_instance" "foobar" {
         "hello" = "cool"
     }
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
 
     firewall_id = linode_firewall.e2e_test_firewall.id
 }

--- a/linode/instance/tmpl/templates/type_change_disk.gotf
+++ b/linode/instance/tmpl/templates/type_change_disk.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     type = "{{.Type}}"
     region = "{{ .Region }}"
     image = "{{.Image}}"
+    root_pass = "{{ .RootPass }}"
     resize_disk = true
     firewall_id = linode_firewall.e2e_test_firewall.id
 }

--- a/linode/instance/tmpl/templates/vpc_interface.gotf
+++ b/linode/instance/tmpl/templates/vpc_interface.gotf
@@ -20,6 +20,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{ .Image }}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "vpc"

--- a/linode/instance/tmpl/templates/vpc_public_interface.gotf
+++ b/linode/instance/tmpl/templates/vpc_public_interface.gotf
@@ -18,6 +18,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "{{ .Image }}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose = "vpc"

--- a/linode/instanceip/resource_test.go
+++ b/linode/instanceip/resource_test.go
@@ -32,13 +32,15 @@ func TestAccInstanceIP_basic(t *testing.T) {
 	var instance linodego.Instance
 
 	name := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Basic(t, name, testRegion, true),
+				Config: tmpl.Basic(t, name, testRegion, true, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
 					resource.TestCheckResourceAttrSet(testInstanceIPResName, "address"),
@@ -54,7 +56,7 @@ func TestAccInstanceIP_basic(t *testing.T) {
 				PreConfig: func() {
 					acceptance.AssertInstanceReboot(t, true, &instance)
 				},
-				Config: tmpl.Basic(t, name, testRegion, true),
+				Config: tmpl.Basic(t, name, testRegion, true, rootPass),
 			},
 		},
 	})
@@ -66,13 +68,15 @@ func TestAccInstanceIP_noboot(t *testing.T) {
 	var instance linodego.Instance
 
 	name := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.NoBoot(t, name, testRegion, true),
+				Config: tmpl.NoBoot(t, name, testRegion, true, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
 					resource.TestCheckResourceAttrSet(testInstanceIPResName, "address"),
@@ -85,7 +89,7 @@ func TestAccInstanceIP_noboot(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.NoBoot(t, name, testRegion, true),
+				Config: tmpl.NoBoot(t, name, testRegion, true, rootPass),
 				PreConfig: func() {
 					acceptance.AssertInstanceReboot(t, false, &instance)
 				},
@@ -100,13 +104,15 @@ func TestAccInstanceIP_noApply(t *testing.T) {
 	var instance linodego.Instance
 
 	name := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Basic(t, name, testRegion, false),
+				Config: tmpl.Basic(t, name, testRegion, false, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
 					resource.TestCheckResourceAttrSet(testInstanceIPResName, "address"),
@@ -122,7 +128,7 @@ func TestAccInstanceIP_noApply(t *testing.T) {
 				PreConfig: func() {
 					acceptance.AssertInstanceReboot(t, false, &instance)
 				},
-				Config: tmpl.Basic(t, name, testRegion, false),
+				Config: tmpl.Basic(t, name, testRegion, false, rootPass),
 			},
 		},
 	})

--- a/linode/instanceip/tmpl/basic.gotf
+++ b/linode/instanceip/tmpl/basic.gotf
@@ -6,6 +6,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "linode/debian12"
+    root_pass = "{{ .RootPass }}"
 }
 
 resource "linode_instance_ip" "test" {

--- a/linode/instanceip/tmpl/template.go
+++ b/linode/instanceip/tmpl/template.go
@@ -10,22 +10,25 @@ type TemplateData struct {
 	Label            string
 	ApplyImmediately bool
 	Region           string
+	RootPass         string
 }
 
-func Basic(t testing.TB, instanceLabel, region string, applyImmediately bool) string {
+func Basic(t testing.TB, instanceLabel, region string, applyImmediately bool, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_ip_basic", TemplateData{
 			Label:            instanceLabel,
 			ApplyImmediately: applyImmediately,
 			Region:           region,
+			RootPass:         rootPass,
 		})
 }
 
-func NoBoot(t testing.TB, instanceLabel, region string, applyImmediately bool) string {
+func NoBoot(t testing.TB, instanceLabel, region string, applyImmediately bool, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_ip_no_boot", TemplateData{
 			Label:            instanceLabel,
 			ApplyImmediately: applyImmediately,
 			Region:           region,
+			RootPass:         rootPass,
 		})
 }

--- a/linode/instancenetworking/framework_datasource_test.go
+++ b/linode/instancenetworking/framework_datasource_test.go
@@ -35,16 +35,17 @@ func TestAccDataSourceInstanceNetworking_basic(t *testing.T) {
 	var instance linodego.Instance
 
 	name := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataBasic(t, name, testRegion),
+				Config: tmpl.DataBasic(t, name, testRegion, rootPass),
 			},
 			{
-				Config: tmpl.DataBasic(t, name, testRegion),
+				Config: tmpl.DataBasic(t, name, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
 					resource.TestCheckResourceAttrSet(testInstanceNetworkResName, "ipv4.0.private.#"),
@@ -65,16 +66,17 @@ func TestAccDataSourceInstanceNetworking_vpc(t *testing.T) {
 
 	instanceVPCIP := "10.0.0.3"
 	name := acctest.RandomWithPrefix("tf-test")
+	rootPass := acctest.RandString(16) + "!A1a"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataVPC(t, name, testRegion, "10.0.0.0/24", instanceVPCIP),
+				Config: tmpl.DataVPC(t, name, testRegion, "10.0.0.0/24", instanceVPCIP, rootPass),
 			},
 			{
-				Config: tmpl.DataVPC(t, name, testRegion, "10.0.0.0/24", instanceVPCIP),
+				Config: tmpl.DataVPC(t, name, testRegion, "10.0.0.0/24", instanceVPCIP, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(testInstanceNetworkResName, "ipv4.0.vpc.#"),
 					resource.TestCheckResourceAttr(testInstanceNetworkResName, "ipv4.0.vpc.0.address", instanceVPCIP),
@@ -90,16 +92,17 @@ func TestAccDataSourceInstanceNetworking_basicwithReseved(t *testing.T) {
 	var instance linodego.Instance
 
 	name := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataBasic_withReservedField(t, name, testRegion),
+				Config: tmpl.DataBasic_withReservedField(t, name, testRegion, rootPass),
 			},
 			{
-				Config: tmpl.DataBasic_withReservedField(t, name, testRegion),
+				Config: tmpl.DataBasic_withReservedField(t, name, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
 					resource.TestCheckResourceAttrSet(testInstanceNetworkResName, "ipv4.0.private.#"),

--- a/linode/instancenetworking/tmpl/data_basic.gotf
+++ b/linode/instancenetworking/tmpl/data_basic.gotf
@@ -5,6 +5,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "linode/debian12"
+    root_pass = "{{ .RootPass }}"
 }
 
 data "linode_instance_networking" "test" {

--- a/linode/instancenetworking/tmpl/data_basic_reserved.gotf
+++ b/linode/instancenetworking/tmpl/data_basic_reserved.gotf
@@ -5,6 +5,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "linode/debian12"
+    root_pass = "{{ .RootPass }}"
 }
 
 resource "linode_networking_ip" "reserved_ip" {

--- a/linode/instancenetworking/tmpl/data_vpc.gotf
+++ b/linode/instancenetworking/tmpl/data_vpc.gotf
@@ -7,6 +7,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "linode/debian12"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         purpose   = "vpc"

--- a/linode/instancenetworking/tmpl/template.go
+++ b/linode/instancenetworking/tmpl/template.go
@@ -9,33 +9,37 @@ import (
 type TemplateData struct {
 	Label         string
 	Region        string
+	RootPass      string
 	IPv4          string
 	InterfaceIPv4 string
 }
 
-func DataBasic(t testing.TB, instanceLabel, region string) string {
+func DataBasic(t testing.TB, instanceLabel, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_networking_data_basic", TemplateData{
-			Label:  instanceLabel,
-			Region: region,
+			Label:    instanceLabel,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func DataVPC(t testing.TB, label, region, subnetIPv4, interfaceIPv4 string) string {
+func DataVPC(t testing.TB, label, region, subnetIPv4, interfaceIPv4, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_networking_data_vpc", TemplateData{
 			Label:         label,
 			Region:        region,
+			RootPass:      rootPass,
 			IPv4:          subnetIPv4,
 			InterfaceIPv4: interfaceIPv4,
 		})
 }
 
-func DataBasic_withReservedField(t *testing.T, instanceLabel, region string) string {
+func DataBasic_withReservedField(t *testing.T, instanceLabel, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_networking_data_basic_with_reserved", TemplateData{
-			Label:  instanceLabel,
-			Region: region,
+			Label:    instanceLabel,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 

--- a/linode/networkingip/framework_datasource_test.go
+++ b/linode/networkingip/framework_datasource_test.go
@@ -36,6 +36,7 @@ func TestAccDataSourceNetworkingIP_basic(t *testing.T) {
 	dataResourceName := "data.linode_networking_ip.foobar"
 
 	label := acctest.RandomWithPrefix("tf-test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -43,10 +44,10 @@ func TestAccDataSourceNetworkingIP_basic(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataBasic(t, label, testRegion),
+				Config: tmpl.DataBasic(t, label, testRegion, rootPass),
 			},
 			{
-				Config: tmpl.DataBasic(t, label, testRegion),
+				Config: tmpl.DataBasic(t, label, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					// statechecks can't compare int linode_id with string id without implementing a custom comparer.
 					// Keep this legacy check for now.

--- a/linode/networkingip/tmpl/data_basic.gotf
+++ b/linode/networkingip/tmpl/data_basic.gotf
@@ -13,6 +13,7 @@ resource "linode_instance" "foobar" {
     image = "linode/arch"
     type = "g6-standard-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/networkingip/tmpl/template.go
+++ b/linode/networkingip/tmpl/template.go
@@ -9,13 +9,14 @@ import (
 type TemplateData struct {
 	Label               string
 	Region              string
+	RootPass            string
 	AssignedLinodeIndex int
 	Reserved            bool
 }
 
-func DataBasic(t testing.TB, label, region string) string {
+func DataBasic(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
-		"networking_ip_data_basic", TemplateData{Label: label, Region: region})
+		"networking_ip_data_basic", TemplateData{Label: label, Region: region, RootPass: rootPass})
 }
 
 func NetworkingIPReservedAssigned(

--- a/linode/rdns/resource_test.go
+++ b/linode/rdns/resource_test.go
@@ -62,6 +62,7 @@ func TestAccResourceRDNS_basic(t *testing.T) {
 
 	resName := "linode_rdns.foobar"
 	linodeLabel := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -70,7 +71,7 @@ func TestAccResourceRDNS_basic(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Basic(t, linodeLabel, testRegion, false),
+				Config: tmpl.Basic(t, linodeLabel, testRegion, rootPass, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkRDNSExists,
 					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`.nip.io$`)),
@@ -91,6 +92,7 @@ func TestAccResourceRDNS_update(t *testing.T) {
 
 	label := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_rdns.foobar"
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -99,7 +101,7 @@ func TestAccResourceRDNS_update(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Basic(t, label, testRegion, false),
+				Config: tmpl.Basic(t, label, testRegion, rootPass, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkRDNSExists,
 					resource.TestCheckResourceAttrPair(resName, "address", "linode_instance.foobar", "ip_address"),
@@ -107,17 +109,17 @@ func TestAccResourceRDNS_update(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.Changed(t, label, testRegion, false),
+				Config: tmpl.Changed(t, label, testRegion, rootPass, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkRDNSExists,
 					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`([0-9]{1,3}\-){3}[0-9]{1,3}.nip.io$`)),
 				),
 			},
 			{
-				Config: tmpl.Deleted(t, label, testRegion),
+				Config: tmpl.Deleted(t, label, testRegion, rootPass),
 			},
 			{
-				Config: tmpl.Deleted(t, label, testRegion),
+				Config: tmpl.Deleted(t, label, testRegion, rootPass),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("data.linode_networking_ip.foobar", "rdns", regexp.MustCompile(`.ip.linodeusercontent.com$`)),
 				),
@@ -132,6 +134,7 @@ func TestAccResourceRDNS_waitForAvailable(t *testing.T) {
 
 	label := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_rdns.foobar"
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -140,7 +143,7 @@ func TestAccResourceRDNS_waitForAvailable(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.Basic(t, label, testRegion, true),
+				Config: tmpl.Basic(t, label, testRegion, rootPass, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkRDNSExists,
 					resource.TestCheckResourceAttrPair(resName, "address", "linode_instance.foobar", "ip_address"),
@@ -148,17 +151,17 @@ func TestAccResourceRDNS_waitForAvailable(t *testing.T) {
 				),
 			},
 			{
-				Config: tmpl.Changed(t, label, testRegion, true),
+				Config: tmpl.Changed(t, label, testRegion, rootPass, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkRDNSExists,
 					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`([0-9]{1,3}\-){3}[0-9]{1,3}.nip.io$`)),
 				),
 			},
 			{
-				Config: tmpl.Deleted(t, label, testRegion),
+				Config: tmpl.Deleted(t, label, testRegion, rootPass),
 			},
 			{
-				Config: tmpl.Deleted(t, label, testRegion),
+				Config: tmpl.Deleted(t, label, testRegion, rootPass),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("data.linode_networking_ip.foobar", "rdns", regexp.MustCompile(`.ip.linodeusercontent.com$`)),
 				),
@@ -172,6 +175,7 @@ func TestAccResourceRDNS_waitForAvailableWithTimeout(t *testing.T) {
 
 	resName := "linode_rdns.foobar"
 	linodeLabel := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	createTimeout := "15m"
 	updateTimeout := "15m"
@@ -183,14 +187,14 @@ func TestAccResourceRDNS_waitForAvailableWithTimeout(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.WithTimeout(t, linodeLabel, testRegion, createTimeout, updateTimeout),
+				Config: tmpl.WithTimeout(t, linodeLabel, testRegion, rootPass, createTimeout, updateTimeout),
 				Check: resource.ComposeTestCheckFunc(
 					checkRDNSExists,
 					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`.nip.io$`)),
 				),
 			},
 			{
-				Config: tmpl.WithTimeoutUpdated(t, linodeLabel, testRegion, createTimeout, updateTimeout),
+				Config: tmpl.WithTimeoutUpdated(t, linodeLabel, testRegion, rootPass, createTimeout, updateTimeout),
 				Check: resource.ComposeTestCheckFunc(
 					checkRDNSExists,
 					resource.TestMatchResourceAttr(resName, "rdns", regexp.MustCompile(`([0-9]{1,3}\-){3}[0-9]{1,3}.nip.io$`)),

--- a/linode/rdns/tmpl/basic.gotf
+++ b/linode/rdns/tmpl/basic.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     image = "linode/arch"
     type = "g6-standard-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/rdns/tmpl/changed.gotf
+++ b/linode/rdns/tmpl/changed.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     image = "linode/arch"
     type = "g6-standard-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/rdns/tmpl/deleted.gotf
+++ b/linode/rdns/tmpl/deleted.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     image = "linode/arch"
     type = "g6-standard-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/rdns/tmpl/template.go
+++ b/linode/rdns/tmpl/template.go
@@ -9,52 +9,58 @@ import (
 type TemplateData struct {
 	Label            string
 	Region           string
+	RootPass         string
 	CreateTimeout    string
 	UpdateTimeout    string
 	WaitForAvailable bool
 }
 
-func Basic(t testing.TB, label, region string, waitForAvailable bool) string {
+func Basic(t testing.TB, label, region, rootPass string, waitForAvailable bool) string {
 	return acceptance.ExecuteTemplate(t,
 		"rdns_basic", TemplateData{
 			Label:            label,
 			WaitForAvailable: waitForAvailable,
 			Region:           region,
+			RootPass:         rootPass,
 		})
 }
 
-func Changed(t testing.TB, label, region string, waitForAvailable bool) string {
+func Changed(t testing.TB, label, region, rootPass string, waitForAvailable bool) string {
 	return acceptance.ExecuteTemplate(t,
 		"rdns_changed", TemplateData{
 			Label:            label,
 			WaitForAvailable: waitForAvailable,
 			Region:           region,
+			RootPass:         rootPass,
 		})
 }
 
-func Deleted(t testing.TB, label, region string) string {
+func Deleted(t testing.TB, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"rdns_deleted", TemplateData{
-			Label:  label,
-			Region: region,
+			Label:    label,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }
 
-func WithTimeout(t testing.TB, label, region, createTimeout, updateTimeout string) string {
+func WithTimeout(t testing.TB, label, region, rootPass, createTimeout, updateTimeout string) string {
 	return acceptance.ExecuteTemplate(t,
 		"rdns_with_timeout", TemplateData{
 			Label:         label,
 			Region:        region,
+			RootPass:      rootPass,
 			CreateTimeout: createTimeout,
 			UpdateTimeout: updateTimeout,
 		})
 }
 
-func WithTimeoutUpdated(t testing.TB, label, region, createTimeout, updateTimeout string) string {
+func WithTimeoutUpdated(t testing.TB, label, region, rootPass, createTimeout, updateTimeout string) string {
 	return acceptance.ExecuteTemplate(t,
 		"rdns_with_timeout_updated", TemplateData{
 			Label:         label,
 			Region:        region,
+			RootPass:      rootPass,
 			CreateTimeout: createTimeout,
 			UpdateTimeout: updateTimeout,
 		})

--- a/linode/rdns/tmpl/with_timeout.gotf
+++ b/linode/rdns/tmpl/with_timeout.gotf
@@ -7,6 +7,7 @@ resource "linode_instance" "foobar" {
     image = "linode/arch"
     type = "g6-nanode-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/rdns/tmpl/with_timeout_updated.gotf
+++ b/linode/rdns/tmpl/with_timeout_updated.gotf
@@ -7,6 +7,7 @@ resource "linode_instance" "foobar" {
     image = "linode/arch"
     type = "g6-nanode-1"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/vlan/datasource_test.go
+++ b/linode/vlan/datasource_test.go
@@ -44,6 +44,7 @@ func TestAccDataSourceVLANs_basic(t *testing.T) {
 	vlanName := "tf-test"
 	resourceName := "data.linode_vlans.foolan"
 	label := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -51,11 +52,11 @@ func TestAccDataSourceVLANs_basic(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataBasic(t, instanceName, testRegion, vlanName, label),
+				Config: tmpl.DataBasic(t, instanceName, testRegion, vlanName, label, rootPass),
 			},
 			{
 				PreConfig: preConfigVLANPoll(t, vlanName),
-				Config:    tmpl.DataBasic(t, instanceName, testRegion, vlanName, label),
+				Config:    tmpl.DataBasic(t, instanceName, testRegion, vlanName, label, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "vlans.0.label", vlanName),
 					resource.TestCheckResourceAttr(resourceName, "vlans.0.region", testRegion),
@@ -74,6 +75,7 @@ func TestAccDataSourceVLANs_regex(t *testing.T) {
 	vlanName := "tf-test"
 	resourceName := "data.linode_vlans.foolan"
 	label := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -81,11 +83,11 @@ func TestAccDataSourceVLANs_regex(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.DataRegex(t, instanceName, testRegion, vlanName, label),
+				Config: tmpl.DataRegex(t, instanceName, testRegion, vlanName, label, rootPass),
 			},
 			{
 				PreConfig: preConfigVLANPoll(t, vlanName),
-				Config:    tmpl.DataRegex(t, instanceName, testRegion, vlanName, label),
+				Config:    tmpl.DataRegex(t, instanceName, testRegion, vlanName, label, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckResourceAttrGreaterThan(resourceName, "vlans.#", 0),
 					resource.TestCheckResourceAttr(resourceName, "vlans.0.label", vlanName),

--- a/linode/vlan/tmpl/data_basic.gotf
+++ b/linode/vlan/tmpl/data_basic.gotf
@@ -7,6 +7,7 @@ resource "linode_instance" "fooinst" {
     type = "g6-nanode-1"
     image = "linode/debian12"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         label = "{{.VLANLabel}}"

--- a/linode/vlan/tmpl/data_regex.gotf
+++ b/linode/vlan/tmpl/data_regex.gotf
@@ -7,6 +7,7 @@ resource "linode_instance" "fooinst" {
     type = "g6-nanode-1"
     image = "linode/debian12"
     region = "{{ .Region }}"
+    root_pass = "{{ .RootPass }}"
 
     interface {
         label = "{{.VLANLabel}}"

--- a/linode/vlan/tmpl/template.go
+++ b/linode/vlan/tmpl/template.go
@@ -11,34 +11,38 @@ type TemplateData struct {
 	VLANLabel string
 	Region    string
 	Label     string
+	RootPass  string
 }
 
-func DataBasic(t testing.TB, instLabel, region, vlanLabel, label string) string {
+func DataBasic(t testing.TB, instLabel, region, vlanLabel, label, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"vlan_data_basic", TemplateData{
 			InstLabel: instLabel,
 			VLANLabel: vlanLabel,
 			Region:    region,
 			Label:     label,
+			RootPass:  rootPass,
 		})
 }
 
-func DataRegex(t testing.TB, instLabel, region, vlanLabel, label string) string {
+func DataRegex(t testing.TB, instLabel, region, vlanLabel, label, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"vlan_data_regex", TemplateData{
 			InstLabel: instLabel,
 			VLANLabel: vlanLabel,
 			Region:    region,
 			Label:     label,
+			RootPass:  rootPass,
 		})
 }
 
-func DataCheckDuplicate(t testing.TB, instLabel, region, vlanLabel, label string) string {
+func DataCheckDuplicate(t testing.TB, instLabel, region, vlanLabel, label, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"vlan_data_check_duplicate", TemplateData{
 			InstLabel: instLabel,
 			VLANLabel: vlanLabel,
 			Region:    region,
 			Label:     label,
+			RootPass:  rootPass,
 		})
 }


### PR DESCRIPTION
## 📝 Description

Fixed integration tests broken by SLADE/CLEO breaking changes.

## ✔️ How to Test

* `make test-int PKG_NAME="instancenetworking" TEST_CASE="TestAccDataSourceInstanceNetworking_basic"`
* `make test-int PKG_NAME="instancenetworking" TEST_CASE="TestAccDataSourceInstanceNetworking_vpc"`
* `make test-int PKG_NAME="vlan" TEST_CASE="TestAccDataSourceVLANs"`
* `make test-int PKG_NAME="instanceip" TEST_CASE="TestAccInstanceIP"`
* `make test-int PKG_NAME="networkingip" TEST_CASE="TestAccDataSourceNetworkingIP"`
* `make test-int PKG_NAME="rdns" TEST_CASE="TestAccResourceRDNS"`
* `make test-int PKG_NAME="instance" TEST_CASE="TestAccResourceInstance"`
* `make test-int PKG_NAME="instance" TEST_CASE="TestAccDataSourceInstance"`
