### PR TITLE
TPT-4491: Add support for firewall protocol ALL and numeric

### DIFF
--- a/docs/data-sources/firewall.md
+++ b/docs/data-sources/firewall.md
@@ -63,7 +63,7 @@ The following arguments are supported in the inbound and outbound rule blocks:
 
 * `action` - Controls whether traffic is accepted or dropped by this rule. Overrides the Firewall’s inbound_policy if this is an inbound rule, or the outbound_policy if this is an outbound rule.
 
-* `protocol` - The network protocol this rule controls. (`TCP`, `UDP`, `ICMP`)
+* `protocol` - The network protocol this rule controls. Possible values include `ALL`, `TCP`, `UDP`, `ICMP`, `IPENCAP`, or a protocol number from `0` to `255`.
 
 * `ports` - A string representation of ports and/or port ranges (i.e. "443" or "80-90, 91").
 

--- a/docs/data-sources/firewalls.md
+++ b/docs/data-sources/firewalls.md
@@ -99,7 +99,7 @@ Each Linode firewall will be stored in the `firewalls` attribute and will export
 
 * `action` - Controls whether traffic is accepted or dropped by this rule (ACCEPT, DROP).
 
-* `protocol` - The network protocol this rule controls. (TCP, UDP, ICMP)
+* `protocol` - The network protocol this rule controls. Possible values include `ALL`, `TCP`, `UDP`, `ICMP`, `IPENCAP`, or a protocol number from `0` to `255`.
 
 * `ports` - A string representation of ports and/or port ranges (i.e. "443" or "80-90, 91").
 

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -104,7 +104,7 @@ The following arguments are supported in the inbound and outbound rule blocks:
   
 * `action` - (required) Controls whether traffic is accepted or dropped by this rule (`ACCEPT`, `DROP`). Overrides the Firewall’s inbound_policy if this is an inbound rule, or the outbound_policy if this is an outbound rule.
 
-* `protocol` - (Required) The network protocol this rule controls. (`TCP`, `UDP`, `ICMP`)
+* `protocol` - (Required) The network protocol this rule controls. Accepted values are `ALL`, `TCP`, `UDP`, `ICMP`, `IPENCAP`, or a protocol number from `0` to `255`.
 
 * `ports` - (Optional) A string representation of ports and/or port ranges (i.e. "443" or "80-90, 91").
   

--- a/linode/firewall/framework_resource_test.go
+++ b/linode/firewall/framework_resource_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/linode/linodego/v2"
 	"github.com/linode/terraform-provider-linode/v4/linode/acceptance"
 	acceptanceTmpl "github.com/linode/terraform-provider-linode/v4/linode/acceptance/tmpl"
@@ -121,6 +124,67 @@ func TestAccLinodeFirewall_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"created", "updated"},
+			},
+		},
+	})
+}
+
+func TestAccLinodeFirewall_protocolAllNumeric(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix("tf_test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acceptanceTmpl.ProviderNoPoll(t) + tmpl.Protocol(t, name, "ALL", ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("label"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("ALL"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ports"),
+						knownvalue.Null(),
+					),
+				},
+			},
+			{
+				Config: acceptanceTmpl.ProviderNoPoll(t) + tmpl.Protocol(t, name, "50", ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("label"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("50"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ports"),
+						knownvalue.Null(),
+					),
+				},
+			},
+			{
+				Config: acceptanceTmpl.ProviderNoPoll(t) + tmpl.Protocol(t, name, "6", "443"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("label"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("6"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ports"),
+						knownvalue.StringExact("443"),
+					),
+				},
 			},
 		},
 	})

--- a/linode/firewall/framework_schema_resource.go
+++ b/linode/firewall/framework_schema_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/linode/linodego/v2"
 	"github.com/linode/terraform-provider-linode/v4/linode/helper"
 	linodesetplanmodifiers "github.com/linode/terraform-provider-linode/v4/linode/helper/setplanmodifiers"
 )
@@ -38,15 +37,11 @@ var ruleNestedObject = schema.NestedBlockObject{
 			},
 		},
 		"protocol": schema.StringAttribute{
-			Description: "The network protocol this rule controls.",
-			Required:    true,
+			Description: "The network protocol this rule controls. Accepted values are ALL, TCP, UDP, " +
+				"ICMP, IPENCAP, or a protocol number from 0 to 255.",
+			Required: true,
 			Validators: []validator.String{
-				stringvalidator.OneOf(
-					string(linodego.TCP),
-					string(linodego.UDP),
-					string(linodego.ICMP),
-					string(linodego.IPENCAP),
-				),
+				firewallProtocolValidator{},
 			},
 		},
 		"description": schema.StringAttribute{

--- a/linode/firewall/tmpl/protocol.gotf
+++ b/linode/firewall/tmpl/protocol.gotf
@@ -1,0 +1,18 @@
+{{ define "firewall_protocol" }}
+
+resource "linode_firewall" "test" {
+    label = "{{.Label}}"
+    tags  = ["test"]
+
+    inbound {
+        label    = "tf-test-in"
+        action   = "ACCEPT"
+        protocol = "{{.Protocol}}"
+        {{ if .Ports }}ports    = "{{.Ports}}"{{ end }}
+        ipv4     = ["0.0.0.0/0"]
+    }
+    inbound_policy = "DROP"
+    outbound_policy = "DROP"
+}
+
+{{ end }}

--- a/linode/firewall/tmpl/template.go
+++ b/linode/firewall/tmpl/template.go
@@ -19,7 +19,9 @@ type TemplateData struct {
 	Instances     []ResourceTemplateData
 	NodeBalancers []ResourceTemplateData
 
-	Label string
+	Label    string
+	Protocol string
+	Ports    string
 }
 
 func Basic(t testing.TB, label, devicePrefix, region string) string {
@@ -108,6 +110,15 @@ func NoRules(t testing.TB, label string) string {
 	return acceptance.ExecuteTemplate(t,
 		"firewall_no_rules", TemplateData{
 			Label: label,
+		})
+}
+
+func Protocol(t testing.TB, label, protocol, ports string) string {
+	return acceptance.ExecuteTemplate(t,
+		"firewall_protocol", TemplateData{
+			Label:    label,
+			Protocol: protocol,
+			Ports:    ports,
 		})
 }
 

--- a/linode/firewall/validation.go
+++ b/linode/firewall/validation.go
@@ -1,0 +1,66 @@
+package firewall
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var firewallProtocolKeywords = map[string]struct{}{
+	"ALL":     {},
+	"TCP":     {},
+	"UDP":     {},
+	"ICMP":    {},
+	"IPENCAP": {},
+}
+
+var _ validator.String = firewallProtocolValidator{}
+
+type firewallProtocolValidator struct{}
+
+func (v firewallProtocolValidator) Description(ctx context.Context) string {
+	return "value must be ALL, TCP, UDP, ICMP, IPENCAP, or a protocol number from 0 to 255"
+}
+
+func (v firewallProtocolValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v firewallProtocolValidator) ValidateString(
+	ctx context.Context,
+	req validator.StringRequest,
+	resp *validator.StringResponse,
+) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	protocol := req.ConfigValue.ValueString()
+	if isValidFirewallProtocol(protocol) {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid Firewall Rule Protocol",
+		fmt.Sprintf(
+			"Expected ALL, TCP, UDP, ICMP, IPENCAP, or a protocol number from 0 to 255 without leading zeros, got %q.",
+			protocol,
+		),
+	)
+}
+
+func isValidFirewallProtocol(protocol string) bool {
+	if _, ok := firewallProtocolKeywords[protocol]; ok {
+		return true
+	}
+
+	value, err := strconv.Atoi(protocol)
+	if err != nil {
+		return false
+	}
+
+	return value >= 0 && value <= 255 && strconv.Itoa(value) == protocol
+}

--- a/linode/firewall/validation_unit_test.go
+++ b/linode/firewall/validation_unit_test.go
@@ -1,0 +1,85 @@
+//go:build unit
+
+package firewall
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	fwvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/linode/linodego/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFirewallProtocolValidator(t *testing.T) {
+	testCases := []struct {
+		name      string
+		protocol  string
+		wantError bool
+	}{
+		{name: "zero", protocol: "0"},
+		{name: "max", protocol: "255"},
+		{name: "all keyword", protocol: "ALL"},
+		{name: "tcp keyword", protocol: "TCP"},
+		{name: "too large", protocol: "256", wantError: true},
+		{name: "leading zero", protocol: "06", wantError: true},
+		{name: "invalid keyword", protocol: "any", wantError: true},
+		{name: "lowercase all", protocol: "all", wantError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp fwvalidator.StringResponse
+
+			firewallProtocolValidator{}.ValidateString(
+				context.Background(),
+				fwvalidator.StringRequest{
+					Path:        path.Root("protocol"),
+					ConfigValue: types.StringValue(tc.protocol),
+				},
+				&resp,
+			)
+
+			assert.Equal(t, tc.wantError, resp.Diagnostics.HasError())
+		})
+	}
+}
+
+func TestExpandRuleOmitsNullPortsFromJSON(t *testing.T) {
+	ruleModel := RuleModel{
+		Label:       types.StringValue("tf-test-in"),
+		Action:      types.StringValue("ACCEPT"),
+		Protocol:    types.StringValue("ALL"),
+		Ports:       types.StringNull(),
+		Description: types.StringNull(),
+		IPv4: types.ListValueMust(
+			cidrtypes.IPv4PrefixType{},
+			[]attr.Value{
+				cidrtypes.NewIPv4PrefixValue("0.0.0.0/0"),
+			},
+		),
+		IPv6: types.ListValueMust(
+			cidrtypes.IPv6PrefixType{},
+			[]attr.Value{},
+		),
+	}
+
+	var diags diag.Diagnostics
+	rule := ExpandRule[linodego.FirewallRuleInbound](context.Background(), ruleModel, &diags)
+
+	require.False(t, diags.HasError())
+	require.Empty(t, rule.Ports)
+
+	payload, err := json.Marshal(rule)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(payload), `"protocol":"ALL"`)
+	assert.NotContains(t, string(payload), `"ports"`)
+}

--- a/linode/firewalls/framework_datasource_test.go
+++ b/linode/firewalls/framework_datasource_test.go
@@ -231,3 +231,40 @@ func TestAccDataSourceFirewalls_basic(t *testing.T) {
 		})
 	})
 }
+
+func TestAccDataSourceFirewalls_protocolAllNumeric(t *testing.T) {
+	t.Parallel()
+
+	firewallName := acctest.RandomWithPrefix("tf_test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataProtocolAllNumeric(t, firewallName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("firewalls"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("firewalls").AtSliceIndex(0).AtMapKey("label"),
+						knownvalue.StringExact(firewallName),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("firewalls").AtSliceIndex(0).AtMapKey("inbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("ALL"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("firewalls").AtSliceIndex(0).AtMapKey("outbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("50"),
+					),
+				},
+			},
+		},
+	})
+}

--- a/linode/firewalls/framework_schema.go
+++ b/linode/firewalls/framework_schema.go
@@ -52,12 +52,15 @@ var FirewallRuleObject = schema.NestedBlockObject{
 			Computed:    true,
 		},
 		"protocol": schema.StringAttribute{
-			Description: "The network protocol this rule controls. (TCP, UDP, ICMP)",
-			Computed:    true,
+			Description: "The network protocol this rule controls. " +
+				"Valid values include ALL, TCP, UDP, ICMP, IPENCAP, " +
+				"or a protocol number from 0 to 255.",
+			Computed: true,
 		},
 		"ports": schema.StringAttribute{
-			Description: "A string representation of ports and/or port ranges (i.e. \"443\" or \"80-90, 91\").",
-			Computed:    true,
+			Description: "A string representation of ports and/or port ranges " +
+				"(i.e. \"443\" or \"80-90, 91\").",
+			Computed: true,
 		},
 		"ipv4": schema.SetAttribute{
 			Description: "A list of IPv4 addresses or networks in IP/mask format.",

--- a/linode/firewalls/tmpl/data_protocol_all_numeric.gotf
+++ b/linode/firewalls/tmpl/data_protocol_all_numeric.gotf
@@ -1,0 +1,37 @@
+    {{ define "data_linode_firewalls_protocol_all_numeric" }}
+
+resource "linode_firewall" "foobar" {
+  label = "{{ .Label }}"
+  tags  = ["test"]
+
+  inbound {
+    label    = "allow-all"
+    action   = "ACCEPT"
+    protocol = "ALL"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  inbound_policy = "DROP"
+
+  outbound {
+    label    = "drop-numeric"
+    action   = "DROP"
+    protocol = "50"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  outbound_policy = "ACCEPT"
+}
+
+data "linode_firewalls" "test" {
+  depends_on = [linode_firewall.foobar]
+
+  filter {
+    name = "label"
+    values = ["{{ .Label }}"]
+  }
+}
+
+{{ end }}

--- a/linode/firewalls/tmpl/template.go
+++ b/linode/firewalls/tmpl/template.go
@@ -26,3 +26,10 @@ func DataFilter(t testing.TB, label, region string) string {
 			Region: region,
 		})
 }
+
+func DataProtocolAllNumeric(t testing.TB, label string) string {
+	return acceptance.ExecuteTemplate(t,
+		"data_linode_firewalls_protocol_all_numeric", TemplateData{
+			Label: label,
+		})
+}


### PR DESCRIPTION
## 📝 Description

This pull request adds support for the CFW protocol `ALL` and numeric project.

## ✔️ How to Test

See TPT-4469 for testing environment requirements.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int PKG_NAME=firewall
make test-int PKG_NAME=firewalls
```