### PR TITLE
Fixed LKE-E tests

### DIFF
--- a/linode/lke/framework_datasource_test.go
+++ b/linode/lke/framework_datasource_test.go
@@ -161,10 +161,12 @@ func TestAccDataSourceLKECluster_controlPlane(t *testing.T) {
 func TestAccDataSourceLKECluster_enterprise(t *testing.T) {
 	t.Parallel()
 
-	enterpriseRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{"Kubernetes Enterprise", "VPCs"}, "core")
-	if err != nil {
-		t.Fatal(err)
-	}
+	//enterpriseRegion, err := acceptance.GetRandomRegionWithCaps([]linodego.RegionCapability{"Kubernetes Enterprise", "VPCs"}, "core")
+	//if err != nil {
+	//	t.Fatal(err)
+	//}
+	// TODO: Remove hard-coded region and replace with enterpriseRegion once capability filtering works properly
+	enterpriseRegionWithACLP := "us-lax"
 
 	var k8sVersionEnterprise string
 
@@ -203,10 +205,10 @@ func TestAccDataSourceLKECluster_enterprise(t *testing.T) {
 			CheckDestroy:             acceptance.CheckLKEClusterDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: tmpl.DataEnterprise(t, clusterName, k8sVersionEnterprise, enterpriseRegion, "on_recycle", firewall.ID),
+					Config: tmpl.DataEnterprise(t, clusterName, k8sVersionEnterprise, enterpriseRegionWithACLP, "on_recycle", firewall.ID),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(dataSourceClusterName, "label", clusterName),
-						resource.TestCheckResourceAttr(dataSourceClusterName, "region", enterpriseRegion),
+						resource.TestCheckResourceAttr(dataSourceClusterName, "region", enterpriseRegionWithACLP),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "k8s_version", k8sVersionEnterprise),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "status", "ready"),
 						resource.TestCheckResourceAttr(dataSourceClusterName, "tier", "enterprise"),

--- a/linode/lke/tmpl/enterprise.gotf
+++ b/linode/lke/tmpl/enterprise.gotf
@@ -4,12 +4,24 @@ resource "linode_vpc" "foobar" {
     label = "{{.Label}}"
     region = "{{.Region}}"
     description = "some description"
+
+    ipv6 = [
+        {
+            range = "/52"
+        }
+    ]
 }
 
 resource "linode_vpc_subnet" "foobar" {
     vpc_id = linode_vpc.foobar.id
     label = "{{.Label}}-subnet"
     ipv4 = "172.16.0.0/14"
+
+    ipv6 = [
+        {
+            range = "/52"
+        }
+    ]
 }
 
 resource "linode_lke_cluster" "test" {


### PR DESCRIPTION
## 📝 Description

Added hard-coded region in `TestAccDataSourceLKECluster_enterprise` due to recurring region issue with ACLP. Also added `ipv6` to LKE-E test templates to fix recurring `[400] [subnet_id] The provided VPC subnet does not have any IPv6 range available` error.

## ✔️ How to Test

`make test-int PKG_NAME="lke" TEST_CASE="TestAccDataSourceLKECluster_enterprise"`
`make test-int PKG_NAME="lke" TEST_CASE="TestAccResourceLKECluster_enterprise"`