### PR TITLE
TPT-4535: Fixed failing and broken integration tests

### DIFF
--- a/docs/resources/database_access_controls.md
+++ b/docs/resources/database_access_controls.md
@@ -30,7 +30,7 @@ resource "linode_instance" "my-instance" {
 
 resource "linode_database_mysql_v2" "my-db" {
   label = "mydatabase"
-  engine_id = "mysql/8.0.30"
+  engine_id = "mysql/8"
   region = "us-southeast"
   type = "g6-nanode-1"
 }

--- a/docs/resources/database_mysql_v2.md
+++ b/docs/resources/database_mysql_v2.md
@@ -116,7 +116,7 @@ Creating a MySQL database hidden behind a VPC:
 ```hcl
 resource "linode_database_mysql_v2" "foobar" {
   label = "mydatabase"
-  engine_id = "mysql/16"
+  engine_id = "mysql/8"
   region = "us-mia"
   type = "g6-nanode-1"
 

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -666,11 +666,11 @@ func GetRandomObjectStorageEndpoint() (*linodego.ObjectStorageEndpoint, error) {
 }
 
 // accountAvailabilityCaps are capabilities that must be verified both at the region level and at the account availability level.
-var accountAvailabilityCaps = map[string]bool{
-	"Linodes":       true,
-	"NodeBalancers": true,
-	"Block Storage": true,
-	"Kubernetes":    true,
+var accountAvailabilityCaps = map[linodego.RegionCapability]bool{
+	linodego.CapabilityLinodes:       true,
+	linodego.CapabilityNodeBalancers: true,
+	linodego.CapabilityBlockStorage:  true,
+	linodego.CapabilityLKE:           true,
 }
 
 // GetRegionsWithCaps returns a list of region IDs that support the given capabilities
@@ -678,7 +678,7 @@ var accountAvailabilityCaps = map[string]bool{
 // - capabilities: Required capabilities that the regions must support.
 // - siteType: The site type to filter by ("core" or "distributed" or "any").
 // - filters: Optional custom filters for additional criteria.
-func GetRegionsWithCaps(capabilities []string, regionType string, filters ...RegionFilterFunc) ([]string, error) {
+func GetRegionsWithCaps(capabilities []linodego.RegionCapability, regionType string, filters ...RegionFilterFunc) ([]string, error) {
 	client, err := GetTestClient()
 	if err != nil {
 		return nil, err
@@ -707,7 +707,7 @@ func GetRegionsWithCaps(capabilities []string, regionType string, filters ...Reg
 	}
 
 	// Determine which of the requested capabilities also require account-level checks.
-	var requiredAccountCaps []string
+	var requiredAccountCaps []linodego.RegionCapability
 	for _, c := range capabilities {
 		if accountAvailabilityCaps[c] {
 			requiredAccountCaps = append(requiredAccountCaps, c)
@@ -722,14 +722,14 @@ func GetRegionsWithCaps(capabilities []string, regionType string, filters ...Reg
 			return true
 		}
 
-		capsMap := make(map[string]bool)
+		capsMap := make(map[linodego.RegionCapability]bool)
 
 		for _, c := range region.Capabilities {
-			capsMap[strings.ToUpper(c)] = true
+			capsMap[linodego.RegionCapability(strings.ToUpper(c))] = true
 		}
 
 		for _, c := range capabilities {
-			if _, ok := capsMap[strings.ToUpper(c)]; !ok {
+			if !capsMap[linodego.RegionCapability(strings.ToUpper(string(c)))] {
 				return true
 			}
 		}
@@ -743,7 +743,7 @@ func GetRegionsWithCaps(capabilities []string, regionType string, filters ...Reg
 				return true
 			}
 			for _, c := range requiredAccountCaps {
-				if !regionAvail[c] {
+				if !regionAvail[string(c)] {
 					return true
 				}
 			}
@@ -769,7 +769,7 @@ func GetRegionsWithCaps(capabilities []string, regionType string, filters ...Reg
 }
 
 // GetRandomRegionWithCaps gets a random region given a list of region capabilities.
-func GetRandomRegionWithCaps(capabilities []string, regionType string, filters ...RegionFilterFunc) (string, error) {
+func GetRandomRegionWithCaps(capabilities []linodego.RegionCapability, regionType string, filters ...RegionFilterFunc) (string, error) {
 	regions, err := GetRegionsWithCaps(capabilities, regionType, filters...)
 	if err != nil {
 		return "", err

--- a/linode/accountavailability/datasource_test.go
+++ b/linode/accountavailability/datasource_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNodeBalancers_basic(t *testing.T) {
 
 	resourceName := "data.linode_account_availability.foobar"
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/backup/datasource_test.go
+++ b/linode/backup/datasource_test.go
@@ -18,7 +18,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -31,6 +31,9 @@ func TestAccDataSourceInstanceBackups_basic(t *testing.T) {
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
 	snapshotName := acctest.RandomWithPrefix("tf_test_cool")
+	snapshotCreateOptions := linodego.InstanceSnapshotCreateOptions{
+		Label: snapshotName,
+	}
 
 	resourceName := "data.linode_instance_backups.foobar"
 
@@ -52,7 +55,7 @@ func TestAccDataSourceInstanceBackups_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					client := acceptance.TestAccSDKv2Provider.Meta().(*helper.ProviderMeta).Client
-					newSnapshot, err := client.CreateInstanceSnapshot(context.Background(), instance.ID, snapshotName)
+					newSnapshot, err := client.CreateInstanceSnapshot(context.Background(), instance.ID, snapshotCreateOptions)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -72,7 +75,7 @@ func TestAccDataSourceInstanceBackups_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					client := acceptance.TestAccSDKv2Provider.Meta().(*helper.ProviderMeta).Client
-					if _, err := client.WaitForSnapshotStatus(context.Background(), instance.ID, snapshot.ID, linodego.SnapshotSuccessful, 1800); err != nil {
+					if _, err := client.WaitForSnapshotStatus(context.Background(), instance.ID, snapshot.ID, linodego.SnapshotSuccessful); err != nil {
 						t.Fatal(err)
 					}
 				},

--- a/linode/consumerimagesharegroupimageshares/datasource_test.go
+++ b/linode/consumerimagesharegroupimageshares/datasource_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/linodego/v2"
 	"github.com/linode/terraform-provider-linode/v3/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/v3/linode/consumerimagesharegroupimageshares/tmpl"
 )
@@ -50,7 +51,7 @@ func TestAccDataSourceImageShareGroupImageShares_basic(t *testing.T) {
 	fwLabel := acctest.RandomWithPrefix("tf_test")
 	instanceLabel := acctest.RandomWithPrefix("tf_test")
 
-	instanceRegion, err := acceptance.GetRandomRegionWithCaps([]string{}, "core")
+	instanceRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/databaseaccesscontrols/resource_test.go
+++ b/linode/databaseaccesscontrols/resource_test.go
@@ -45,7 +45,7 @@ func init() {
 
 	postgresEngineVersion = v.ID
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityDBAAS}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityDBAAS}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/databasemysqlv2/framework_resource_test.go
+++ b/linode/databasemysqlv2/framework_resource_test.go
@@ -271,7 +271,7 @@ func TestAccResourceDatabaseMysqlV2_resize(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members", "allow_list"},
 			},
 		},
 	})
@@ -405,7 +405,7 @@ func TestAccResourceDatabaseMysqlV2_complex(t *testing.T) {
 				ResourceName:            resName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members"},
+				ImportStateVerifyIgnore: []string{"updated", "oldest_restore_time", "members", "allow_list"},
 			},
 		},
 	})

--- a/linode/databasemysqlv2/framework_resource_test.go
+++ b/linode/databasemysqlv2/framework_resource_test.go
@@ -33,7 +33,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityDBAAS, linodego.CapabilityVPCs}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityDBAAS, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/databasepostgresqlv2/datasource_test.go
+++ b/linode/databasepostgresqlv2/datasource_test.go
@@ -94,7 +94,7 @@ func TestAccDataSource_engineConfig(t *testing.T) {
 				Config: tmpl.DataEngineConfig(t, tmpl.TemplateDataEngineConfig{
 					Label:    label,
 					Region:   testRegion,
-					EngineID: "postgresql/14",
+					EngineID: "postgresql/18",
 					Type:     "g6-nanode-1",
 
 					EngineConfigPGAutovacuumAnalyzeScaleFactor:         0.1,

--- a/linode/databasepostgresqlv2/framework_resource_test.go
+++ b/linode/databasepostgresqlv2/framework_resource_test.go
@@ -664,7 +664,7 @@ func TestAccResourceDatabasePostgresqlV2_engineConfig(t *testing.T) {
 					tmpl.TemplateDataEngineConfig{
 						Label:    label,
 						Region:   testRegion,
-						EngineID: "postgresql/14",
+						EngineID: "postgresql/18",
 						Type:     "g6-nanode-1",
 
 						EngineConfigPGAutovacuumAnalyzeScaleFactor:         0.1,
@@ -776,7 +776,7 @@ func TestAccResourceDatabasePostgresqlV2_engineConfig(t *testing.T) {
 					tmpl.TemplateDataEngineConfig{
 						Label:    label,
 						Region:   testRegion,
-						EngineID: "postgresql/14",
+						EngineID: "postgresql/18",
 						Type:     "g6-nanode-1",
 
 						EngineConfigPGAutovacuumAnalyzeScaleFactor:         0.5,
@@ -889,7 +889,7 @@ func TestAccResourceDatabasePostgresqlV2_engineConfig(t *testing.T) {
 					tmpl.TemplateDataEngineConfig{
 						Label:    label,
 						Region:   testRegion,
-						EngineID: "postgresql/14",
+						EngineID: "postgresql/18",
 						Type:     "g6-nanode-1",
 
 						EngineConfigPGAutovacuumAnalyzeScaleFactor: 0.7,

--- a/linode/databasepostgresqlv2/framework_resource_test.go
+++ b/linode/databasepostgresqlv2/framework_resource_test.go
@@ -33,7 +33,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityDBAAS, linodego.CapabilityVPCs}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityDBAAS, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/databases/datasource_test.go
+++ b/linode/databases/datasource_test.go
@@ -33,7 +33,7 @@ func init() {
 
 	engineVersion = v.ID
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityDBAAS}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityDBAAS}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/firewall/framework_resource_test.go
+++ b/linode/firewall/framework_resource_test.go
@@ -27,7 +27,7 @@ func init() {
 		F:    sweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityCloudFirewall, linodego.CapabilityNodeBalancers}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityCloudFirewall, linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/firewalldevice/resource_test.go
+++ b/linode/firewalldevice/resource_test.go
@@ -20,7 +20,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityCloudFirewall, linodego.CapabilityNodeBalancers}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityCloudFirewall, linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/firewalls/framework_datasource_test.go
+++ b/linode/firewalls/framework_datasource_test.go
@@ -21,7 +21,7 @@ const testFirewallDataName = "data.linode_firewalls.test"
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes, linodego.CapabilityCloudFirewall}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityCloudFirewall}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/firewallsettings/framework_resource_test.go
+++ b/linode/firewallsettings/framework_resource_test.go
@@ -41,7 +41,7 @@ func init() {
 
 	testFirewall, err := client.CreateFirewall(context.Background(), linodego.FirewallCreateOptions{
 		Label: acctest.RandomWithPrefix("tf_test"),
-		Rules: linodego.FirewallRuleSet{
+		Rules: linodego.FirewallRulesCreateOptions{
 			InboundPolicy:  "DROP",
 			OutboundPolicy: "ACCEPT",
 		},

--- a/linode/helper/databaseshared/engine.go
+++ b/linode/helper/databaseshared/engine.go
@@ -38,7 +38,30 @@ func CreateLegacyDatabaseEngineSlug(engine, version string) string {
 }
 
 func CreateDatabaseEngineSlug(engine, version string) string {
-	return fmt.Sprintf("%s/%s", engine, strings.Split(version, ".")[0])
+	parts := strings.Split(version, ".")
+
+	switch engine {
+	case "mysql":
+		if len(parts) >= 2 {
+			return fmt.Sprintf("%s/%s.%s", engine, parts[0], parts[1])
+		}
+
+		return fmt.Sprintf("%s/%s", engine, version)
+
+	case "postgresql":
+		if len(parts) >= 1 {
+			return fmt.Sprintf("%s/%s", engine, parts[0])
+		}
+
+		return fmt.Sprintf("%s/%s", engine, version)
+
+	default:
+		if len(parts) >= 1 {
+			return fmt.Sprintf("%s/%s", engine, parts[0])
+		}
+
+		return fmt.Sprintf("%s/%s", engine, version)
+	}
 }
 
 func ParseDatabaseEngineSlug(engineID string) (string, string, error) {

--- a/linode/helper/instance.go
+++ b/linode/helper/instance.go
@@ -423,8 +423,9 @@ func BootInstanceSync(
 
 	tflog.Debug(ctx, "client.BootInstance(...)")
 
-	bootInstanceOption := linodego.InstanceBootOptions{
-		ConfigID: &configID,
+	bootInstanceOption := linodego.InstanceBootOptions{}
+	if configID != 0 {
+		bootInstanceOption.ConfigID = &configID
 	}
 
 	if err := client.BootInstance(ctx, instanceID, bootInstanceOption); err != nil {

--- a/linode/iamentities/framework_datasource_test.go
+++ b/linode/iamentities/framework_datasource_test.go
@@ -23,7 +23,7 @@ func init() {
 		F:    volumeSweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityBlockStorage}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityBlockStorage}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/iamuser/framework_resource_test.go
+++ b/linode/iamuser/framework_resource_test.go
@@ -28,7 +28,7 @@ func init() {
 		F:    volumeSweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityBlockStorage}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityBlockStorage}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/image/resource_test.go
+++ b/linode/image/resource_test.go
@@ -60,7 +60,7 @@ func init() {
 		F:    sweep,
 	})
 
-	regions, err := acceptance.GetRegionsWithCaps([]string{linodego.CapabilityObjectStorage, linodego.CapabilityLinodes}, "core")
+	regions, err := acceptance.GetRegionsWithCaps([]linodego.RegionCapability{linodego.CapabilityObjectStorage, linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/images/datasource_test.go
+++ b/linode/images/datasource_test.go
@@ -16,7 +16,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/instance/datasource_test.go
+++ b/linode/instance/datasource_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 
 	// Resolve a region with support for Maintenance Policy
 	region, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityMaintenancePolicy},
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityMaintenancePolicy},
 		"core",
 	)
 	if err != nil {
@@ -105,7 +105,7 @@ func TestAccDataSourceInstances_withBlockStorageEncryption(t *testing.T) {
 
 	// Resolve a region with support for Block Storage Encryption
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityBlockStorageEncryption},
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityBlockStorageEncryption},
 		"core",
 	)
 	if err != nil {
@@ -142,7 +142,7 @@ func TestAccDataSourceInstances_withPG(t *testing.T) {
 
 	// Resolve a region with support for PGs
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup},
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup},
 		"core",
 	)
 	if err != nil {
@@ -283,7 +283,7 @@ func TestAccDataSourceInstance_interfaceVPCIPv6(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf-test")
 	rootPass := acctest.RandString(64)
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityLinodes,
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -35,7 +35,7 @@ func init() {
 		F:    sweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityLinodes, linodego.CapabilityVlans, linodego.CapabilityVPCs, linodego.CapabilityDiskEncryption,
 	}, "core")
 	if err != nil {
@@ -1105,7 +1105,7 @@ func TestAccResourceInstance_updateMaintenancePolicy(t *testing.T) {
 	t.Parallel()
 	var instance linodego.Instance
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes, linodego.CapabilityMaintenancePolicy}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityMaintenancePolicy}, "core")
 	require.NoError(t, err)
 
 	instanceName := acctest.RandomWithPrefix("tf_test")
@@ -2365,7 +2365,7 @@ func TestAccResourceInstance_userData(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityMetadata}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityMetadata}, "core")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2468,7 +2468,7 @@ func TestAccResourceInstance_firewallOnCreation(t *testing.T) {
 	var instance linodego.Instance
 	instanceName := acctest.RandomWithPrefix("tf_test")
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityCloudFirewall}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityCloudFirewall}, "core")
 	rootPass := acctest.RandString(64)
 	if err != nil {
 		t.Fatal(err)
@@ -2646,7 +2646,7 @@ func TestAccResourceInstance_migration(t *testing.T) {
 
 	// Resolve a region to migrate to
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes}, "core",
+		[]linodego.RegionCapability{linodego.CapabilityLinodes}, "core",
 		func(v linodego.Region) bool {
 			return v.ID != testRegion
 		},
@@ -2703,7 +2703,7 @@ func TestAccResourceInstance_withPG(t *testing.T) {
 
 	// Resolve a region with support for PGs
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup}, "core",
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup}, "core",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -2750,7 +2750,7 @@ func TestAccResourceInstance_pgAssignment(t *testing.T) {
 
 	// Resolve a region with support for PGs
 	testRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup}, "core",
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup}, "core",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -2840,7 +2840,7 @@ func TestAccResourceInstance_diskEncryption(t *testing.T) {
 
 	// Resolve a region that supports disk encryption
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityDiskEncryption}, "core",
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityDiskEncryption}, "core",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -3062,7 +3062,7 @@ func TestAccResourceInstance_interfaceVPCIPv6(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf-test")
 	rootPass := acctest.RandString(64)
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityLinodes,
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
@@ -3256,7 +3256,7 @@ func TestAccResourceInstance_configInterfaceVPCIPv6(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf-test")
 	rootPass := acctest.RandString(64)
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityLinodes,
 		linodego.CapabilityVPCs,
 	}, "core")

--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -36,7 +36,7 @@ func init() {
 	})
 
 	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
-		linodego.CapabilityLinodes, linodego.CapabilityVlans, linodego.CapabilityVPCs, linodego.CapabilityDiskEncryption,
+		linodego.CapabilityLinodes, linodego.CapabilityVlans, linodego.CapabilityVPCs, linodego.CapabilityDiskEncryption, linodego.CapabilityBlockStorage,
 	}, "core")
 	if err != nil {
 		log.Fatal(err)
@@ -238,13 +238,13 @@ func TestAccResourceInstance_vpu(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.VPU(t, instanceName, acceptance.PublicKeyMaterial, "us-lax", rootPass),
+				Config: tmpl.VPU(t, instanceName, acceptance.PublicKeyMaterial, "in-maa", rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists(resName, &instance),
 					resource.TestCheckResourceAttr(resName, "label", instanceName),
 					resource.TestCheckResourceAttr(resName, "type", "g1-accelerated-netint-vpu-t1u1-s"),
 					resource.TestCheckResourceAttr(resName, "image", acceptance.TestImageLatest),
-					resource.TestCheckResourceAttr(resName, "region", "us-lax"),
+					resource.TestCheckResourceAttr(resName, "region", "in-maa"),
 					resource.TestCheckResourceAttr(resName, "swap_size", "256"),
 					resource.TestCheckResourceAttrSet(resName, "host_uuid"),
 					resource.TestCheckResourceAttrSet(resName, "specs.0.accelerated_devices"),

--- a/linode/instanceconfig/resource_test.go
+++ b/linode/instanceconfig/resource_test.go
@@ -24,7 +24,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityLinodes, linodego.CapabilityVlans, linodego.CapabilityVPCs,
 	}, "core")
 	if err != nil {
@@ -492,7 +492,7 @@ func TestAccResourceInstanceConfig_rescueBooted(t *testing.T) {
 						t.Fatalf("failed to boot instance into rescue mode: %v", err)
 					}
 
-					if _, err := poller.WaitForFinished(context.Background(), 240); err != nil {
+					if _, err := poller.WaitForFinished(context.Background()); err != nil {
 						t.Fatalf("failed to wait for instance to boot into rescue mode: %v", err)
 					}
 				},
@@ -535,7 +535,7 @@ func TestAccResourceInstanceConfig_vpcInterfaceIPv6(t *testing.T) {
 	instanceName := acctest.RandomWithPrefix("tf-test")
 	rootPass := acctest.RandString(64)
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityLinodes,
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,

--- a/linode/instancedisk/resource_test.go
+++ b/linode/instancedisk/resource_test.go
@@ -22,7 +22,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/instanceip/resource_test.go
+++ b/linode/instanceip/resource_test.go
@@ -18,7 +18,7 @@ const testInstanceIPResName = "linode_instance_ip.test"
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/instancenetworking/framework_datasource_test.go
+++ b/linode/instancenetworking/framework_datasource_test.go
@@ -21,7 +21,7 @@ const testInstanceNetworkResName = "data.linode_instance_networking.test"
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityVPCs, linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityVPCs, linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/instancereservedipassignment/resource_test.go
+++ b/linode/instancereservedipassignment/resource_test.go
@@ -18,7 +18,7 @@ const testInstanceIPResName = "linode_reserved_ip_assignment.test"
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/instancereservedipassignment/resource_test.go
+++ b/linode/instancereservedipassignment/resource_test.go
@@ -30,13 +30,14 @@ func TestAccInstanceIP_addReservedIP(t *testing.T) {
 
 	var instance linodego.Instance
 	name := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
 		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
 		CheckDestroy:             acceptance.CheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.AddReservedIP(t, name, testRegion),
+				Config: tmpl.AddReservedIP(t, name, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					acceptance.CheckInstanceExists("linode_instance.foobar", &instance),
 					resource.TestCheckResourceAttrSet(testInstanceIPResName, "address"),

--- a/linode/instancereservedipassignment/tmpl/AddReservedIPToInstance.gotf
+++ b/linode/instancereservedipassignment/tmpl/AddReservedIPToInstance.gotf
@@ -8,6 +8,7 @@ resource "linode_instance" "foobar" {
     type = "g6-nanode-1"
     region = "{{ .Region }}"
     image = "linode/debian12"
+    root_pass = "{{ .RootPass }}"
     firewall_id = linode_firewall.e2e_test_firewall.id
 }
 

--- a/linode/instancereservedipassignment/tmpl/template.go
+++ b/linode/instancereservedipassignment/tmpl/template.go
@@ -10,12 +10,14 @@ type TemplateData struct {
 	Label            string
 	ApplyImmediately bool
 	Region           string
+	RootPass         string
 }
 
-func AddReservedIP(t *testing.T, instanceLabel, region string) string {
+func AddReservedIP(t *testing.T, instanceLabel, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"instance_ip_add_reservedIP", TemplateData{
-			Label:  instanceLabel,
-			Region: region,
+			Label:    instanceLabel,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }

--- a/linode/ipv6ranges/datasource_test.go
+++ b/linode/ipv6ranges/datasource_test.go
@@ -16,7 +16,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/linodeinterface/framework_resource_test.go
+++ b/linode/linodeinterface/framework_resource_test.go
@@ -28,7 +28,7 @@ var testRegion string
 
 func init() {
 	region, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityVlans, linodego.CapabilityVPCs, linodego.CapabilityCloudFirewall},
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityVlans, linodego.CapabilityVPCs, linodego.CapabilityCloudFirewall},
 		"core",
 	)
 	if err != nil {
@@ -776,7 +776,7 @@ func TestAccLinodeInterface_vpc_empty_ip_objects(t *testing.T) {
 func TestAccLinodeInterface_vpc_with_ipv6(t *testing.T) {
 	t.Parallel()
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityLinodes,
 		linodego.CapabilityVlans,
 		linodego.CapabilityVPCs,

--- a/linode/lke/framework_datasource_test.go
+++ b/linode/lke/framework_datasource_test.go
@@ -161,7 +161,7 @@ func TestAccDataSourceLKECluster_controlPlane(t *testing.T) {
 func TestAccDataSourceLKECluster_enterprise(t *testing.T) {
 	t.Parallel()
 
-	enterpriseRegion, err := acceptance.GetRandomRegionWithCaps([]string{"Kubernetes Enterprise", "VPCs"}, "core")
+	enterpriseRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{"Kubernetes Enterprise", "VPCs"}, "core")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +186,7 @@ func TestAccDataSourceLKECluster_enterprise(t *testing.T) {
 
 	firewall, err := client.CreateFirewall(context.Background(), linodego.FirewallCreateOptions{
 		Label: "tftest-enterprise-upgrade-" + acctest.RandString(5),
-		Rules: linodego.FirewallRuleSet{
+		Rules: linodego.FirewallRulesCreateOptions{
 			InboundPolicy:  "ACCEPT",
 			OutboundPolicy: "ACCEPT",
 		},

--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"regexp"
 	"sort"
@@ -76,7 +77,7 @@ func init() {
 		k8sVersionPrevious = k8sVersions[len(k8sVersions)-2]
 	}
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLKE}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLKE}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -94,7 +95,7 @@ func init() {
 		k8sVersionEnterprise = enterpriseVersions[0].ID
 	}
 
-	enterpriseRegion, err = acceptance.GetRandomRegionWithCaps([]string{"Kubernetes Enterprise", "VPCs"}, "core")
+	enterpriseRegion, err = acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{"Kubernetes Enterprise", "VPCs"}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -304,7 +305,12 @@ func TestAccResourceLKECluster_basicUpdates(t *testing.T) {
 
 				var opts linodego.LKEClusterUpdateOptions
 
-				if err := json.Unmarshal([]byte(request.Body.(string)), &opts); err != nil {
+				body, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := json.Unmarshal(body, &opts); err != nil {
 					t.Fatal(err)
 				}
 
@@ -737,7 +743,7 @@ func TestAccResourceLKECluster_enterprise(t *testing.T) {
 
 	firewall, err := client.CreateFirewall(context.Background(), linodego.FirewallCreateOptions{
 		Label: "tftest-enterprise-upgrade-" + acctest.RandString(5),
-		Rules: linodego.FirewallRuleSet{
+		Rules: linodego.FirewallRulesCreateOptions{
 			InboundPolicy:  "ACCEPT",
 			OutboundPolicy: "ACCEPT",
 		},
@@ -1089,7 +1095,7 @@ func TestAccResourceLKECluster_poolDiskEncryption(t *testing.T) {
 	t.Parallel()
 
 	diskEncryptionRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLKE, linodego.CapabilityDiskEncryption}, "core",
+		[]linodego.RegionCapability{linodego.CapabilityLKE, linodego.CapabilityDiskEncryption}, "core",
 	)
 	if err != nil {
 		t.Skipf("Skipping test: no region with LKE and Disk Encryption capabilities: %s", err)

--- a/linode/lkeclusters/datasource_test.go
+++ b/linode/lkeclusters/datasource_test.go
@@ -45,7 +45,7 @@ func init() {
 
 	k8sVersionLatest = k8sVersions[len(k8sVersions)-1]
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLKE}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLKE}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/lkenodepool/framework_resource_test.go
+++ b/linode/lkenodepool/framework_resource_test.go
@@ -61,7 +61,7 @@ func init() {
 
 		k8sVersion = k8sVersions[len(k8sVersions)-1]
 
-		region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLKE}, "core")
+		region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLKE}, "core")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -116,7 +116,7 @@ func TestAccResourceNodePool_basic(t *testing.T) {
 
 	// This test validates disk_encryption, so we need a region that supports both LKE and Disk Encryption
 	diskEncRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLKE, linodego.CapabilityDiskEncryption}, "core",
+		[]linodego.RegionCapability{linodego.CapabilityLKE, linodego.CapabilityDiskEncryption}, "core",
 	)
 	if err != nil {
 		t.Skipf("No region with LKE + Disk Encryption capabilities: %v", err)
@@ -441,7 +441,7 @@ func TestAccResourceNodePoolEnterprise_basic(t *testing.T) {
 
 	enterpriseK8sVersion := versions[0].ID
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityKubernetesEnterprise}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityKubernetesEnterprise}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -513,14 +513,14 @@ func TestAccResourceNodePoolEnterprise_withFirewall(t *testing.T) {
 
 	enterpriseK8sVersion := versions[0].ID
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityKubernetesEnterprise}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityKubernetesEnterprise}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	firewall, err := client.CreateFirewall(context.Background(), linodego.FirewallCreateOptions{
 		Label: "tftest-enterprise-upgrade-" + acctest.RandString(5),
-		Rules: linodego.FirewallRuleSet{
+		Rules: linodego.FirewallRulesCreateOptions{
 			InboundPolicy:  "ACCEPT",
 			OutboundPolicy: "ACCEPT",
 		},

--- a/linode/lock/framework_datasource_test.go
+++ b/linode/lock/framework_datasource_test.go
@@ -19,7 +19,7 @@ const (
 func TestAccDataSourceLock_basic(t *testing.T) {
 	t.Parallel()
 
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/linode/lock/framework_resource_test.go
+++ b/linode/lock/framework_resource_test.go
@@ -27,14 +27,14 @@ var (
 )
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	testRegion = region
 
-	nodeBalancerRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers}, "core")
+	nodeBalancerRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/locks/framework_datasource_test.go
+++ b/linode/locks/framework_datasource_test.go
@@ -23,7 +23,7 @@ const (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nb/datasource_test.go
+++ b/linode/nb/datasource_test.go
@@ -116,7 +116,7 @@ func TestAccDataSourceNodeBalancer_vpc(t *testing.T) {
 	dsName := "data.linode_nodebalancer.test"
 	nodebalancerName := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nb/framework_resource_test.go
+++ b/linode/nb/framework_resource_test.go
@@ -33,7 +33,7 @@ func init() {
 		F:    sweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestAccResourceNodeBalancer_vpc(t *testing.T) {
 	resName := "linode_nodebalancer.test"
 	nodebalancerName := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nbconfig/resource_test.go
+++ b/linode/nbconfig/resource_test.go
@@ -24,7 +24,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nbconfigs/datasource_test.go
+++ b/linode/nbconfigs/datasource_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceNodeBalancerConfigs_basic(t *testing.T) {
 	resourceName := "data.linode_nodebalancer_configs.foo"
 
 	nbLabel := acctest.RandomWithPrefix("tf_test")
-	nbRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers}, "core")
+	nbRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nbnode/datasource_test.go
+++ b/linode/nbnode/datasource_test.go
@@ -50,7 +50,7 @@ func TestAccDataSourceNodeBalancerNode_vpc(t *testing.T) {
 	label := acctest.RandomWithPrefix("tf-test")
 	rootPass := acctest.RandString(64)
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nbnode/resource_test.go
+++ b/linode/nbnode/resource_test.go
@@ -24,7 +24,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestAccResourceNodeBalancerNode_vpc(t *testing.T) {
 	label := acctest.RandomWithPrefix("tf-test")
 	rootPass := acctest.RandString(64)
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nbs/datasource_test.go
+++ b/linode/nbs/datasource_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceNodeBalancers_basic(t *testing.T) {
 	resourceName := "data.linode_nodebalancers.nbs"
 
 	nbLabel := acctest.RandomWithPrefix("tf_test")
-	nbRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers}, "core")
+	nbRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nbvpc/framework_datasource_test.go
+++ b/linode/nbvpc/framework_datasource_test.go
@@ -23,7 +23,7 @@ func TestAccDataSource_basic(t *testing.T) {
 
 	label := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/nbvpcs/framework_datasource_test.go
+++ b/linode/nbvpcs/framework_datasource_test.go
@@ -23,7 +23,7 @@ func TestAccDataSource_basic(t *testing.T) {
 
 	label := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityNodeBalancers, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/networkingip/framework_datasource_test.go
+++ b/linode/networkingip/framework_datasource_test.go
@@ -21,7 +21,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/networkingip/resource_test.go
+++ b/linode/networkingip/resource_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/networkingipassignment/resource_test.go
+++ b/linode/networkingipassignment/resource_test.go
@@ -34,6 +34,7 @@ func TestAccResourceNetworkingIPsAssign(t *testing.T) {
 
 	resourceName := "linode_networking_ip_assignment.test"
 	instanceName := acctest.RandomWithPrefix("tf_test")
+	rootPass := acctest.RandString(16) + "!A1a"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -41,7 +42,7 @@ func TestAccResourceNetworkingIPsAssign(t *testing.T) {
 		CheckDestroy:             checkNetworkingIPsAssignDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: tmpl.NetworkingIPsAssign(t, instanceName, testRegion),
+				Config: tmpl.NetworkingIPsAssign(t, instanceName, testRegion, rootPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "region"),
 					resource.TestCheckResourceAttrSet(resourceName, "assignments.#"),

--- a/linode/networkingipassignment/resource_test.go
+++ b/linode/networkingipassignment/resource_test.go
@@ -21,7 +21,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/networkingipassignment/tmpl/network_ip_assign.gotf
+++ b/linode/networkingipassignment/tmpl/network_ip_assign.gotf
@@ -5,6 +5,7 @@ resource "linode_instance" "test1" {
     type   = "g6-nanode-1"
     region = "{{ .Region }}"
     image  = "linode/arch"
+    root_pass = "{{ .RootPass }}"
 }
 
 resource "linode_instance" "test2" {
@@ -12,6 +13,7 @@ resource "linode_instance" "test2" {
     type   = "g6-nanode-1"
     region = "{{ .Region }}"
     image  = "linode/arch"
+    root_pass = "{{ .RootPass }}"
 }
 
 resource "linode_networking_ip" "reserved_ip1" {
@@ -24,7 +26,7 @@ resource "linode_networking_ip" "reserved_ip1" {
 resource "linode_networking_ip" "reserved_ip2" {
   public   = true
   type     = "ipv4"
-  region   = "{{ .Region }}" 
+  region   = "{{ .Region }}"
   reserved = true
 }
 

--- a/linode/networkingipassignment/tmpl/template.go
+++ b/linode/networkingipassignment/tmpl/template.go
@@ -7,15 +7,17 @@ import (
 )
 
 type TemplateData struct {
-	Label  string
-	Region string
+	Label    string
+	Region   string
+	RootPass string
 }
 
-func NetworkingIPsAssign(t *testing.T, label string, region string) string {
+func NetworkingIPsAssign(t *testing.T, label, region, rootPass string) string {
 	return acceptance.ExecuteTemplate(t,
 		"networking_ips_assign",
 		TemplateData{
-			Label:  label,
-			Region: region,
+			Label:    label,
+			Region:   region,
+			RootPass: rootPass,
 		})
 }

--- a/linode/networkingips/framework_datasource_test.go
+++ b/linode/networkingips/framework_datasource_test.go
@@ -22,7 +22,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/obj/resource_test.go
+++ b/linode/obj/resource_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/linode/terraform-provider-linode/v3/linode/obj/tmpl"
 )
 
+var testRegion string
+
 func init() {
 	endpoint, err := acceptance.GetRandomObjectStorageEndpoint()
 	if err != nil {
@@ -150,7 +152,7 @@ func getObject(ctx context.Context, rs *terraform.ResourceState) (*s3.GetObjectO
 
 		createOpts := linodego.ObjectStorageKeyCreateOptions{
 			Label: fmt.Sprintf("temp_%s_%v", bucket, time.Now().Unix()),
-			BucketAccess: &[]linodego.ObjectStorageKeyBucketAccess{{
+			BucketAccess: []linodego.ObjectStorageKeyBucketAccessCreateOptions{{
 				BucketName:  bucket,
 				Region:      rs.Primary.Attributes["region"],
 				Permissions: "read_write",

--- a/linode/objbucket/resource_test.go
+++ b/linode/objbucket/resource_test.go
@@ -180,7 +180,6 @@ func TestSmokeTests_objbucket(t *testing.T) {
 		name string
 		test func(*testing.T)
 	}{
-		{"TestAccResourceBucket_basic_legacy_smoke", TestAccResourceBucket_basic_legacy_smoke},
 		{"TestAccResourceBucket_basic_smoke", TestAccResourceBucket_basic_smoke},
 	}
 
@@ -637,7 +636,7 @@ func TestAccResourceBucket_forceDelete(t *testing.T) {
 						client := acceptance.TestAccSDKv2Provider.Meta().(*helper.ProviderMeta).Client
 						createOpts := linodego.ObjectStorageKeyCreateOptions{
 							Label: fmt.Sprintf("temp_%s_%v", objectStorageBucketName, time.Now().Unix()),
-							BucketAccess: &[]linodego.ObjectStorageKeyBucketAccess{{
+							BucketAccess: []linodego.ObjectStorageKeyBucketAccessCreateOptions{{
 								BucketName:  objectStorageBucketName,
 								Region:      testRegion,
 								Permissions: "read_write",

--- a/linode/objkey/framework_model.go
+++ b/linode/objkey/framework_model.go
@@ -20,7 +20,6 @@ type RegionDetail struct {
 
 type BucketAccessModelEntry struct {
 	BucketName  types.String `tfsdk:"bucket_name"`
-	Cluster     types.String `tfsdk:"cluster"`
 	Permissions types.String `tfsdk:"permissions"`
 	Region      types.String `tfsdk:"region"`
 }

--- a/linode/objkey/helpers.go
+++ b/linode/objkey/helpers.go
@@ -4,20 +4,11 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/linode/terraform-provider-linode/v3/linode/helper"
 )
-
-func getRegionFromCluster(cluster string) (string, error) {
-	s := strings.Split(cluster, "-")
-	if len(s) <= 2 {
-		return "", fmt.Errorf("failed to parse cluster %q", cluster)
-	}
-	return strings.Join(s[:2], "-"), nil
-}
 
 func validateRegionsAgainstBucketAccesses(ctx context.Context, plan ResourceModel, diags *diag.Diagnostics) {
 	// regions will be computed if not configured, so it's okay to be null or unknown.
@@ -31,18 +22,11 @@ func validateRegionsAgainstBucketAccesses(ctx context.Context, plan ResourceMode
 	plan.Regions.ElementsAs(ctx, &regions, true)
 
 	for _, ba := range plan.BucketAccess {
-		var bucketRegion string
-		var err error
-
 		if ba.Region.IsNull() || ba.Region.IsUnknown() {
-			bucketRegion, err = getRegionFromCluster(ba.Cluster.ValueString())
-			if err != nil {
-				diags.AddWarning("Failed to Parse Cluster", err.Error())
-				continue
-			}
-		} else {
-			bucketRegion = ba.Region.ValueString()
+			continue
 		}
+
+		bucketRegion := ba.Region.ValueString()
 
 		if !slices.Contains(bucketRegions, bucketRegion) {
 			bucketRegions = append(bucketRegions, bucketRegion)

--- a/linode/placementgroup/resource_test.go
+++ b/linode/placementgroup/resource_test.go
@@ -27,7 +27,7 @@ func init() {
 	})
 
 	var err error
-	testRegion, err = acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityPlacementGroup}, "core")
+	testRegion, err = acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityPlacementGroup}, "core")
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}

--- a/linode/placementgroupassignment/resource_test.go
+++ b/linode/placementgroupassignment/resource_test.go
@@ -19,7 +19,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityPlacementGroup}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/placementgroups/datasource_test.go
+++ b/linode/placementgroups/datasource_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourcePlacementGroups_basic(t *testing.T) {
 
 	baseLabel := acctest.RandomWithPrefix("tf-test")
 
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityPlacementGroup}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityPlacementGroup}, "core")
 	if err != nil {
 		t.Error(fmt.Errorf("failed to get region with PG capability: %w", err))
 	}

--- a/linode/producerimagesharegroup/resource_test.go
+++ b/linode/producerimagesharegroup/resource_test.go
@@ -47,7 +47,7 @@ func TestAccResourceImageShareGroup_updates(t *testing.T) {
 
 	resourceName := "linode_producer_image_share_group.foobar"
 	label := acctest.RandomWithPrefix("tf-test")
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		t.Fatalf("failed to get test region: %s", err)
 	}

--- a/linode/producerimagesharegroupimageshares/datasource_test.go
+++ b/linode/producerimagesharegroupimageshares/datasource_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/linode/linodego/v2"
 	"github.com/linode/terraform-provider-linode/v3/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/v3/linode/producerimagesharegroupimageshares/tmpl"
 )
@@ -22,7 +23,7 @@ func TestAccDataSourceImageShareGroupImageShares_basic(t *testing.T) {
 	label := acctest.RandomWithPrefix("tf_test")
 	instanceLabel := acctest.RandomWithPrefix("tf_test")
 
-	instanceRegion, err := acceptance.GetRandomRegionWithCaps([]string{}, "core")
+	instanceRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/rdns/framework_resource.go
+++ b/linode/rdns/framework_resource.go
@@ -228,7 +228,7 @@ func (r *Resource) Delete(
 	client := r.Meta.Client
 
 	updateOpts := linodego.IPAddressUpdateOptions{
-		RDNS: nil,
+		RDNS: linodego.Pointer((*string)(nil)),
 	}
 
 	tflog.Debug(ctx, "client.UpdateIPAddress(...)", map[string]any{

--- a/linode/rdns/resource_test.go
+++ b/linode/rdns/resource_test.go
@@ -25,7 +25,7 @@ func init() {
 		F:    sweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/region/datasource_test.go
+++ b/linode/region/datasource_test.go
@@ -19,7 +19,7 @@ var (
 )
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/vlan/datasource_test.go
+++ b/linode/vlan/datasource_test.go
@@ -20,7 +20,7 @@ import (
 var testRegion string
 
 func init() {
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes, linodego.CapabilityVlans}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityVlans}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/volume/framework_datasource_test.go
+++ b/linode/volume/framework_datasource_test.go
@@ -48,7 +48,7 @@ func TestAccDataSourceVolume_withBlockStorageEncryption(t *testing.T) {
 
 	// Resolve a region with support for Block Storage Encryption
 	targetRegion, err := acceptance.GetRandomRegionWithCaps(
-		[]string{linodego.CapabilityLinodes, linodego.CapabilityBlockStorageEncryption},
+		[]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityBlockStorageEncryption},
 		"core",
 	)
 	if err != nil {

--- a/linode/volume/framework_resource_test.go
+++ b/linode/volume/framework_resource_test.go
@@ -25,7 +25,7 @@ func init() {
 		F:    sweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityBlockStorage}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityBlockStorage}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestAccResourceVolume_encryptionExplicitEnabled(t *testing.T) {
 	volumeName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_volume.foobar"
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -419,7 +419,7 @@ func TestAccResourceVolume_encryptionExplicitDisabled(t *testing.T) {
 	volumeName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_volume.foobar"
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +448,7 @@ func TestAccResourceVolume_encryptionChangeForcesReplace(t *testing.T) {
 	volumeName := acctest.RandomWithPrefix("tf_test")
 	resName := "linode_volume.foobar"
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes}, "core")
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes}, "core")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/linode/volumes/datasource_test.go
+++ b/linode/volumes/datasource_test.go
@@ -23,7 +23,7 @@ func init() {
 		F:    sweep,
 	})
 
-	region, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityBlockStorage}, "core")
+	region, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityBlockStorage}, "core")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/linode/vpc/datasource_test.go
+++ b/linode/vpc/datasource_test.go
@@ -46,7 +46,7 @@ func TestAccDataSourceVPC_dualStack(t *testing.T) {
 	resourceName := "data.linode_vpc.foo"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
 	}, "core")

--- a/linode/vpc/resource_test.go
+++ b/linode/vpc/resource_test.go
@@ -32,7 +32,7 @@ func init() {
 
 	var err error
 
-	testRegion, err = acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityVPCs}, "core")
+	testRegion, err = acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}
@@ -139,7 +139,7 @@ func TestAccResourceVPC_dualStack(t *testing.T) {
 	resName := "linode_vpc.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
 	}, "core")

--- a/linode/vpcips/datasource_test.go
+++ b/linode/vpcips/datasource_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceVPCIPs_basic(t *testing.T) {
 	)
 
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityVPCs}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}
@@ -220,7 +220,7 @@ func TestAccDataSourceVPCIPs_dualStack(t *testing.T) {
 
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
 	}, "core")

--- a/linode/vpcs/datasource_test.go
+++ b/linode/vpcs/datasource_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceVPCs_basic_smoke(t *testing.T) {
 
 	resourceName := "data.linode_vpcs.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityVPCs}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		t.Error(fmt.Errorf("failed to get region with VPC capability: %w", err))
 	}
@@ -51,7 +51,7 @@ func TestAccDataSourceVPCs_dualStack(t *testing.T) {
 	resourceName := "data.linode_vpcs.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
 	}, "core")
@@ -112,7 +112,7 @@ func TestAccDataSourceVPCs_filterByLabel(t *testing.T) {
 
 	resourceName := "data.linode_vpcs.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityVPCs}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}

--- a/linode/vpcsubnet/datasource_test.go
+++ b/linode/vpcsubnet/datasource_test.go
@@ -54,7 +54,7 @@ func TestAccDataSourceVPCSubnet_dualStack(t *testing.T) {
 	resourceName := "data.linode_vpc_subnet.foo"
 	subnetLabel := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
 	}, "core")

--- a/linode/vpcsubnet/resource_test.go
+++ b/linode/vpcsubnet/resource_test.go
@@ -25,7 +25,7 @@ import (
 var testRegion string
 
 func init() {
-	r, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes, linodego.CapabilityVPCs}, "core")
+	r, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}
@@ -155,7 +155,7 @@ func TestAccResourceVPCSubnet_dualStack(t *testing.T) {
 	resName := "linode_vpc_subnet.foobar"
 	subnetLabel := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
 	}, "core")

--- a/linode/vpcsubnets/framework_datasource_test.go
+++ b/linode/vpcsubnets/framework_datasource_test.go
@@ -36,7 +36,7 @@ func TestAccDataSourceVPCSubnets_basic_smoke(t *testing.T) {
 
 	resourceName := "data.linode_vpc_subnets.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityLinodes, linodego.CapabilityVPCs}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityLinodes, linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}
@@ -110,7 +110,7 @@ func TestAccDataSourceVPCSubnets_dualStack(t *testing.T) {
 	resourceName := "data.linode_vpc_subnets.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
 
-	targetRegion, err := acceptance.GetRandomRegionWithCaps([]string{
+	targetRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{
 		linodego.CapabilityVPCs,
 		linodego.CapabilityVPCDualStack,
 	}, "core")
@@ -173,7 +173,7 @@ func TestAccDataSourceVPCSubnets_filterByLabel(t *testing.T) {
 
 	resourceName := "data.linode_vpc_subnets.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
-	testRegion, err := acceptance.GetRandomRegionWithCaps([]string{linodego.CapabilityVPCs}, "core")
+	testRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{linodego.CapabilityVPCs}, "core")
 	if err != nil {
 		log.Fatal(fmt.Errorf("Error getting region: %s", err))
 	}


### PR DESCRIPTION
## 📝 Description

Fixed integration tests broken by linodego v2 migration

## ✔️ How to Test

`make test-unit`
`make test-int`

There will still be some test failures (the known intermittent ones) but hopefully nothing related to the v2 migration.