### PR TITLE
TPT-4578: Add community contribution and hotfix labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -26,6 +26,12 @@
 - name: breaking-change
   description: for breaking changes in the changelog.
   color: ff0000
+- name: community-contribution
+  description: contributions from the community.
+  color: 22ee47
+- name: hotfix
+  description: urgent fixes for production issues.
+  color: ff0000
 - name: ignore-for-release
   description: PRs you do not want to render in the changelog
   color: 7b8eac


### PR DESCRIPTION
## Summary

Add `community-contribution` and `hotfix` to the GitHub label configuration so label automation applies these repository labels.

## Validation

Validated `.github/labels.yml` parses as YAML and contains each new label exactly once.