### PR TITLE
TPT-2980: Add version and fingerprint attributes to Firewall resources and data sources

### DIFF
--- a/docs/data-sources/firewall.md
+++ b/docs/data-sources/firewall.md
@@ -49,6 +49,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the firewall. (`enabled`, `disabled`, `deleted`)
 
+* `version` - The current version of the Firewall rules.
+
+* `fingerprint` - The fingerprint of the current Firewall rules.
+
 * `created` - When this firewall was created.
 
 * `updated` - When this firewall was last updated.

--- a/docs/data-sources/firewalls.md
+++ b/docs/data-sources/firewalls.md
@@ -81,6 +81,10 @@ Each Linode firewall will be stored in the `firewalls` attribute and will export
 
 * `outbound_policy` - The default behavior for outbound traffic.
 
+* `version` - The current version of the Firewall rules.
+
+* `fingerprint` - The fingerprint of the current Firewall rules.
+
 * `linodes` - The IDs of Linodes this firewall is applied to.
 
 * `nodebalancers` - The IDs of NodeBalancers this firewall is applied to.

--- a/docs/resources/firewall.md
+++ b/docs/resources/firewall.md
@@ -120,6 +120,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the Firewall.
 
+* `version` - The current version of the Firewall rules.
+
+* `fingerprint` - The fingerprint of the current Firewall rules.
+
 * [`devices`](#devices) - The devices governed by the Firewall.
 
 ### devices

--- a/linode/firewall/framework_datasource_test.go
+++ b/linode/firewall/framework_datasource_test.go
@@ -3,10 +3,14 @@
 package firewall_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/linode/terraform-provider-linode/v4/linode/acceptance"
 	"github.com/linode/terraform-provider-linode/v4/linode/firewall/tmpl"
 )
@@ -25,37 +29,98 @@ func TestAccDataSourceFirewall_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmpl.DataBasic(t, firewallName, devicePrefix, testRegion),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testFirewallDataName, "label", firewallName),
-					resource.TestCheckResourceAttr(testFirewallDataName, "disabled", "false"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound_policy", "DROP"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.0.action", "ACCEPT"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.0.ports", "80"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.0.ipv4.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.0.ipv4.0", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.0.ipv6.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "inbound.0.ipv6.0", "::/0"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound_policy", "DROP"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound.0.ports", "80"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound.0.ipv4.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound.0.ipv4.0", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound.0.ipv6.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "outbound.0.ipv6.0", "2001:db8::/32"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "devices.#", "2"),
-					resource.TestCheckResourceAttrSet(testFirewallDataName, "devices.0.type"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "nodebalancers.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "linodes.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "tags.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallDataName, "tags.0", "test"),
-					resource.TestCheckResourceAttrSet(testFirewallDataName, "devices.0.url"),
-					resource.TestCheckResourceAttrSet(testFirewallDataName, "devices.0.id"),
-					resource.TestCheckResourceAttrSet(testFirewallDataName, "devices.0.entity_id"),
-					resource.TestCheckResourceAttrSet(testFirewallDataName, "devices.0.label"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("label"), knownvalue.StringExact(firewallName)),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("disabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("inbound_policy"), knownvalue.StringExact("DROP")),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("inbound"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("ACCEPT"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("TCP"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ports"),
+						knownvalue.StringExact("80"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ipv4"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("0.0.0.0/0")}),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ipv6"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("::/0")}),
+					),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("outbound_policy"), knownvalue.StringExact("DROP")),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("outbound"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("TCP"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("ports"),
+						knownvalue.StringExact("80"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("ipv4"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("0.0.0.0/0")}),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("ipv6"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("2001:db8::/32")}),
+					),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("devices"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("type"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("nodebalancers"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("linodes"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("tags"),
+						knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact("test")}),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("url"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("entity_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("label"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(testFirewallDataName, tfjsonpath.New("version"), knownvalue.Int64Exact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallDataName,
+						tfjsonpath.New("fingerprint"),
+						knownvalue.StringRegexp(regexp.MustCompile(".+")),
+					),
+				},
 			},
 		},
 	})

--- a/linode/firewall/framework_models.go
+++ b/linode/firewall/framework_models.go
@@ -22,6 +22,8 @@ type FirewallDataSourceModel struct {
 	InboundPolicy  types.String  `tfsdk:"inbound_policy"`
 	Outbound       []RuleModel   `tfsdk:"outbound"`
 	OutboundPolicy types.String  `tfsdk:"outbound_policy"`
+	Version        types.Int64   `tfsdk:"version"`
+	Fingerprint    types.String  `tfsdk:"fingerprint"`
 	Linodes        types.Set     `tfsdk:"linodes"`
 	NodeBalancers  types.Set     `tfsdk:"nodebalancers"`
 	Interfaces     types.Set     `tfsdk:"interfaces"`
@@ -42,6 +44,8 @@ type FirewallResourceModel struct {
 	InboundPolicy  types.String      `tfsdk:"inbound_policy"`
 	Outbound       []RuleModel       `tfsdk:"outbound"`
 	OutboundPolicy types.String      `tfsdk:"outbound_policy"`
+	Version        types.Int64       `tfsdk:"version"`
+	Fingerprint    types.String      `tfsdk:"fingerprint"`
 	Linodes        types.Set         `tfsdk:"linodes"`
 	NodeBalancers  types.Set         `tfsdk:"nodebalancers"`
 	Interfaces     types.Set         `tfsdk:"interfaces"`
@@ -266,6 +270,8 @@ func (data *FirewallResourceModel) flattenRules(
 	}
 
 	data.Outbound = outboundRules
+	data.Version = helper.KeepOrUpdateInt64(data.Version, int64(rules.Version), preserveKnown)
+	data.Fingerprint = helper.KeepOrUpdateString(data.Fingerprint, rules.Fingerprint, preserveKnown)
 }
 
 func (data *FirewallResourceModel) flattenFirewallForResource(
@@ -341,6 +347,8 @@ func (data *FirewallDataSourceModel) flattenFirewallForDataSource(
 	data.Disabled = types.BoolValue(firewall.Status == linodego.FirewallDisabled)
 	data.InboundPolicy = types.StringValue(ruleSet.InboundPolicy)
 	data.OutboundPolicy = types.StringValue(ruleSet.OutboundPolicy)
+	data.Version = types.Int64Value(int64(ruleSet.Version))
+	data.Fingerprint = types.StringValue(ruleSet.Fingerprint)
 	data.Label = types.StringValue(firewall.Label)
 
 	if ruleSet.Inbound != nil {
@@ -372,6 +380,8 @@ func (data *FirewallResourceModel) CopyFrom(
 	data.Disabled = helper.KeepOrUpdateValue(data.Disabled, other.Disabled, preserveKnown)
 	data.InboundPolicy = helper.KeepOrUpdateValue(data.InboundPolicy, other.InboundPolicy, preserveKnown)
 	data.OutboundPolicy = helper.KeepOrUpdateValue(data.OutboundPolicy, other.OutboundPolicy, preserveKnown)
+	data.Version = helper.KeepOrUpdateValue(data.Version, other.Version, preserveKnown)
+	data.Fingerprint = helper.KeepOrUpdateValue(data.Fingerprint, other.Fingerprint, preserveKnown)
 	data.Linodes = helper.KeepOrUpdateValue(data.Linodes, other.Linodes, preserveKnown)
 	data.NodeBalancers = helper.KeepOrUpdateValue(data.NodeBalancers, other.NodeBalancers, preserveKnown)
 	data.Interfaces = helper.KeepOrUpdateValue(data.Interfaces, other.Interfaces, preserveKnown)

--- a/linode/firewall/framework_models_unit_test.go
+++ b/linode/firewall/framework_models_unit_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Unit tests for private functions in framework_models
@@ -91,6 +94,8 @@ func TestParseComputedAttributes(t *testing.T) {
 		Inbound:        inboundRules,
 		OutboundPolicy: "DROP",
 		Outbound:       outboundRules,
+		Version:        1,
+		Fingerprint:    "test-fingerprint",
 	}
 
 	data := &FirewallDataSourceModel{}
@@ -108,6 +113,8 @@ func TestParseComputedAttributes(t *testing.T) {
 
 	assert.Contains(t, data.OutboundPolicy.String(), firewallRules.OutboundPolicy)
 	assert.Contains(t, data.InboundPolicy.String(), firewallRules.InboundPolicy)
+	assert.Equal(t, types.Int64Value(1), data.Version)
+	assert.Equal(t, types.StringValue("test-fingerprint"), data.Fingerprint)
 
 	assert.Equal(t, data.Inbound[0].Action.ValueString(), inboundRules[0].Action)
 	assert.Equal(t, data.Inbound[0].Protocol.ValueString(), string(inboundRules[0].Protocol))
@@ -121,4 +128,19 @@ func TestParseComputedAttributes(t *testing.T) {
 
 	assert.Equal(t, data.Devices[0].ID.ValueInt64(), int64(111))
 	assert.Equal(t, data.Devices[1].ID.ValueInt64(), int64(112))
+}
+
+func TestFirewallResourceModelFlattenRules(t *testing.T) {
+	rules := &linodego.FirewallRules{
+		Version:     3,
+		Fingerprint: "test-fingerprint",
+	}
+	data := FirewallResourceModel{}
+	var diags diag.Diagnostics
+
+	data.flattenRules(context.Background(), rules, false, &diags)
+
+	require.False(t, diags.HasError())
+	assert.Equal(t, types.Int64Value(3), data.Version)
+	assert.Equal(t, types.StringValue("test-fingerprint"), data.Fingerprint)
 }

--- a/linode/firewall/framework_resource_test.go
+++ b/linode/firewall/framework_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -87,37 +88,98 @@ func TestAccLinodeFirewall_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acceptanceTmpl.ProviderNoPoll(t) + tmpl.Basic(t, name, devicePrefix, testRegion),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testFirewallResName, "label", name),
-					resource.TestCheckResourceAttr(testFirewallResName, "disabled", "false"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound_policy", "DROP"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.0.action", "ACCEPT"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.0.ports", "80"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.0.ipv4.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.0.ipv4.0", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.0.ipv6.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "inbound.0.ipv6.0", "::/0"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound_policy", "DROP"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound.0.ports", "80"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound.0.ipv4.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound.0.ipv4.0", "0.0.0.0/0"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound.0.ipv6.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "outbound.0.ipv6.0", "2001:db8::/32"),
-					resource.TestCheckResourceAttr(testFirewallResName, "devices.#", "2"),
-					resource.TestCheckResourceAttrSet(testFirewallResName, "devices.0.type"),
-					resource.TestCheckResourceAttr(testFirewallResName, "linodes.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "nodebalancers.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "tags.#", "1"),
-					resource.TestCheckResourceAttr(testFirewallResName, "tags.0", "test"),
-					resource.TestCheckResourceAttrSet(testFirewallResName, "devices.0.url"),
-					resource.TestCheckResourceAttrSet(testFirewallResName, "devices.0.id"),
-					resource.TestCheckResourceAttrSet(testFirewallResName, "devices.0.entity_id"),
-					resource.TestCheckResourceAttrSet(testFirewallResName, "devices.0.label"),
-				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("label"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("disabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("inbound_policy"), knownvalue.StringExact("DROP")),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("inbound"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("ACCEPT"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("TCP"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ports"),
+						knownvalue.StringExact("80"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ipv4"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("0.0.0.0/0")}),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("inbound").AtSliceIndex(0).AtMapKey("ipv6"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("::/0")}),
+					),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("outbound_policy"), knownvalue.StringExact("DROP")),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("outbound"), knownvalue.ListSizeExact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("protocol"),
+						knownvalue.StringExact("TCP"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("ports"),
+						knownvalue.StringExact("80"),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("ipv4"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("0.0.0.0/0")}),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("outbound").AtSliceIndex(0).AtMapKey("ipv6"),
+						knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("2001:db8::/32")}),
+					),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("devices"), knownvalue.ListSizeExact(2)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("type"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("linodes"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("nodebalancers"), knownvalue.SetSizeExact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("tags"),
+						knownvalue.SetExact([]knownvalue.Check{knownvalue.StringExact("test")}),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("url"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("entity_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("devices").AtSliceIndex(0).AtMapKey("label"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(testFirewallResName, tfjsonpath.New("version"), knownvalue.Int64Exact(1)),
+					statecheck.ExpectKnownValue(
+						testFirewallResName,
+						tfjsonpath.New("fingerprint"),
+						knownvalue.StringRegexp(regexp.MustCompile(".+")),
+					),
+				},
 			},
 			{
 				ResourceName:            testFirewallResName,

--- a/linode/firewall/framework_schema_datasource.go
+++ b/linode/firewall/framework_schema_datasource.go
@@ -69,6 +69,14 @@ var frameworkDatasourceSchema = schema.Schema{
 				"the outbound.action property for an individual Firewall Rule.",
 			Computed: true,
 		},
+		"version": schema.Int64Attribute{
+			Description: "The current version of the Firewall rules.",
+			Computed:    true,
+		},
+		"fingerprint": schema.StringAttribute{
+			Description: "The fingerprint of the current Firewall rules.",
+			Computed:    true,
+		},
 		"linodes": schema.SetAttribute{
 			ElementType: types.Int64Type,
 			Description: "The IDs of Linodes assigned to this Firewall.",

--- a/linode/firewall/framework_schema_resource.go
+++ b/linode/firewall/framework_schema_resource.go
@@ -136,6 +136,14 @@ var frameworkResourceSchema = schema.Schema{
 				stringvalidator.OneOf("ACCEPT", "DROP"),
 			},
 		},
+		"version": schema.Int64Attribute{
+			Description: "The current version of the Firewall rules.",
+			Computed:    true,
+		},
+		"fingerprint": schema.StringAttribute{
+			Description: "The fingerprint of the current Firewall rules.",
+			Computed:    true,
+		},
 		"linodes": schema.SetAttribute{
 			Description: "The IDs of Linodes to apply this firewall to.",
 			Optional:    true,

--- a/linode/firewalls/framework_datasource_test.go
+++ b/linode/firewalls/framework_datasource_test.go
@@ -4,6 +4,7 @@ package firewalls_test
 
 import (
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -85,6 +86,16 @@ func TestAccDataSourceFirewalls_basic(t *testing.T) {
 							testFirewallDataName,
 							tfjsonpath.New("firewalls").AtSliceIndex(0).AtMapKey("outbound_policy"),
 							knownvalue.StringExact("ACCEPT"),
+						),
+						statecheck.ExpectKnownValue(
+							testFirewallDataName,
+							tfjsonpath.New("firewalls").AtSliceIndex(0).AtMapKey("version"),
+							knownvalue.Int64Exact(1),
+						),
+						statecheck.ExpectKnownValue(
+							testFirewallDataName,
+							tfjsonpath.New("firewalls").AtSliceIndex(0).AtMapKey("fingerprint"),
+							knownvalue.StringRegexp(regexp.MustCompile(".+")),
 						),
 						statecheck.ExpectKnownValue(
 							testFirewallDataName,

--- a/linode/firewalls/framework_models.go
+++ b/linode/firewalls/framework_models.go
@@ -92,6 +92,8 @@ type FirewallModel struct {
 	Disabled       types.Bool        `tfsdk:"disabled"`
 	InboundPolicy  types.String      `tfsdk:"inbound_policy"`
 	OutboundPolicy types.String      `tfsdk:"outbound_policy"`
+	Version        types.Int64       `tfsdk:"version"`
+	Fingerprint    types.String      `tfsdk:"fingerprint"`
 	Linodes        []types.Int64     `tfsdk:"linodes"`
 	NodeBalancers  []types.Int64     `tfsdk:"nodebalancers"`
 	Interfaces     []types.Int64     `tfsdk:"interfaces"`
@@ -115,6 +117,8 @@ func (data *FirewallModel) parseFirewall(
 	data.Disabled = types.BoolValue(firewall.Status == linodego.FirewallDisabled)
 	data.InboundPolicy = types.StringValue(rules.InboundPolicy)
 	data.OutboundPolicy = types.StringValue(rules.OutboundPolicy)
+	data.Version = types.Int64Value(int64(rules.Version))
+	data.Fingerprint = types.StringValue(rules.Fingerprint)
 	data.Linodes = helper.IntSliceToFramework(
 		firewallresource.AggregateEntityIDs(devices, linodego.FirewallDeviceLinode),
 	)

--- a/linode/firewalls/framework_schema.go
+++ b/linode/firewalls/framework_schema.go
@@ -102,6 +102,14 @@ var firewallAttributes = map[string]schema.Attribute{
 		Description: "The default behavior for outbound traffic.",
 		Computed:    true,
 	},
+	"version": schema.Int64Attribute{
+		Description: "The current version of the Firewall rules.",
+		Computed:    true,
+	},
+	"fingerprint": schema.StringAttribute{
+		Description: "The fingerprint of the current Firewall rules.",
+		Computed:    true,
+	},
 	"linodes": schema.SetAttribute{
 		ElementType: types.Int64Type,
 		Description: "The IDs of Linodes assigned to this Firewall.",


### PR DESCRIPTION
## 📝 Description

Support for `version` and `fingerprint` attributes to Firewall are now implemented.

## ✔️ How to Test
```bash
make PKG_NAME="firewalls" test-int
```

```bash
make PKG_NAME="firewall" test-int
```