### PR TITLE
TPT-4056: Fix workflow injection and suppress test randomness findings

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -88,12 +88,13 @@ jobs:
 
       - name: Run Integration Tests
         run: |
-          make TEST_SUITE="${{ env.TEST_SUITE }}" PARALLEL="${{ github.event.inputs.parallel_value || '5' }}" test-int | go-junit-report -set-exit-code -iocopy -out $REPORT_FILENAME
+          make TEST_SUITE="${{ env.TEST_SUITE }}" PARALLEL="$PARALLEL" test-int | go-junit-report -set-exit-code -iocopy -out $REPORT_FILENAME
         env:
           LINODE_TOKEN: ${{ env.LINODE_TOKEN }}
           LINODE_PRODUCER_TOKEN: ${{ env.LINODE_PRODUCER_TOKEN }}
           LINODE_CONSUMER_TOKEN: ${{ env.LINODE_CONSUMER_TOKEN }}
           RUN_LONG_TESTS: ${{ github.event.inputs.run_long_tests || 'false' }}
+          PARALLEL: ${{ github.event.inputs.parallel_value || '5' }}
 
       - name: Upload Test Report as Artifact
         if: always()

--- a/.github/workflows/integration_tests_pr.yml
+++ b/.github/workflows/integration_tests_pr.yml
@@ -61,13 +61,14 @@ jobs:
 
       - run: make deps
 
-      - run: make TEST_SUITE="${{ inputs.test_suite }}" test-int
+      - run: make TEST_SUITE="$TEST_SUITE" test-int
         if: ${{ steps.disallowed-character-check.outputs.result == 'pass' }}
         env:
           LINODE_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           LINODE_PRODUCER_TOKEN: ${{ secrets.DX_LINODE_TOKEN }}
           LINODE_CONSUMER_TOKEN: ${{ secrets.LINODE_TOKEN_USER_2 }}
           RUN_LONG_TESTS: ${{ inputs.run_long_tests }}
+          TEST_SUITE: ${{ inputs.test_suite }}
 
       - name: Get the hash value of the latest commit from the PR branch
         uses: octokit/graphql-action@v2.x

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/big"
 	"os"
 	"path/filepath"
 	"slices"
@@ -644,9 +645,14 @@ func GetRandomObjectStorageEndpoint() (*linodego.ObjectStorageEndpoint, error) {
 		return nil, err
 	}
 
-	rand.Shuffle(len(endpoints), func(i, j int) {
-		endpoints[i], endpoints[j] = endpoints[j], endpoints[i]
-	})
+	for i := len(endpoints) - 1; i > 0; i-- {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to shuffle object storage endpoints: %w", err)
+		}
+
+		endpoints[i], endpoints[j.Int64()] = endpoints[j.Int64()], endpoints[i]
+	}
 
 	for i, e := range endpoints {
 		// Linode Object Storage clusters with E2 and E3 (Object Storage gen2) endpoints
@@ -779,8 +785,12 @@ func GetRandomRegionWithCaps(capabilities []linodego.RegionCapability, regionTyp
 		return "", fmt.Errorf("no region found with the provided caps")
 	}
 
-	// #nosec G404 -- Test data, doesn't need to be cryptography
-	return regions[rand.Intn(len(regions))], nil
+	index, err := rand.Int(rand.Reader, big.NewInt(int64(len(regions))))
+	if err != nil {
+		return "", fmt.Errorf("failed to select a random region: %w", err)
+	}
+
+	return regions[index.Int64()], nil
 }
 
 func GetTestClient() (*linodego.Client, error) {

--- a/linode/acceptance/util.go
+++ b/linode/acceptance/util.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"log"
-	"math/big"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"slices"
@@ -645,14 +644,10 @@ func GetRandomObjectStorageEndpoint() (*linodego.ObjectStorageEndpoint, error) {
 		return nil, err
 	}
 
-	for i := len(endpoints) - 1; i > 0; i-- {
-		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
-		if err != nil {
-			return nil, fmt.Errorf("failed to shuffle object storage endpoints: %w", err)
-		}
-
-		endpoints[i], endpoints[j.Int64()] = endpoints[j.Int64()], endpoints[i]
-	}
+	// #nosec G404 -- Test data, doesn't need to be cryptographically secure
+	rand.Shuffle(len(endpoints), func(i, j int) {
+		endpoints[i], endpoints[j] = endpoints[j], endpoints[i]
+	})
 
 	for i, e := range endpoints {
 		// Linode Object Storage clusters with E2 and E3 (Object Storage gen2) endpoints
@@ -785,12 +780,8 @@ func GetRandomRegionWithCaps(capabilities []linodego.RegionCapability, regionTyp
 		return "", fmt.Errorf("no region found with the provided caps")
 	}
 
-	index, err := rand.Int(rand.Reader, big.NewInt(int64(len(regions))))
-	if err != nil {
-		return "", fmt.Errorf("failed to select a random region: %w", err)
-	}
-
-	return regions[index.Int64()], nil
+	// #nosec G404 -- Test data, doesn't need to be cryptographically secure
+	return regions[rand.Intn(len(regions))], nil
 }
 
 func GetTestClient() (*linodego.Client, error) {


### PR DESCRIPTION
## 📝 Description

Prevent workflow script injection with environment indirection and suppress G404 for non-security-sensitive randomness in acceptance helpers.