### PR TITLE
TPT-4611: Resolve issue that causes implicit LKE cluster nested pool resize on unrelated updates in Pulumi

### DIFF
--- a/linode/lke/cluster_test.go
+++ b/linode/lke/cluster_test.go
@@ -144,6 +144,20 @@ func TestReconcileLKENodePoolSpecs(t *testing.T) {
 			expectedToDelete: []int{},
 			expectedToCreate: []linodego.LKENodePoolCreateOptions{},
 		},
+		{
+			name: "autoscaler update with omitted count",
+			oldSpecs: []lke.NodePoolSpec{
+				{ID: 123, Type: "g6-standard-3", AutoScalerEnabled: true, AutoScalerMin: 3, AutoScalerMax: 7},
+			},
+			newSpecs: []lke.NodePoolSpec{
+				{ID: 123, Type: "g6-standard-3", AutoScalerEnabled: true, AutoScalerMin: 5, AutoScalerMax: 10},
+			},
+			expectedToUpdate: map[int]linodego.LKENodePoolUpdateOptions{
+				123: {Autoscaler: &linodego.LKENodePoolAutoscaler{Enabled: true, Min: 5, Max: 10}},
+			},
+			expectedToDelete: []int{},
+			expectedToCreate: []linodego.LKENodePoolCreateOptions{},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			updates, err := lke.ReconcileLKENodePoolSpecs(context.Background(), tc.oldSpecs, tc.newSpecs, false)

--- a/linode/lke/resource.go
+++ b/linode/lke/resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -350,6 +351,12 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	oldPools, newPools := d.GetChange("pool")
 
+	oldPoolSpecs := expandLinodeLKENodePoolSpecs(oldPools.([]any), false)
+	newPoolSpecs := expandLinodeLKENodePoolSpecs(newPools.([]any), true)
+
+	clearUnconfiguredNodePoolCounts(d.GetRawConfig().GetAttr("pool"), oldPoolSpecs)
+	clearUnconfiguredNodePoolCounts(d.GetRawConfig().GetAttr("pool"), newPoolSpecs)
+
 	var enterprise bool
 
 	cluster, err := client.GetLKECluster(ctx, id)
@@ -368,8 +375,8 @@ func updateResource(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	updates, err := ReconcileLKENodePoolSpecs(
 		ctx,
-		expandLinodeLKENodePoolSpecs(oldPools.([]any), false),
-		expandLinodeLKENodePoolSpecs(newPools.([]any), true),
+		oldPoolSpecs,
+		newPoolSpecs,
 		enterprise,
 	)
 	if err != nil {
@@ -576,6 +583,25 @@ func customDiffValidateOptionalCount(ctx context.Context, diff *schema.ResourceD
 	}
 
 	return nil
+}
+
+func clearUnconfiguredNodePoolCounts(rawPools cty.Value, specs []NodePoolSpec) {
+	if !rawPools.IsKnown() || rawPools.IsNull() {
+		return
+	}
+
+	poolIterator := rawPools.ElementIterator()
+	for poolIterator.Next() {
+		rawKey, rawPool := poolIterator.Element()
+		index, _ := rawKey.AsBigFloat().Int64()
+		if index < 0 || index >= int64(len(specs)) || !rawPool.IsKnown() || rawPool.IsNull() {
+			continue
+		}
+
+		if rawPool.GetAttr("count").IsNull() {
+			specs[index].Count = 0
+		}
+	}
 }
 
 // customDiffValidatePoolForStandardTier ensures that at least one pool


### PR DESCRIPTION
## 📝 Description

This pull request resolves an issue that causes Pulumi (downstream consumer) to implicitly downsize and re-upsize autoscaled `linode_lke_cluster` node pools when updates are made to unrelated attributes (e.g. tags). 

This is done by trusting the node pool's count in the Terraform config instead of in the plan, which bypasses some weird Pulumi behavior on optional + computed fields. See ticket for details

**NOTE:** [pulumi-linode](https://github.com/pulumi/pulumi-linode) will need to be updated to terraform-provider-linode v4 after this change has been released.

## ✔️ How to Test

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int PKG_NAME=lke
```