### PR TITLE
TPT-4535: Fixed issue with stackscripts in instance disks

### DIFF
--- a/linode/instance/helpers.go
+++ b/linode/instance/helpers.go
@@ -645,9 +645,13 @@ func createInstanceDisk(
 			if !ok {
 				return nil, fmt.Errorf("Error parsing stackscript_data: expected map[string]interface{}")
 			}
-			diskOpts.StackscriptData = make(map[string]string, len(stackscriptData))
-			for name, value := range stackscriptData {
-				diskOpts.StackscriptData[name] = value.(string)
+
+			if len(stackscriptData) > 0 {
+				m := make(map[string]string, len(stackscriptData))
+				for name, value := range stackscriptData {
+					m[name] = value.(string)
+				}
+				diskOpts.StackscriptData = m
 			}
 		}
 	}

--- a/linode/instance/resource.go
+++ b/linode/instance/resource.go
@@ -316,9 +316,16 @@ func createResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			if !ok {
 				return diag.Errorf("Error parsing stackscript_data: expected map[string]interface{}")
 			}
-			createOpts.StackScriptData = make(map[string]string, len(stackscriptData))
-			for name, value := range stackscriptData {
-				createOpts.StackScriptData[name] = value.(string)
+
+			if len(stackscriptData) == 0 {
+				// Prevent "{}" from being sent
+				createOpts.StackScriptData = nil
+			} else {
+				m := make(map[string]string, len(stackscriptData))
+				for name, value := range stackscriptData {
+					m[name] = value.(string)
+				}
+				createOpts.StackScriptData = m
 			}
 		}
 	} else {

--- a/linode/instancedisk/framework_resource.go
+++ b/linode/instancedisk/framework_resource.go
@@ -90,7 +90,18 @@ func (r *Resource) Create(
 
 	resp.Diagnostics.Append(plan.AuthorizedKeys.ElementsAs(ctx, &createOpts.AuthorizedKeys, false)...)
 	resp.Diagnostics.Append(plan.AuthorizedUsers.ElementsAs(ctx, &createOpts.AuthorizedUsers, false)...)
-	resp.Diagnostics.Append(plan.StackScriptData.ElementsAs(ctx, &createOpts.StackscriptData, false)...)
+
+	var m map[string]string
+
+	resp.Diagnostics.Append(
+		plan.StackScriptData.ElementsAs(ctx, &m, false)...,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createOpts.StackscriptData = mapOrNil(m)
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -426,4 +437,11 @@ func populateLogAttributes(ctx context.Context, model ResourceModel) context.Con
 		"linode_id": model.LinodeID.ValueInt64(),
 		"disk_id":   model.ID.ValueString(),
 	})
+}
+
+func mapOrNil(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }


### PR DESCRIPTION
## 📝 Description

Fixed issue with stackscripts in instance disks that caused wide-spread integration test failures.

## ✔️ How to Test

`make test-int`
