### PR TITLE
TPT-2117: Mark databases list filters as API-filterable

### DIFF
--- a/linode/databases/framework_datasource_schema.go
+++ b/linode/databases/framework_datasource_schema.go
@@ -9,11 +9,11 @@ import (
 )
 
 var filterConfig = frameworkfilter.Config{
-	"label":   {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
-	"region":  {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
-	"status":  {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
-	"type":    {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
-	"version": {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
+	"label":   {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"region":  {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"status":  {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"type":    {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
+	"version": {APIFilterable: true, TypeFunc: frameworkfilter.FilterTypeString},
 
 	"engine":         {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},
 	"allow_list":     {APIFilterable: false, TypeFunc: frameworkfilter.FilterTypeString},


### PR DESCRIPTION
## 📝 Description

Marks `label`, `region`, `status`, `type`, and `version` as API-filterable on the `linode_databases` data source so those filters are applied server-side instead of only client-side.

## Test

Create 2 DBaaS instances on Cloud Manager, and try different filter in TF config:

```terraform
# Configure the Linode Provider
provider "linode" {
}

# Upper-group filters on linode_databases (client-side; API filtering WIP):
# label, platform, region, status, type, version
data "linode_databases" "upper_group_filters" {
  filter {
    name   = "label"
    values = ["test-pg"]
  }

  filter {
    name   = "platform"
    values = ["rdbms-default"]
  }

  filter {
    name   = "region"
    values = ["us-mia"]
  }

  filter {
    name   = "status"
    values = ["active"]
  }

  filter {
    name   = "type"
    values = ["g6-standard-1"]
  }

  filter {
    name   = "version"
    values = ["18.4"]
  }
}

output "filtered_databases" {
  value = data.linode_databases.upper_group_filters.databases
}

```