### PR TITLE
Fixed some integration test failures

### DIFF
--- a/linode/lke/resource_test.go
+++ b/linode/lke/resource_test.go
@@ -752,6 +752,9 @@ func TestAccResourceLKECluster_enterprise(t *testing.T) {
 		t.Fatalf("failed creating firewall: %v", err)
 	}
 
+	// TODO: Remove hard-coded region once capability filtering works properly
+	enterpriseRegionWithACLP := "us-lax"
+
 	acceptance.RunTestWithRetries(t, 2, func(t *acceptance.WrappedT) {
 		clusterName := acctest.RandomWithPrefix("tf-test")
 		resource.Test(t, resource.TestCase{
@@ -760,10 +763,10 @@ func TestAccResourceLKECluster_enterprise(t *testing.T) {
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: tmpl.Enterprise(t, clusterName, k8sVersionEnterprise, enterpriseRegion, "on_recycle"),
+					Config: tmpl.Enterprise(t, clusterName, k8sVersionEnterprise, enterpriseRegionWithACLP, "on_recycle"),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
-						resource.TestCheckResourceAttr(resourceClusterName, "region", enterpriseRegion),
+						resource.TestCheckResourceAttr(resourceClusterName, "region", enterpriseRegionWithACLP),
 						resource.TestCheckResourceAttr(resourceClusterName, "k8s_version", k8sVersionEnterprise),
 						resource.TestCheckResourceAttr(resourceClusterName, "status", "ready"),
 						resource.TestCheckResourceAttr(resourceClusterName, "tier", "enterprise"),
@@ -784,10 +787,10 @@ func TestAccResourceLKECluster_enterprise(t *testing.T) {
 					},
 				},
 				{
-					Config: tmpl.Enterprise(t, clusterName, k8sVersionEnterprise, enterpriseRegion, "rolling_update"),
+					Config: tmpl.Enterprise(t, clusterName, k8sVersionEnterprise, enterpriseRegionWithACLP, "rolling_update"),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
-						resource.TestCheckResourceAttr(resourceClusterName, "region", enterpriseRegion),
+						resource.TestCheckResourceAttr(resourceClusterName, "region", enterpriseRegionWithACLP),
 						resource.TestCheckResourceAttr(resourceClusterName, "k8s_version", k8sVersionEnterprise),
 						resource.TestCheckResourceAttr(resourceClusterName, "status", "ready"),
 						resource.TestCheckResourceAttr(resourceClusterName, "tier", "enterprise"),
@@ -804,10 +807,10 @@ func TestAccResourceLKECluster_enterprise(t *testing.T) {
 					},
 				},
 				{
-					Config: tmpl.EnterpriseFirewall(t, clusterName, k8sVersionEnterprise, enterpriseRegion, firewall.ID),
+					Config: tmpl.EnterpriseFirewall(t, clusterName, k8sVersionEnterprise, enterpriseRegionWithACLP, firewall.ID),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceClusterName, "label", clusterName),
-						resource.TestCheckResourceAttr(resourceClusterName, "region", enterpriseRegion),
+						resource.TestCheckResourceAttr(resourceClusterName, "region", enterpriseRegionWithACLP),
 						resource.TestCheckResourceAttr(resourceClusterName, "k8s_version", k8sVersionEnterprise),
 						resource.TestCheckResourceAttr(resourceClusterName, "status", "ready"),
 						resource.TestCheckResourceAttr(resourceClusterName, "tier", "enterprise"),

--- a/linode/vpc/resource_test.go
+++ b/linode/vpc/resource_test.go
@@ -227,7 +227,7 @@ func TestAccResourceVPC_dualStack(t *testing.T) {
 func TestAccResourceLinodeVPC_create_InvalidLabel(t *testing.T) {
 	t.Parallel()
 
-	vpcLabel := "tf-test_123"
+	vpcLabel := "tf-test*123"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -235,7 +235,7 @@ func TestAccResourceLinodeVPC_create_InvalidLabel(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      tmpl.Basic(t, vpcLabel, testRegion),
-				ExpectError: regexp.MustCompile("Must only use ASCII letters, numbers, and dashes"),
+				ExpectError: regexp.MustCompile("Must only use ASCII letters, numbers, and underscores"),
 			},
 		},
 	})
@@ -246,7 +246,7 @@ func TestAccResourceLinodeVPC_update_InvalidLabel(t *testing.T) {
 	resName := "linode_vpc.foobar"
 	vpcLabel := acctest.RandomWithPrefix("tf-test")
 
-	invalidLabel := "tf-test_123"
+	invalidLabel := "tf-test*123"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acceptance.PreCheck(t) },
@@ -264,7 +264,7 @@ func TestAccResourceLinodeVPC_update_InvalidLabel(t *testing.T) {
 			},
 			{
 				Config:      tmpl.Updates(t, invalidLabel, testRegion),
-				ExpectError: regexp.MustCompile("Must only use ASCII letters, numbers, and dashes"),
+				ExpectError: regexp.MustCompile("Must only use ASCII letters, numbers, and underscores"),
 			},
 			{
 				ResourceName:      resName,


### PR DESCRIPTION
## 📝 Description

Fixed some integration test failures.

## ✔️ How to Test
`make test-int PKG_NAME="lke" TEST_CASE="TestAccResourceLKECluster_enterprise"`
`make test-int PKG_NAME="vpc" TEST_CASE="TestAccResourceLinodeVPC_create_InvalidLabel"`
`make test-int PKG_NAME="vpc" TEST_CASE="TestAccResourceLinodeVPC_update_InvalidLabel"`
