### PR TITLE
TPT-4523: Removed reference to `group` in int test

### DIFF
--- a/linode/consumerimagesharegroupimageshares/tmpl/data_basic.gotf
+++ b/linode/consumerimagesharegroupimageshares/tmpl/data_basic.gotf
@@ -51,7 +51,6 @@ resource "linode_instance" "foobar" {
   depends_on = [linode_firewall.e2e_test_firewall]
 
   label  = "{{ .InstanceLabel }}"
-  group  = "tf_test"
   type   = "g6-standard-1"
   region = "{{ .InstanceRegion }}"
 


### PR DESCRIPTION
## 📝 Description

Removed `group` reference from `TestAccDataSourceImageShareGroupImageShares_basic` integration test that was causing a failure.

## ✔️ How to Test

`make test-int PKG_NAME="consumerimagesharegroupimageshares" TEST_CASE="TestAccDataSourceImageShareGroupImageShares_basic"`