### PR TITLE
Integration test fixes

### DIFF
--- a/linode/instance/resource_test.go
+++ b/linode/instance/resource_test.go
@@ -225,6 +225,7 @@ func TestAccResourceInstance_kernelBootSize(t *testing.T) {
 
 func TestAccResourceInstance_vpu(t *testing.T) {
 	t.Parallel()
+	t.Skip("Skipping test: no regions currently available with accelerated instance types.")
 
 	resName := "linode_instance.foobar"
 	var instance linodego.Instance

--- a/linode/networkingip/tmpl/data_basic.gotf
+++ b/linode/networkingip/tmpl/data_basic.gotf
@@ -9,7 +9,6 @@ provider "linode" {
 
 resource "linode_instance" "foobar" {
     label = "{{.Label}}"
-    group = "tf_test"
     image = "linode/arch"
     type = "g6-standard-1"
     region = "{{ .Region }}"


### PR DESCRIPTION
## 📝 Description

Fixed several issues causing integration test failures.

## ✔️ How to Test

`make test-int PKG_NAME="networkingip" TEST_CASE="TestAccDataSourceNetworkingIP_basic"`
