### PR TITLE
TPT-2556: Add support for computed subnets in VPC data source and resource

### DIFF
--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -49,6 +49,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated` - The date and time when the VPC was last updated.
 
+* [`subnets`](#subnets) - A list of subnets under this VPC.
+
 ## IPv6
 
 -> **Limited Availability** IPv6 VPCs may not currently be available to all users.
@@ -65,6 +67,56 @@ Contains information about a single IPv4 range under this VPC.
 
 * `range` - The IPv4 range in CIDR format.
 
-### Subnets Reference
+## Subnets
 
-To list all subnets under a VPC, please refer to the [linode_vpc_subnets](vpc_subnets.html.markdown) data source.
+The following attributes are exported under each entry of the `subnets` field:
+
+* `id` - The id of the VPC Subnet.
+
+* `label` - The label of the VPC Subnet.
+
+* `ipv4` - The IPv4 range of this subnet in CIDR format.
+
+* `ipv6` - The IPv6 ranges of this subnet.
+
+  * `range` - An IPv6 range allocated to this subnet.
+
+* `linodes` - A list of Linodes assigned to this subnet.
+
+  * `id` - ID of the Linode
+
+  * `interfaces` - A list of networking interfaces objects.
+
+    * `id` - ID of the interface.
+
+    * `config_id` - ID of Linode Config that the interface is associated with. `null` for a Linode Interface.
+
+    * `active` - Whether the Interface is actively in use.
+
+* `databases` - A list of Managed Databases assigned to this subnet.
+
+  * `id` - ID of a managed database assigned to the VPC Subnet.
+
+  * `ipv4_range` - IPv4 range assigned to the database.
+
+  * `ipv6_ranges` - A list of IPv6 ranges assigned to the database.
+
+    * `range` - An IPv6 address range in CIDR notation.
+
+* `nodebalancers` - A list of NodeBalancers assigned to this subnet.
+
+  * `id` - ID of a NodeBalancer assigned to the VPC Subnet.
+
+  * `ipv4_range` - IPv4 range assigned to the NodeBalancer.
+
+  * `ipv6_ranges` - A list of IPv6 ranges assigned to the NodeBalancer.
+
+    * `range` - An IPv6 address range in CIDR notation.
+
+* `created` - The date and time when the VPC Subnet was created.
+
+* `updated` - The date and time when the VPC Subnet was last updated.
+
+### Subnets data source
+
+The `subnets` list in this resource requires an additional refresh after the initial apply before newly created subnets appear because all subnets are created as resources after the vpc resource is created. To list all subnets under a VPC with immediate availability after apply, use the [linode_vpc_subnets](vpc_subnets.html.markdown) data source with Terraform [`depends_on`](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on).

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -100,3 +100,55 @@ In addition to all the arguments above, the following attributes are exported.
 * `created` - The date and time when the VPC was created.
 
 * `updated` - The date and time when the VPC was last updated.
+
+* [`subnets`](#subnets) - A list of subnets under this VPC.
+
+## Subnets
+
+The following attributes are exported under each entry of the `subnets` field:
+
+* `id` - The id of the VPC Subnet.
+
+* `label` - The label of the VPC Subnet.
+
+* `ipv4` - The IPv4 range of this subnet in CIDR format.
+
+* `ipv6` - The IPv6 ranges of this subnet.
+
+  * `range` - An IPv6 range allocated to this subnet.
+
+* `linodes` - A list of Linodes assigned to this subnet.
+
+  * `id` - ID of the Linode
+
+  * `interfaces` - A list of networking interfaces objects.
+
+    * `id` - ID of the interface.
+
+    * `config_id` - ID of Linode Config that the interface is associated with. `null` for a Linode Interface.
+
+    * `active` - Whether the Interface is actively in use.
+
+* `databases` - A list of Managed Databases assigned to this subnet.
+
+  * `id` - ID of a managed database assigned to the VPC Subnet.
+
+  * `ipv4_range` - IPv4 range assigned to the database.
+
+  * `ipv6_ranges` - A list of IPv6 ranges assigned to the database.
+
+    * `range` - An IPv6 address range in CIDR notation.
+
+* `nodebalancers` - A list of NodeBalancers assigned to this subnet.
+
+  * `id` - ID of a NodeBalancer assigned to the VPC Subnet.
+
+  * `ipv4_range` - IPv4 range assigned to the NodeBalancer.
+
+  * `ipv6_ranges` - A list of IPv6 ranges assigned to the NodeBalancer.
+
+    * `range` - An IPv6 address range in CIDR notation.
+
+* `created` - The date and time when the VPC Subnet was created.
+
+* `updated` - The date and time when the VPC Subnet was last updated.

--- a/linode/vpc/datasource_test.go
+++ b/linode/vpc/datasource_test.go
@@ -35,6 +35,68 @@ func TestAccDataSourceVPC_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("subnets"),
+						knownvalue.ListSizeExact(0),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVPC_withSubnet(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.linode_vpc.foo"
+	vpcLabel := acctest.RandomWithPrefix("tf-test")
+	subnetIPv4 := "10.0.1.0/24"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.DataWithSubnet(t, vpcLabel, testRegion, subnetIPv4),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("label"),
+						knownvalue.StringExact(vpcLabel),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("subnets"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("label"),
+						knownvalue.StringExact(vpcLabel),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("ipv4"),
+						knownvalue.StringExact(subnetIPv4),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("created"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("updated"),
+						knownvalue.NotNull(),
+					),
+				},
 			},
 		},
 	})

--- a/linode/vpc/framework_models.go
+++ b/linode/vpc/framework_models.go
@@ -5,11 +5,13 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/linode/linodego/v2"
 	"github.com/linode/terraform-provider-linode/v4/linode/helper"
 	"github.com/linode/terraform-provider-linode/v4/linode/helper/customtypes"
+	"github.com/linode/terraform-provider-linode/v4/linode/vpcsubnet"
 )
 
 /*
@@ -25,6 +27,99 @@ type BaseModel struct {
 	Created     timetypes.RFC3339 `tfsdk:"created"`
 	Updated     timetypes.RFC3339 `tfsdk:"updated"`
 	IPv4        types.List        `tfsdk:"ipv4"`
+	Subnets     types.List        `tfsdk:"subnets"`
+}
+
+type SubnetModel struct {
+	ID            types.Int64       `tfsdk:"id"`
+	Label         types.String      `tfsdk:"label"`
+	IPv4          types.String      `tfsdk:"ipv4"`
+	IPv6          types.List        `tfsdk:"ipv6"`
+	Linodes       types.List        `tfsdk:"linodes"`
+	Databases     types.List        `tfsdk:"databases"`
+	Nodebalancers types.List        `tfsdk:"nodebalancers"`
+	Created       timetypes.RFC3339 `tfsdk:"created"`
+	Updated       timetypes.RFC3339 `tfsdk:"updated"`
+}
+
+type SubnetModelIPv6 struct {
+	Range types.String `tfsdk:"range"`
+}
+
+func FlattenSubnets(
+	ctx context.Context,
+	subnets []linodego.VPCSubnet,
+	subnetObjectType attr.Type,
+	ipv6ObjectType attr.Type,
+	preserveKnown bool,
+) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	subnetModels := make([]SubnetModel, len(subnets))
+	for i, subnet := range subnets {
+		var model SubnetModel
+
+		model.ID = helper.KeepOrUpdateInt64(model.ID, int64(subnet.ID), preserveKnown)
+		model.Label = helper.KeepOrUpdateString(model.Label, subnet.Label, preserveKnown)
+		model.IPv4 = helper.KeepOrUpdateString(model.IPv4, subnet.IPv4, preserveKnown)
+		model.Created = helper.KeepOrUpdateValue(
+			model.Created,
+			timetypes.NewRFC3339TimePointerValue(subnet.Created),
+			preserveKnown,
+		)
+		model.Updated = helper.KeepOrUpdateValue(
+			model.Updated,
+			timetypes.NewRFC3339TimePointerValue(subnet.Updated),
+			preserveKnown,
+		)
+
+		ipv6Models := helper.MapSlice(
+			subnet.IPv6,
+			func(r linodego.VPCIPv6Range) SubnetModelIPv6 {
+				return SubnetModelIPv6{
+					Range: types.StringValue(r.Range),
+				}
+			},
+		)
+
+		ipv6List, d := types.ListValueFrom(ctx, ipv6ObjectType, ipv6Models)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(subnetObjectType), diags
+		}
+		model.IPv6 = helper.KeepOrUpdateValue(model.IPv6, ipv6List, preserveKnown)
+
+		linodesList, d := vpcsubnet.FlattenSubnetLinodes(ctx, subnet.Linodes)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(subnetObjectType), diags
+		}
+		model.Linodes = helper.KeepOrUpdateValue(model.Linodes, *linodesList, preserveKnown)
+
+		databasesList, d := vpcsubnet.FlattenSubnetDatabases(ctx, subnet.Databases)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(subnetObjectType), diags
+		}
+		model.Databases = helper.KeepOrUpdateValue(model.Databases, *databasesList, preserveKnown)
+
+		nodebalancersList, d := vpcsubnet.FlattenSubnetNodebalancers(ctx, subnet.Nodebalancers)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ListNull(subnetObjectType), diags
+		}
+		model.Nodebalancers = helper.KeepOrUpdateValue(model.Nodebalancers, *nodebalancersList, preserveKnown)
+
+		subnetModels[i] = model
+	}
+
+	subnetList, d := types.ListValueFrom(ctx, subnetObjectType, subnetModels)
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ListNull(subnetObjectType), diags
+	}
+
+	return subnetList, diags
 }
 
 func (m *BaseModel) FlattenVPC(ctx context.Context, vpc *linodego.VPC, preserveKnown bool) diag.Diagnostics {
@@ -56,6 +151,7 @@ func (m *BaseModel) CopyFrom(ctx context.Context, other BaseModel, preserveKnown
 	m.Label = helper.KeepOrUpdateValue(m.Label, other.Label, preserveKnown)
 	m.Region = helper.KeepOrUpdateValue(m.Region, other.Region, preserveKnown)
 	m.VPCType = helper.KeepOrUpdateValue(m.VPCType, other.VPCType, preserveKnown)
+	m.Subnets = helper.KeepOrUpdateValue(m.Subnets, other.Subnets, preserveKnown)
 }
 
 /*
@@ -121,6 +217,22 @@ func (m *ResourceModel) FlattenVPC(ctx context.Context, vpc *linodego.VPC, prese
 		ipv4List,
 		false,
 	)
+
+	// Flatten Subnets
+	// NOTE: preserveKnown is false here because subnets is computed-only and must
+	// always be populated from the API response.
+	subnetList, subnetDiags := FlattenSubnets(
+		ctx,
+		vpc.Subnets,
+		ResourceSchemaSubnetNestedObject.Type(),
+		ResourceSchemaSubnetIPv6NestedObject.Type(),
+		false,
+	)
+	if subnetDiags.HasError() {
+		return subnetDiags
+	}
+
+	m.Subnets = helper.KeepOrUpdateValue(m.Subnets, subnetList, false)
 
 	return nil
 }
@@ -192,6 +304,20 @@ func (m *DataSourceModel) FlattenVPC(ctx context.Context, vpc *linodego.VPC, pre
 		ipv4List,
 		preserveKnown,
 	)
+
+	// Flatten Subnets
+	subnetList, subnetDiags := FlattenSubnets(
+		ctx,
+		vpc.Subnets,
+		DataSourceSchemaSubnetNestedObject.Type(),
+		DataSourceSchemaSubnetIPv6NestedObject.Type(),
+		preserveKnown,
+	)
+	if subnetDiags.HasError() {
+		return subnetDiags
+	}
+
+	m.Subnets = helper.KeepOrUpdateValue(m.Subnets, subnetList, preserveKnown)
 
 	return nil
 }

--- a/linode/vpc/framework_schema_datasource.go
+++ b/linode/vpc/framework_schema_datasource.go
@@ -3,6 +3,7 @@ package vpc
 import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/linode/terraform-provider-linode/v4/linode/vpcsubnet"
 )
 
 var DataSourceSchemaIPv6NestedObject = schema.NestedAttributeObject{
@@ -19,6 +20,62 @@ var DataSourceSchemaIPv4NestedObject = schema.NestedAttributeObject{
 		"range": schema.StringAttribute{
 			Description: "The IPv4 range assigned to this VPC.",
 			Computed:    true,
+		},
+	},
+}
+
+var DataSourceSchemaSubnetIPv6NestedObject = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"range": schema.StringAttribute{
+			Description: "An IPv6 range allocated to this subnet.",
+			Computed:    true,
+		},
+	},
+}
+
+var DataSourceSchemaSubnetNestedObject = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.Int64Attribute{
+			Description: "The id of the VPC Subnet.",
+			Computed:    true,
+		},
+		"label": schema.StringAttribute{
+			Description: "The label of the VPC Subnet.",
+			Computed:    true,
+		},
+		"ipv4": schema.StringAttribute{
+			Description: "The IPv4 range of this subnet in CIDR format.",
+			Computed:    true,
+		},
+		"ipv6": schema.ListNestedAttribute{
+			Description:  "The IPv6 ranges of this subnet.",
+			Computed:     true,
+			NestedObject: DataSourceSchemaSubnetIPv6NestedObject,
+		},
+		"linodes": schema.ListAttribute{
+			Description: "A list of Linodes assigned to this subnet.",
+			Computed:    true,
+			ElementType: vpcsubnet.LinodeObjectType,
+		},
+		"databases": schema.ListAttribute{
+			Description: "A list of Managed Databases assigned to this subnet.",
+			Computed:    true,
+			ElementType: vpcsubnet.DatabaseObjectType,
+		},
+		"nodebalancers": schema.ListAttribute{
+			Description: "A list of NodeBalancers assigned to this subnet.",
+			Computed:    true,
+			ElementType: vpcsubnet.NodebalancerObjectType,
+		},
+		"created": schema.StringAttribute{
+			Description: "The date and time when the VPC Subnet was created.",
+			Computed:    true,
+			CustomType:  timetypes.RFC3339Type{},
+		},
+		"updated": schema.StringAttribute{
+			Description: "The date and time when the VPC Subnet was updated.",
+			Computed:    true,
+			CustomType:  timetypes.RFC3339Type{},
 		},
 	},
 }
@@ -54,6 +111,11 @@ var VPCAttrs = map[string]schema.Attribute{
 		Description:  "The IPv6 configuration of this VPC.",
 		Computed:     true,
 		NestedObject: DataSourceSchemaIPv6NestedObject,
+	},
+	"subnets": schema.ListNestedAttribute{
+		Description:  "A list of subnets under this VPC.",
+		Computed:     true,
+		NestedObject: DataSourceSchemaSubnetNestedObject,
 	},
 	"created": schema.StringAttribute{
 		Description: "The date and time when the VPC was created.",

--- a/linode/vpc/framework_schema_resource.go
+++ b/linode/vpc/framework_schema_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/linode/terraform-provider-linode/v4/linode/helper/customtypes"
 	"github.com/linode/terraform-provider-linode/v4/linode/helper/stringplanmodifiers"
+	"github.com/linode/terraform-provider-linode/v4/linode/vpcsubnet"
 )
 
 var ResourceSchemaIPv6NestedObject = schema.NestedAttributeObject{
@@ -46,6 +47,62 @@ var ResourceSchemaIPv4NestedObject = schema.NestedAttributeObject{
 		"range": schema.StringAttribute{
 			Description: "The IPv4 range assigned to this VPC.",
 			Required:    true,
+		},
+	},
+}
+
+var ResourceSchemaSubnetIPv6NestedObject = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"range": schema.StringAttribute{
+			Description: "An IPv6 range allocated to this subnet.",
+			Computed:    true,
+		},
+	},
+}
+
+var ResourceSchemaSubnetNestedObject = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"id": schema.Int64Attribute{
+			Description: "The id of the VPC Subnet.",
+			Computed:    true,
+		},
+		"label": schema.StringAttribute{
+			Description: "The label of the VPC Subnet.",
+			Computed:    true,
+		},
+		"ipv4": schema.StringAttribute{
+			Description: "The IPv4 range of this subnet in CIDR format.",
+			Computed:    true,
+		},
+		"ipv6": schema.ListNestedAttribute{
+			Description:  "The IPv6 ranges of this subnet.",
+			Computed:     true,
+			NestedObject: ResourceSchemaSubnetIPv6NestedObject,
+		},
+		"linodes": schema.ListAttribute{
+			Description: "A list of Linodes assigned to this subnet.",
+			Computed:    true,
+			ElementType: vpcsubnet.LinodeObjectType,
+		},
+		"databases": schema.ListAttribute{
+			Description: "A list of Managed Databases assigned to this subnet.",
+			Computed:    true,
+			ElementType: vpcsubnet.DatabaseObjectType,
+		},
+		"nodebalancers": schema.ListAttribute{
+			Description: "A list of NodeBalancers assigned to this subnet.",
+			Computed:    true,
+			ElementType: vpcsubnet.NodebalancerObjectType,
+		},
+		"created": schema.StringAttribute{
+			Description: "The date and time when the VPC Subnet was created.",
+			Computed:    true,
+			CustomType:  timetypes.RFC3339Type{},
+		},
+		"updated": schema.StringAttribute{
+			Description: "The date and time when the VPC Subnet was updated.",
+			Computed:    true,
+			CustomType:  timetypes.RFC3339Type{},
 		},
 	},
 }
@@ -105,6 +162,14 @@ var frameworkResourceSchema = schema.Schema{
 				listplanmodifier.UseStateForUnknown(),
 			},
 			NestedObject: ResourceSchemaIPv4NestedObject,
+		},
+		"subnets": schema.ListNestedAttribute{
+			Description: "A list of subnets under this VPC.",
+			Computed:    true,
+			PlanModifiers: []planmodifier.List{
+				listplanmodifier.UseStateForUnknown(),
+			},
+			NestedObject: ResourceSchemaSubnetNestedObject,
 		},
 		"created": schema.StringAttribute{
 			Description: "The date and time when the VPC was created.",

--- a/linode/vpc/resource_test.go
+++ b/linode/vpc/resource_test.go
@@ -85,11 +85,102 @@ func TestAccResourceVPC_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "created"),
 					resource.TestCheckResourceAttrSet(resName, "updated"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets"),
+						knownvalue.ListSizeExact(0),
+					),
+				},
 			},
 			{
 				ResourceName:      resName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceVPC_withSubnet(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_vpc.foobar"
+	vpcLabel := acctest.RandomWithPrefix("tf-test")
+	subnetIPv4 := "10.0.1.0/24"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acceptance.PreCheck(t) },
+		ProtoV6ProviderFactories: acceptance.ProtoV6ProviderFactories,
+		CheckDestroy:             checkVPCDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: tmpl.WithSubnet(t, vpcLabel, testRegion, subnetIPv4),
+				Check:  checkVPCExists,
+			},
+			{
+				RefreshState: true,
+			},
+			{
+				Config: tmpl.WithSubnet(t, vpcLabel, testRegion, subnetIPv4),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("label"),
+						knownvalue.StringExact(vpcLabel),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets"),
+						knownvalue.ListSizeExact(1),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("label"),
+						knownvalue.StringExact(vpcLabel),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("ipv4"),
+						knownvalue.StringExact(subnetIPv4),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("created"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("updated"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("linodes"),
+						knownvalue.ListSizeExact(0),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("databases"),
+						knownvalue.ListSizeExact(0),
+					),
+					statecheck.ExpectKnownValue(
+						resName,
+						tfjsonpath.New("subnets").AtSliceIndex(0).AtMapKey("nodebalancers"),
+						knownvalue.ListSizeExact(0),
+					),
+				},
+			},
+			{
+				ResourceName:            resName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated"},
 			},
 		},
 	})

--- a/linode/vpc/tmpl/data_with_subnet.gotf
+++ b/linode/vpc/tmpl/data_with_subnet.gotf
@@ -1,0 +1,11 @@
+{{ define "vpc_data_with_subnet" }}
+
+{{ template "vpc_with_subnet" . }}
+
+data "linode_vpc" "foo" {
+    id = linode_vpc.foobar.id
+
+    depends_on = [linode_vpc_subnet.foobar]
+}
+
+{{ end }}

--- a/linode/vpc/tmpl/template.go
+++ b/linode/vpc/tmpl/template.go
@@ -90,3 +90,21 @@ func VPCType(t testing.TB, label, region, vpcType string) string {
 			VPCType: vpcType,
 		})
 }
+
+func WithSubnet(t testing.TB, label, region, ipv4Range string) string {
+	return acceptance.ExecuteTemplate(t,
+		"vpc_with_subnet", TemplateData{
+			Label:     label,
+			Region:    region,
+			IPv4Range: ipv4Range,
+		})
+}
+
+func DataWithSubnet(t testing.TB, label, region, ipv4Range string) string {
+	return acceptance.ExecuteTemplate(t,
+		"vpc_data_with_subnet", TemplateData{
+			Label:     label,
+			Region:    region,
+			IPv4Range: ipv4Range,
+		})
+}

--- a/linode/vpc/tmpl/with_subnet.gotf
+++ b/linode/vpc/tmpl/with_subnet.gotf
@@ -1,0 +1,15 @@
+{{ define "vpc_with_subnet" }}
+
+resource "linode_vpc" "foobar" {
+    label = "{{.Label}}"
+    region = "{{.Region}}"
+    description = "some description"
+}
+
+resource "linode_vpc_subnet" "foobar" {
+    vpc_id = linode_vpc.foobar.id
+    label = "{{.Label}}"
+    ipv4 = "{{.IPv4Range}}"
+}
+
+{{ end }}


### PR DESCRIPTION
## 📝 Description

Add computed VPC subnets support in VPC resource and data source.

## ✔️ How to Test

```bash
make test-int PKG_NAME=vpc
```
