### PR TITLE
Add golangci-lint installer to smoke tests GHA workflow

### DIFF
--- a/.github/workflows/nightly_smoke_tests.yml
+++ b/.github/workflows/nightly_smoke_tests.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           go-version: '1.x'
 
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          install-only: true
+
       - name: Install Dependencies
         run: |
           make deps


### PR DESCRIPTION
## 📝 Description

Added missing golangci-lint installer to Nightly Smoke Test workflow

## ✔️ How to Test

Run nightly smoke test pipeline in GHA
